### PR TITLE
docs: bootstrap ADR system under tech-docs/adr

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ tapestry/
 │           └── infrastructure/
 ```
 
+## Architectural Decision Records (ADRs)
+
+Significant architectural decisions are recorded as ADRs under
+[`tech-docs/adr/`](tech-docs/adr/). The system is two-level:
+
+- **Iterations** (`TAP-YYYY`) are units of work that follow a 5-phase
+  template: SCOPE → PLAN → EXECUTE → VERIFY → CLOSE. SCOPE and PLAN are
+  written *before* implementation begins.
+- **Component decisions** (`XXX-YYYY`) capture specific technical choices
+  within a subsystem and reference their parent iteration. Prefixes:
+  `DAT` (data), `TRN` (training), `INF` (infrastructure), `DOC` (docs site),
+  `WG` (work groups).
+
+Before changing architecture, dependencies, services, schemas, frameworks, or
+durable project conventions, read [`tech-docs/adr/README.md`](tech-docs/adr/README.md)
+for the full convention, file-naming rules, and evidence standard. Routine bug
+fixes, local refactors, tests, and docs do not need an ADR.
+
 <a id="getting-involved-anchor"></a>
 
 ## Getting Involved

--- a/tech-docs/adr/README.md
+++ b/tech-docs/adr/README.md
@@ -1,0 +1,116 @@
+# Architectural Decision Records
+
+## Two-level system: iterations + component decisions
+
+### Iterations (`PRJ-YYYY`)
+
+Top-level units of work. Each iteration follows a **mandatory 5-phase methodology**:
+
+1. **SCOPE** — goal, exit criteria, budget (written *before* work starts)
+2. **PLAN** — component decisions needed, steps, risks
+3. **EXECUTE** — work through tasks, record component ADRs as decisions arise
+4. **VERIFY** — check exit criteria, run tests, prove it works
+5. **CLOSE** — document outcomes, flag carryover items
+
+**Iteration template:**
+
+```markdown
+# PRJ-YYYY: [Title]
+
+## 1. SCOPE
+**Goal:** [1-2 sentences]
+**Date opened:** YYYY-MM-DD
+**Date closed:** —
+**Budget:** $X
+**Exit criteria:**
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## 2. PLAN
+**Steps:** ...
+**Component decisions anticipated:** ...
+**Risks:** ...
+
+## 3. EXECUTE
+| ID | Decision | Status |
+|----|----------|--------|
+| XXX-YYYY | ... | Accepted |
+
+## 4. VERIFY
+- [x] Test 1
+- [ ] Test 2
+
+## 5. CLOSE
+**Status:** Complete | Open
+**Carries over:** ...
+```
+
+### Component decisions (`XXX-YYYY`)
+
+Specific architectural choices within a component. Each references its parent iteration.
+
+```
+TAP-0001: Adopt ADR system for tapestry
+├── TAP-0001-A: ADR numbering convention
+```
+
+- `TAP-YYYY` = iteration (project-level)
+- `XXX-YYYY` = component decision (component abbreviation)
+- Each component ADR has a `Parent: TAP-YYYY` field
+- Sub-decisions of an iteration itself use `TAP-YYYY-X` suffix (A, B, C...)
+
+### Component prefixes (tapestry)
+
+| Prefix | Scope |
+|--------|-------|
+| `TAP`  | tapestry project-wide / iteration |
+| `DAT`  | data subsystem (`src/tapestry/data`) |
+| `TRN`  | training / tuning subsystem (`src/tapestry/training`) |
+| `INF`  | infrastructure subsystem (`src/tapestry/infrastructure`) |
+| `DOC`  | technical docs site / Jekyll (`docs/`, `tech-docs/`) |
+| `WG`   | work-group governance and process |
+
+New component prefixes may be introduced via a component ADR documenting the addition.
+
+### Rules
+
+- **Iterations are opened before work starts** — SCOPE and PLAN first, then EXECUTE.
+- Append-only. Superseded ADRs get a status update + link to the new one. Never edit history.
+- Sequential numbering within scope, never reused.
+- Every iteration lists what it comprises. Every component ADR references its parent.
+- ADR files are named `XXX-YYYY-slug.md`.
+- Filter by component with `ls tech-docs/adr/DAT-*` etc.
+
+### Evidence standard
+
+A checked box is not evidence by itself. Every completed SCOPE or VERIFY item
+must be paired with at least one concrete proof artifact:
+
+- command output or summarized command result with command name and pass/fail count
+- artifact path, evidence path, generated file path, or code path
+- test name, test file, or focused test invocation
+- PR, issue, commit, or release reference
+- explicit carryover/defer statement when proof was not gathered
+
+If an ADR closes with pending EXECUTE rows, unchecked original SCOPE criteria, or
+stale `VERIFY`/`CLOSE` text, append a reconciliation section that states which
+section is authoritative and which claims remain partial or deferred.
+
+---
+
+## Status index
+
+Open iteration ADRs:
+
+| ADR | Title | Phase |
+|-----|-------|-------|
+| —   | —     | —     |
+
+Closed iteration ADRs:
+
+| ADR | Title | Closed |
+|-----|-------|--------|
+| [TAP-0001](TAP-0001-adr-system.md) | Adopt ADR system for tapestry | 2026-05-04 |
+
+Component ADRs (accepted decisions, not tracked open/closed):
+`TAP-0001-A`

--- a/tech-docs/adr/TAP-0001-A-adr-numbering-convention.md
+++ b/tech-docs/adr/TAP-0001-A-adr-numbering-convention.md
@@ -1,0 +1,41 @@
+# ADR TAP-0001-A: ADR numbering convention (`XXX-YYYY` under iterations)
+
+**Status:** Accepted
+**Date:** 2026-05-04
+**Decided by:** maintainers
+**Stakeholders notified:** tapestry contributors
+**Parent:** TAP-0001
+
+## Context
+Tapestry spans several distinct subsystems (data, training, infrastructure) plus a documentation site and work-group process. Flat sequential ADR numbering would obscure which decisions belong to which part of the system. We want decisions to be filterable by scope and to clearly link component choices back to the iteration that drove them.
+
+## Decision
+Use `XXX-YYYY` numbering where `XXX` is a scope abbreviation and `YYYY` is monotonic within that scope.
+
+- Project-level / iteration prefix: `TAP` (tapestry).
+- Component prefixes:
+  - `DAT` — data subsystem (`src/tapestry/data`)
+  - `TRN` — training / tuning subsystem (`src/tapestry/training`)
+  - `INF` — infrastructure subsystem (`src/tapestry/infrastructure`)
+  - `DOC` — technical docs site (Jekyll under `docs/`, prose under `tech-docs/`)
+  - `WG`  — work-group governance and process
+- Sub-decisions of an iteration itself use the iteration id with a letter suffix: `TAP-YYYY-A`, `TAP-YYYY-B`, ...
+- Files are named `XXX-YYYY-slug.md` and live under `tech-docs/adr/`.
+- Each component ADR carries a `Parent: TAP-YYYY` field linking it to its driving iteration.
+- Numbering is sequential within scope and never reused. Superseded ADRs get a status update plus a link to the replacement; history is append-only.
+
+New prefixes may be introduced by a component ADR documenting the addition.
+
+## Why this and not the alternatives
+- **Flat numbering (0001, 0002, ...)** — rejected: cannot tell at a glance whether a decision is project-wide or scoped to one subsystem.
+- **Numeric scope prefixes (000, 100, 200, ...)** — rejected: less readable and not self-documenting.
+- **Directory-per-component** — rejected: fragments the timeline. Prefix-in-filename keeps everything in one sorted list while still showing scope.
+- **Reusing aito-teams' `AIT` prefix verbatim** — rejected: the project-level prefix should derive from the project name, per the originating convention.
+
+## Consequences
+- ADR files sort and filter cleanly: `ls tech-docs/adr/DAT-*` lists data-subsystem decisions.
+- Contributors must learn the prefix table (documented in `tech-docs/adr/README.md`).
+- Iterations are the unit of planning and verification; component ADRs are the unit of architectural choice.
+
+## Reversibility
+**High** — renaming files is trivial and the convention is documentation-only, with no tooling lock-in.

--- a/tech-docs/adr/TAP-0001-adr-system.md
+++ b/tech-docs/adr/TAP-0001-adr-system.md
@@ -1,0 +1,39 @@
+# TAP-0001: Adopt ADR system for tapestry
+
+## 1. SCOPE
+**Goal:** Establish a lightweight, two-level Architectural Decision Record (ADR) convention for the tapestry project so that iteration-level decisions and component-level technical choices are captured consistently and reviewably alongside the code and docs.
+**Date opened:** 2026-05-04
+**Date closed:** 2026-05-04
+**Budget:** N/A (process bootstrap)
+**Exit criteria:**
+- [x] `tech-docs/adr/` directory exists and is the canonical location for ADRs.
+- [x] `tech-docs/adr/README.md` documents the iteration template, component prefixes, rules, and evidence standard.
+- [x] Numbering convention is itself recorded as a component ADR (`TAP-0001-A`).
+- [x] At least one iteration ADR (`TAP-0001`) exists demonstrating the 5-phase template.
+
+## 2. PLAN
+**Steps:**
+1. Create `tech-docs/adr/` and add a `README.md` with the convention, template, prefix table, rules, and status index.
+2. Record `TAP-0001-A` capturing the `XXX-YYYY` numbering convention as an explicit, citable decision.
+3. Use this iteration ADR (`TAP-0001`) as the worked example of the 5-phase template.
+
+**Component decisions anticipated:**
+- `TAP-0001-A`: ADR numbering convention.
+
+**Risks:**
+- Convention drift if contributors add ad-hoc decision docs outside `tech-docs/adr/`. Mitigation: README rules + review.
+- Prefix proliferation. Mitigation: new prefixes require a component ADR.
+
+## 3. EXECUTE
+| ID | Decision | Status |
+|----|----------|--------|
+| TAP-0001-A | ADR numbering convention (`XXX-YYYY` under iterations) | Accepted |
+
+## 4. VERIFY
+- [x] `tech-docs/adr/README.md` present and includes template, prefix table, rules, evidence standard, status index — see `tech-docs/adr/README.md` in this commit.
+- [x] `tech-docs/adr/TAP-0001-A-adr-numbering-convention.md` present — see file in this commit.
+- [x] `tech-docs/adr/TAP-0001-adr-system.md` present (this file) and follows the 5-phase template.
+
+## 5. CLOSE
+**Status:** Complete
+**Carries over:** Future architectural decisions for the data, training, and infrastructure subsystems should be filed as component ADRs (`DAT-`, `TRN-`, `INF-`) under their owning iteration. Work-group process decisions use `WG-`. Documentation-site decisions use `DOC-`.


### PR DESCRIPTION
## Summary

Adopts a two-level Architectural Decision Record convention (iterations + component decisions) for tapestry, modeled on `aitomatic/aito-teams` and scoped with project prefix `TAP`.

- `tech-docs/adr/README.md` — convention, 5-phase iteration template (SCOPE → PLAN → EXECUTE → VERIFY → CLOSE), prefix table, rules, evidence standard, status index.
- `tech-docs/adr/TAP-0001-adr-system.md` — bootstrap iteration ADR (worked example of the template).
- `tech-docs/adr/TAP-0001-A-adr-numbering-convention.md` — component sub-decision capturing the `XXX-YYYY` numbering rule.
- `README.md` — adds a brief "Architectural Decision Records (ADRs)" section pointing readers at `tech-docs/adr/`.

Component prefixes: `DAT` (data), `TRN` (training), `INF` (infrastructure), `DOC` (docs site), `WG` (work groups). New prefixes require a component ADR.

ADRs live under `tech-docs/` (internal) rather than `docs/` (the published Jekyll site) so they remain engineering artifacts rather than user-facing content.

Replaces #3 (closed for DCO sign-off mismatch).

## Test plan

- [ ] Confirm `tech-docs/adr/` location is acceptable (vs `docs/adr/`).
- [ ] Confirm prefix table covers the subsystems maintainers expect.
- [ ] No code changes — no test run required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S37wvHo9CbhzRnsFAdh4Sj)_