### PR TITLE
Polish README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 ![The AI Alliance banner](https://the-ai-alliance.github.io/assets/images/ai-alliance-logo-horiz-pos-blue-cmyk-trans.png)
 
 # Welcome to Project Tapestry
-Project Tapestry is creating a global frontier foundation model with a new "consortium training" platfrom harnessing data, compute and contributors from around the world to enable sovereign AI.
 
-[Website](https://thealliance.ai/projects/tapestry/)
+_Project Tapestry is creating a global frontier foundation model with a new "consortium training" platform harnessing data, compute and contributors from around the world to enable sovereign AI._
 
-This repo contains the code and technical documentation for the AI Alliance, [Project Tapestry](https://events.thealliance.ai/tapestry). 
+This repo contains the code and technical documentation for the AI Alliance, [Project Tapestry](https://events.thealliance.ai/tapestry).
 
 ![Project Tapestry Image](docs/assets/images/03-tapestry-logo-1000x545.png)
 


### PR DESCRIPTION
## Summary
- Tightens the opening Project Tapestry description in the root README.
- Fixes the `platfrom` typo and removes an extra standalone website link from the intro.

## Test plan
- Documentation-only change; no tests run.

Made with [Cursor](https://cursor.com)