### PR TITLE
Small make target refinements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ make format-lint-type-check
 make flt                # Synonym for format-lint-type-check.
 make format             # Format the Python code with 'black'.
 make lint               # Lint the Python code by making the ruff and pylint targets.
-make ruff               # Lint the Python code 'ruff'.
-make pylint             # Lint the Python code 'pylint'.
+make ruff               # Lint the Python code with 'ruff'.
+make pylint             # Lint the Python code with 'pylint'.
 make type-check         # Type check the Python code with 'ty'.
 make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
                         # so you can fix mistakes and keep it updating.

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,18 @@ make all                # Makes the 'help' and 'print-info' targets (see below).
 make tests              # Run the test suite.
 make clean              # Remove built artifacts, etc.
 
+make format-lint-type-check
+                        # Do formating, linting, and type checking.
+make flt                # Synonym for format-lint-type-check.
 make format             # Format the Python code with 'black'.
-make lint               # Lint the Python code with 'ruff' and 'pylint.
+make lint               # Lint the Python code by making the ruff and pylint targets.
+make ruff               # Lint the Python code 'ruff'.
+make pylint             # Lint the Python code 'pylint'.
 make type-check         # Type check the Python code with 'ty'.
 make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
                         # so you can fix mistakes and keep it updating.
-make before-pr          # Make tests, format, lint, and type-check. Do this before submitting a PR!
+make before-pr          # Make format-lint-type-check and tests. 
+                        # DO THIS BEFORE SUBMITTING A PR!
 
 For the consortium-training prototype:
 
@@ -112,9 +118,6 @@ print-info:
 	@echo "Website files:       ${DOCS_DIR}"
 	@echo "JEKYLL_PORT:         ${JEKYLL_PORT}"
 
-.PHONY: before-pr
-before-pr:: tests format lint type-check
-
 .PHONY: tests unit-tests
 tests:: unit-tests
 
@@ -133,15 +136,24 @@ consortium-tests::
 	@echo "${INFO}Running the consortium-training tests...${_END}"
 	uv run pytest ${SRC_DIR}/tests/tapestry/training/consortium -q
 
-.PHONY: format lint type-check type-check-watch
+.PHONY: before-pr format-lint-type-check flt
+before-pr:: format-lint-type-check tests
+format-lint-type-check flt:: format lint type-check
+
+.PHONY: format lint ruff pylint type-check type-check-watch
 
 format::
 	@echo "${INFO}$@: Running 'black' on the code.${_END}"
 	uv run black ${SRC_DIR}
 
-lint::
-	@echo "${INFO}$@: Running 'ruff' and 'pylint' on the code.${_END}"
-	uv run ruff check ${SRC_DIR}
+lint:: ruff pylint
+
+ruff::
+	@echo "${INFO}$@: Running 'ruff' to lint the code.${_END}"
+	uv run ruff check --fix ${SRC_DIR}
+
+pylint::
+	@echo "${INFO}$@: Running 'pylint' on the code.${_END} (configuration in pylintrc.toml)"
 	uv run pylint ${SRC_DIR}
 
 type-check::

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ make lint               # Lint the Python code with 'ruff' and 'pylint.
 make type-check         # Type check the Python code with 'ty'.
 make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
                         # so you can fix mistakes and keep it updating.
+make before-pr          # Make tests, format, lint, and type-check. Do this before submitting a PR!
 
 For the consortium-training prototype:
 
@@ -111,6 +112,8 @@ print-info:
 	@echo "Website files:       ${DOCS_DIR}"
 	@echo "JEKYLL_PORT:         ${JEKYLL_PORT}"
 
+.PHONY: before-pr
+before-pr:: tests format lint type-check
 
 .PHONY: tests unit-tests
 tests:: unit-tests

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ uv run ty --watch src
 Before submitting a PR, please run the tests, format, lint, and type checking commands. Make sure everything passes cleanly! Use the convenient `make` target `before-pr`, or run the individual commands above:
 
 ```shell
-make before-pr   # Equivalent to 'make tests format lint type-check'
+make before-pr               # Equivalent to 'make format lint type-check tests'
+make format-lint-type-check  # Equivalent to 'make format lint type-check'
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ make type-check-watch
 uv run ty --watch src
 ```
 
+### Before You Submit a PR...
+
+Before submitting a PR, please run the tests, format, lint, and type checking commands. Make sure everything passes cleanly! Use the convenient `make` target `before-pr`, or run the individual commands above:
+
+```shell
+make before-pr   # Equivalent to 'make tests format lint type-check'
+```
+
 ## Project Structure
 
 The structure is as follows, where three major _subsystems_ are managed: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.12"
 dependencies = [
     "torch>=2.0.0",
     "numpy>=1.24.0",
+    "pytest>=9.0.3",
+    "black>=26.5.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Refines a Few Make Targets

## Description of Changes

Adds/refines the targets for formatting, linting, and type checking.

## Related Issues

N/A

## Testing Performed

Local execution testing

## Code Changes

* `Makefile` - Target changes
* `pyproject.toml` - Added missing dependencies for tools like `black`.
* `README.md` - Documentation for new targets.

## Example Usage
Include an example of how to use the new function or feature:

* `make format-lint-type-check`
    * Makes the format, lint, and type-check targets.
* `make before-pr`
    * Same, but also makes tests after the other targets.

## Checklist

Confirm that the following have been completed, where applicable:

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For code changes:

- [x] I have tested the code changes in my local development environment.
- [ ] I have added and/or updated tests for all code changes.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation.
