### PR TITLE
Replace the old main URL with the new URL for Tapestry.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Quick-start guidance for AI agents working in this repository.
 
 ## Project snapshot
 
-`tapestry` is the AI Alliance's [Project Tapestry](http://thealliance.ai/projects/tapestry)
+`tapestry` is the AI Alliance's [Project Tapestry](https://thealliance.ai/projects/tapestry)
 technical repo. It is a Python 3 project (managed with [`uv`](https://docs.astral.sh/uv/))
 organized around three subsystems plus a published technical website:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Quick-start guidance for AI agents working in this repository.
 
 ## Project snapshot
 
-`tapestry` is the AI Alliance's [Project Tapestry](https://events.thealliance.ai/tapestry)
+`tapestry` is the AI Alliance's [Project Tapestry](http://thealliance.ai/projects/tapestry)
 technical repo. It is a Python 3 project (managed with [`uv`](https://docs.astral.sh/uv/))
 organized around three subsystems plus a published technical website:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Project Tapestry
 
-> [Technical website](https://the-ai-alliance.github.io/tapestry/) · [Project page](https://events.thealliance.ai/tapestry)
+> [Technical website](https://the-ai-alliance.github.io/tapestry/) · [Project page](http://thealliance.ai/projects/tapestry)
 
 ![Project Tapestry Image](docs/assets/images/03-tapestry-logo-1000x545.png)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Project Tapestry
 
-> [Technical website](https://the-ai-alliance.github.io/tapestry/) · [Project page](http://thealliance.ai/projects/tapestry)
+> [Technical website](https://the-ai-alliance.github.io/tapestry/) · [Project page](https://thealliance.ai/projects/tapestry)
 
 ![Project Tapestry Image](docs/assets/images/03-tapestry-logo-1000x545.png)
 

--- a/docs/_includes/header_buttons_custom.html
+++ b/docs/_includes/header_buttons_custom.html
@@ -1,3 +1,3 @@
 <a href="https://github.com/The-AI-Alliance/tapestry" class="header-btn" target="_blank">GitHub Repo</a>
 <a href="{{site.baseurl}}/contributing/#join-this-project" class="header-btn">Join This Project</a>
-<a href="http://thealliance.ai/projects/tapestry" class="header-btn" target="aia-tapestry">AI Alliance Page</a>
+<a href="https://thealliance.ai/projects/tapestry" class="header-btn" target="aia-tapestry">AI Alliance Page</a>

--- a/docs/_includes/header_buttons_custom.html
+++ b/docs/_includes/header_buttons_custom.html
@@ -1,3 +1,3 @@
 <a href="https://github.com/The-AI-Alliance/tapestry" class="header-btn" target="_blank">GitHub Repo</a>
 <a href="{{site.baseurl}}/contributing/#join-this-project" class="header-btn">Join This Project</a>
-<a href="https://events.thealliance.ai/tapestry" class="header-btn" target="aia-tapestry">AI Alliance Page</a>
+<a href="http://thealliance.ai/projects/tapestry" class="header-btn" target="aia-tapestry">AI Alliance Page</a>

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -7,7 +7,7 @@ has_children: false
 
 # About Project Tapestry and The AI Alliance
 
-The [AI Alliance](https://www.aialliance.org){:target="aia"} created and develops [Project Tapestry](https://events.thealliance.ai/tapestry){:target="aia-tapestry"}.
+The [AI Alliance](https://www.aialliance.org){:target="aia"} created and develops [Project Tapestry](http://thealliance.ai/projects/tapestry){:target="aia-tapestry"}.
 
 The [AI Alliance](https://aialliance.org){:target="aia"} is a global collaboration of startups, enterprises, academic, and other research institutions interested in advancing the state of the art, the availability, and the safety of AI technology and uses. The AI Alliance's core projects seek to address substantial cross-community challenges and are an opportunity for contributors to collaborate, build, and make an impact on the future of AI. Core Projects are managed directly by the AI Alliance and governed as described in our [community GitHub repository](https://github.com/The-AI-Alliance/community){:target="community"}. 
 

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -7,7 +7,7 @@ has_children: false
 
 # About Project Tapestry and The AI Alliance
 
-The [AI Alliance](https://www.aialliance.org){:target="aia"} created and develops [Project Tapestry](http://thealliance.ai/projects/tapestry){:target="aia-tapestry"}.
+The [AI Alliance](https://www.aialliance.org){:target="aia"} created and develops [Project Tapestry](https://thealliance.ai/projects/tapestry){:target="aia-tapestry"}.
 
 The [AI Alliance](https://aialliance.org){:target="aia"} is a global collaboration of startups, enterprises, academic, and other research institutions interested in advancing the state of the art, the availability, and the safety of AI technology and uses. The AI Alliance's core projects seek to address substantial cross-community challenges and are an opportunity for contributors to collaborate, build, and make an impact on the future of AI. Core Projects are managed directly by the AI Alliance and governed as described in our [community GitHub repository](https://github.com/The-AI-Alliance/community){:target="community"}. 
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -8,10 +8,10 @@ work_groups: https://github.com/The-AI-Alliance/tapestry/tree/main/tech-docs/wor
 
 # Project Tapestry: Technical Website
 
-Welcome to the technical website for **The AI Alliance Project Tapestry**, representing the content from the [technical documentation and code repository](https://github.com/The-AI-Alliance/tapestry){:target="repo"} for [Project Tapestry](http://thealliance.ai/projects/tapestry){:target="aia-tapestry"}. 
+Welcome to the technical website for **The AI Alliance Project Tapestry**, representing the content from the [technical documentation and code repository](https://github.com/The-AI-Alliance/tapestry){:target="repo"} for [Project Tapestry](https://thealliance.ai/projects/tapestry){:target="aia-tapestry"}. 
 
 {: .attention}
-> For a general introduction to Project Tapestry, including its motivations and goals, see the [AI Alliance website Tapestry page](http://thealliance.ai/projects/tapestry){:target="aia-tapestry"}
+> For a general introduction to Project Tapestry, including its motivations and goals, see the [AI Alliance website Tapestry page](https://thealliance.ai/projects/tapestry){:target="aia-tapestry"}
 
 ![Project Tapestry Image]({{site.baseurl}}/assets/images/03-tapestry-logo-1000x545.png){: .tapestry-image .center}
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -8,10 +8,10 @@ work_groups: https://github.com/The-AI-Alliance/tapestry/tree/main/tech-docs/wor
 
 # Project Tapestry: Technical Website
 
-Welcome to the technical website for **The AI Alliance Project Tapestry**, representing the content from the [technical documentation and code repository](https://github.com/The-AI-Alliance/tapestry){:target="repo"} for [Project Tapestry](https://events.thealliance.ai/tapestry){:target="aia-tapestry"}. 
+Welcome to the technical website for **The AI Alliance Project Tapestry**, representing the content from the [technical documentation and code repository](https://github.com/The-AI-Alliance/tapestry){:target="repo"} for [Project Tapestry](http://thealliance.ai/projects/tapestry){:target="aia-tapestry"}. 
 
 {: .attention}
-> For a general introduction to Project Tapestry, including its motivations and goals, see the [AI Alliance website Tapestry page](https://events.thealliance.ai/tapestry){:target="aia-tapestry"}
+> For a general introduction to Project Tapestry, including its motivations and goals, see the [AI Alliance website Tapestry page](http://thealliance.ai/projects/tapestry){:target="aia-tapestry"}
 
 ![Project Tapestry Image]({{site.baseurl}}/assets/images/03-tapestry-logo-1000x545.png){: .tapestry-image .center}
 

--- a/tech-docs/strategic-plan/PRD.md
+++ b/tech-docs/strategic-plan/PRD.md
@@ -500,7 +500,7 @@ Phase 3 — Planetary Scale (Jul 2027 – Dec 2027)
 
 - LeCun, Y. UN Security Council Briefing S/PV.9821 (December 19, 2023)
 - TAPESTRY Strategic Plan: `strategic-plan/` (aitomatic/aia-tapestry)
-- AI Alliance Project Tapestry (public): http://thealliance.ai/projects/tapestry
+- AI Alliance Project Tapestry (public): https://thealliance.ai/projects/tapestry
 - AI Alliance Technical Repo: https://github.com/The-AI-Alliance/tapestry
 
 ---

--- a/tech-docs/strategic-plan/PRD.md
+++ b/tech-docs/strategic-plan/PRD.md
@@ -500,7 +500,7 @@ Phase 3 — Planetary Scale (Jul 2027 – Dec 2027)
 
 - LeCun, Y. UN Security Council Briefing S/PV.9821 (December 19, 2023)
 - TAPESTRY Strategic Plan: `strategic-plan/` (aitomatic/aia-tapestry)
-- AI Alliance Project Tapestry (public): https://events.thealliance.ai/tapestry
+- AI Alliance Project Tapestry (public): http://thealliance.ai/projects/tapestry
 - AI Alliance Technical Repo: https://github.com/The-AI-Alliance/tapestry
 
 ---


### PR DESCRIPTION
# URL Update

## Description of Changes

Changes the references from the old Tapestry page URL, 

  https://events.thealliance.ai/tapestry

to the new URL,
  
  http://thealliance.ai/projects/tapestry
