### PR TITLE
feat: add consortium experiment metrics runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ cython_debug/
 .uv/
 uv.lock
 
+# Consortium experiment outputs
+runs/
+
 # IDEs
 .vscode/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ consortium-demo::
 
 consortium-experiment::
 	@echo "${INFO}Running the consortium-training experiment metrics...${_END}"
-	PYTHONPATH=${PWD}/${SRC_DIR}:${PWD}/contrib/jneums-consortium-experiment uv run python contrib/jneums-consortium-experiment/run.py
+	PYTHONPATH="${PWD}/${SRC_DIR}:${PWD}/contrib/jneums-consortium-experiment" uv run python contrib/jneums-consortium-experiment/run.py
 
 consortium-tests::
 	@echo "${INFO}Running the consortium-training tests...${_END}"

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ make before-pr          # Make format-lint-type-check and tests.
 For the consortium-training prototype:
 
 make consortium-demo    # Run the N+1 consortium-training proof-of-concept demo.
+make consortium-experiment
+                        # Run deterministic PoC metrics for consortium-training rounds.
 make consortium-tests   # Run only the consortium-training prototype tests.
 
 For the documentation website:
@@ -126,15 +128,19 @@ unit-tests::
 	cd ${SRC_DIR} && \
 	  uv run pytest tests -q
 
-.PHONY: consortium-demo consortium-tests
+.PHONY: consortium-demo consortium-experiment consortium-tests
 
 consortium-demo::
 	@echo "${INFO}Running the consortium-training demo...${_END}"
 	uv run python examples/consortium_training_demo.py
 
+consortium-experiment::
+	@echo "${INFO}Running the consortium-training experiment metrics...${_END}"
+	PYTHONPATH=${PWD}/${SRC_DIR}:${PWD}/contrib/jneums-consortium-experiment uv run python contrib/jneums-consortium-experiment/run.py
+
 consortium-tests::
 	@echo "${INFO}Running the consortium-training tests...${_END}"
-	uv run pytest ${SRC_DIR}/tests/tapestry/training/consortium -q
+	PYTHONPATH=${PWD}/${SRC_DIR}:${PWD}/contrib/jneums-consortium-experiment uv run pytest ${SRC_DIR}/tests/tapestry/training/consortium contrib/jneums-consortium-experiment/tests -q
 
 .PHONY: before-pr format-lint-type-check flt
 before-pr:: format-lint-type-check tests

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The source code is under the [`src`](src/) directory.
 
 * Use the [**`Makefile`**](Makefile) targets, e.g., `make help`. More details are in [**Development**](#development-anchor) below.
 * Runnable demos in [**`examples/`**](examples/) (try `make consortium-demo`).
-* Consortium training prototype in [**`src/tapestry/training/consortium/`**](src/tapestry/training/consortium/README.md) (try `make consortium-demo` and also `make consortium-tests`).
+* Consortium training prototype in [**`src/tapestry/training/consortium/`**](src/tapestry/training/consortium/README.md) (try `make consortium-demo` and `make consortium-tests`).
+* Contrib experiment metrics for the consortium prototype in [**`contrib/jneums-consortium-experiment/`**](contrib/jneums-consortium-experiment/README.md) (try `make consortium-experiment`).
 
 ### Working with the Technical Documentation
 

--- a/contrib/jneums-consortium-experiment/LICENSE
+++ b/contrib/jneums-consortium-experiment/LICENSE
@@ -1,0 +1,5 @@
+This contribution follows the repository default licenses:
+
+- Code: Apache License, Version 2.0. See ../../LICENSE.Apache-2.0.
+- Documentation: Creative Commons Attribution 4.0 International. See ../../LICENSE.CC-BY-4.0.
+- Data, if added later: CDLA Permissive 2.0. See ../../LICENSE.CDLA-2.0.

--- a/contrib/jneums-consortium-experiment/README.md
+++ b/contrib/jneums-consortium-experiment/README.md
@@ -1,0 +1,34 @@
+# Consortium experiment metrics
+
+This contribution contains a deterministic measurement layer around the
+Tapestry consortium-training proof of concept. It is staged under `contrib/`
+so the core training-loop package can remain focused on the minimal PoC
+protocol while experiment ideas are reviewed and iterated.
+
+Status: prototype / measurement scaffold.
+
+It intentionally does not replace Flower, NIID-Bench, OpenDiLoCo,
+lm-evaluation-harness, Unitxt, or other larger evaluation and federated
+training tools. It only records CI-scale PoC metrics for the existing tiny
+consortium-training loop.
+
+Run from the repository root:
+
+```shell
+make consortium-experiment
+```
+
+or directly:
+
+```shell
+PYTHONPATH="$PWD/src:$PWD/contrib/jneums-consortium-experiment" \
+  uv run python contrib/jneums-consortium-experiment/run.py
+```
+
+The default run writes:
+
+- `runs/consortium_experiment/metrics.jsonl` with one JSON object per round;
+- `runs/consortium_experiment/summary.json` with aggregate metrics.
+
+Recorded metrics include accepted/rejected nodes, contribution weights, maximum
+node influence, shared-base movement, sovereign artifact count, and node losses.

--- a/contrib/jneums-consortium-experiment/consortium_experiment/__init__.py
+++ b/contrib/jneums-consortium-experiment/consortium_experiment/__init__.py
@@ -1,0 +1,21 @@
+"""Contrib experiment tooling for the Tapestry consortium-training PoC."""
+
+from .experiment import (
+    ConsortiumExperimentRunner,
+    ExperimentConfig,
+    ExperimentResult,
+    ExperimentSummary,
+    NodeSpec,
+    PolicySpec,
+    RoundMetrics,
+)
+
+__all__ = [
+    "ConsortiumExperimentRunner",
+    "ExperimentConfig",
+    "ExperimentResult",
+    "ExperimentSummary",
+    "NodeSpec",
+    "PolicySpec",
+    "RoundMetrics",
+]

--- a/contrib/jneums-consortium-experiment/consortium_experiment/experiment.py
+++ b/contrib/jneums-consortium-experiment/consortium_experiment/experiment.py
@@ -1,0 +1,182 @@
+"""Deterministic experiment runner for the consortium-training proof of concept."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+import torch
+
+from .metrics import max_weight, state_delta_norm
+from tapestry.training.consortium import (
+    ConsortiumCoordinator,
+    ContributionPolicy,
+    SovereignTrainingNode,
+    TinyCausalModel,
+)
+
+
+@dataclass(frozen=True)
+class NodeSpec:
+    """Configuration for one sovereign participant node in a PoC experiment."""
+
+    node_id: str
+    jurisdiction: str
+    corpus: Sequence[list[int]]
+    quality_score: float
+    local_epochs: int = 2
+    lr: float = 0.01
+    batch_size: int = 8
+
+
+@dataclass(frozen=True)
+class PolicySpec:
+    """Configuration for the PoC contribution policy."""
+
+    name: str = "quality_weighted"
+    quality_floor: float = 0.0
+    max_node_weight: float = 1.0
+
+    def build(self) -> ContributionPolicy:
+        """Build the contribution policy for this experiment."""
+        return ContributionPolicy(
+            quality_floor=self.quality_floor,
+            max_node_weight=self.max_node_weight,
+        )
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    """Configuration for a deterministic consortium-training PoC experiment."""
+
+    seed: int
+    rounds: int
+    nodes: Sequence[NodeSpec]
+    policy: PolicySpec
+    model_vocab_size: int = 128
+    model_hidden_size: int = 32
+
+
+@dataclass(frozen=True)
+class RoundMetrics:  # pylint: disable=too-many-instance-attributes
+    """Machine-readable metrics for one consortium-training round."""
+
+    round_num: int
+    accepted_nodes: list[str]
+    rejected_nodes: list[str]
+    contribution_weights: dict[str, float]
+    max_node_weight: float
+    shared_base_delta_norm: float
+    sovereign_artifact_count: int
+    node_losses: dict[str, float]
+
+
+@dataclass(frozen=True)
+class ExperimentSummary:
+    """Summary metrics for a completed consortium-training PoC experiment."""
+
+    seed: int
+    rounds: int
+    policy_name: str
+    final_artifact_count: int
+    total_rejected_contributions: int
+    max_observed_node_weight: float
+    final_shared_base_delta_norm: float
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    """Complete result for a consortium-training PoC experiment."""
+
+    config: ExperimentConfig
+    rounds: list[RoundMetrics]
+    summary: ExperimentSummary
+
+    def write_json(self, output_dir: Path | str) -> None:
+        """Write round metrics as JSONL and the summary as JSON."""
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        with (output_path / "metrics.jsonl").open("w", encoding="utf-8") as metrics_file:
+            for round_metrics in self.rounds:
+                metrics_file.write(json.dumps(asdict(round_metrics), sort_keys=True) + "\n")
+
+        with (output_path / "summary.json").open("w", encoding="utf-8") as summary_file:
+            json.dump(asdict(self.summary), summary_file, indent=2, sort_keys=True)
+            summary_file.write("\n")
+
+
+class ConsortiumExperimentRunner:  # pylint: disable=too-few-public-methods
+    """Run deterministic CI-scale measurements around the existing consortium PoC."""
+
+    def __init__(self, config: ExperimentConfig) -> None:
+        if config.rounds < 1:
+            raise ValueError("rounds must be at least 1")
+        if not config.nodes:
+            raise ValueError("at least one node is required")
+        self.config = config
+
+    def run(self) -> ExperimentResult:
+        """Run the configured consortium-training experiment."""
+        random.seed(self.config.seed)
+        torch.manual_seed(self.config.seed)
+
+        base_model = TinyCausalModel(
+            vocab_size=self.config.model_vocab_size,
+            hidden_size=self.config.model_hidden_size,
+        )
+        coordinator = ConsortiumCoordinator(
+            base_model=base_model,
+            contribution_policy=self.config.policy.build(),
+        )
+        nodes = [self._build_node(node_spec, base_model) for node_spec in self.config.nodes]
+
+        round_metrics: list[RoundMetrics] = []
+        for _round in range(self.config.rounds):
+            result = coordinator.run_round(nodes)
+            node_losses = {
+                node_id: artifact.metrics["loss"]
+                for node_id, artifact in sorted(coordinator.sovereign_artifacts.items())
+            }
+            round_metrics.append(
+                RoundMetrics(
+                    round_num=result.round_num,
+                    accepted_nodes=result.accepted_nodes,
+                    rejected_nodes=result.rejected_nodes,
+                    contribution_weights=result.contribution_weights,
+                    max_node_weight=max_weight(result.contribution_weights),
+                    shared_base_delta_norm=state_delta_norm(
+                        result.previous_base_state,
+                        result.shared_base_state,
+                    ),
+                    sovereign_artifact_count=len(coordinator.sovereign_artifacts),
+                    node_losses=node_losses,
+                )
+            )
+
+        summary = ExperimentSummary(
+            seed=self.config.seed,
+            rounds=self.config.rounds,
+            policy_name=self.config.policy.name,
+            final_artifact_count=len(coordinator.sovereign_artifacts),
+            total_rejected_contributions=sum(len(metrics.rejected_nodes) for metrics in round_metrics),
+            max_observed_node_weight=max((metrics.max_node_weight for metrics in round_metrics), default=0.0),
+            final_shared_base_delta_norm=round_metrics[-1].shared_base_delta_norm,
+        )
+        return ExperimentResult(config=self.config, rounds=round_metrics, summary=summary)
+
+    @staticmethod
+    def _build_node(node_spec: NodeSpec, base_model: TinyCausalModel) -> SovereignTrainingNode:
+        return SovereignTrainingNode(
+            node_id=node_spec.node_id,
+            jurisdiction=node_spec.jurisdiction,
+            model=base_model,
+            sovereign_corpus=node_spec.corpus,
+            quality_score=node_spec.quality_score,
+            local_epochs=node_spec.local_epochs,
+            lr=node_spec.lr,
+            batch_size=node_spec.batch_size,
+        )

--- a/contrib/jneums-consortium-experiment/consortium_experiment/metrics.py
+++ b/contrib/jneums-consortium-experiment/consortium_experiment/metrics.py
@@ -1,0 +1,31 @@
+"""Metrics helpers for consortium-training PoC experiments."""
+
+from __future__ import annotations
+
+from math import sqrt
+
+import torch
+
+from tapestry.training.consortium.messages import ModelState
+
+
+def state_delta_norm(before: ModelState, after: ModelState) -> float:
+    """Return the L2 norm of the difference between two model states."""
+    if set(before) != set(after):
+        missing_before = sorted(set(after) - set(before))
+        missing_after = sorted(set(before) - set(after))
+        raise ValueError(
+            "model states must contain the same keys; "
+            f"missing_before={missing_before}, missing_after={missing_after}"
+        )
+
+    squared_norm = torch.tensor(0.0)
+    for name, before_tensor in before.items():
+        delta = after[name] - before_tensor
+        squared_norm = squared_norm + torch.sum(delta * delta)
+    return sqrt(float(squared_norm.item()))
+
+
+def max_weight(weights: dict[str, float]) -> float:
+    """Return the maximum contribution weight, or 0.0 when no nodes are accepted."""
+    return max(weights.values(), default=0.0)

--- a/contrib/jneums-consortium-experiment/run.py
+++ b/contrib/jneums-consortium-experiment/run.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run deterministic metrics around the Tapestry consortium-training PoC."""
+
+# pylint: disable=wrong-import-position
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from consortium_experiment import (  # noqa: E402
+    ConsortiumExperimentRunner,
+    ExperimentConfig,
+    NodeSpec,
+    PolicySpec,
+)
+
+DOMAIN_CORPORA: dict[str, list[str]] = {
+    "vietnam": [
+        "Vietnamese public services require local legal context.",
+        "Agricultural advice must reflect Mekong Delta climate conditions.",
+        "Education examples should match Vietnamese classroom expectations.",
+    ],
+    "switzerland": [
+        "Swiss AI deployments must respect multilingual governance.",
+        "Public-sector systems require federal and cantonal context.",
+        "Trustworthy AI depends on auditability and institutional neutrality.",
+    ],
+    "india": [
+        "Indian AI systems must work across many languages and scripts.",
+        "Digital public infrastructure shapes local adoption patterns.",
+        "Health advice must reflect regional institutions and constraints.",
+    ],
+}
+
+QUALITY_SCORES = {
+    "vietnam": 0.90,
+    "switzerland": 0.86,
+    "india": 0.88,
+}
+
+
+def _encode(texts: list[str]) -> list[list[int]]:
+    """Byte-encode text into the tiny model's vocabulary range."""
+    return [[token % 128 for token in text.encode("utf-8")] for text in texts]
+
+
+def _default_config(rounds: int, seed: int) -> ExperimentConfig:
+    return ExperimentConfig(
+        seed=seed,
+        rounds=rounds,
+        policy=PolicySpec(
+            name="quality_floor_capped",
+            quality_floor=0.75,
+            max_node_weight=0.5,
+        ),
+        nodes=[
+            NodeSpec(
+                node_id=node_id,
+                jurisdiction=node_id.title(),
+                corpus=_encode(corpus),
+                quality_score=QUALITY_SCORES[node_id],
+                local_epochs=2,
+                lr=0.01,
+            )
+            for node_id, corpus in DOMAIN_CORPORA.items()
+        ],
+    )
+
+
+def main() -> None:
+    """Run the default deterministic consortium-training experiment."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out", default="runs/consortium_experiment", help="directory for metrics.jsonl and summary.json"
+    )
+    parser.add_argument("--rounds", type=int, default=3, help="number of consortium-training rounds")
+    parser.add_argument("--seed", type=int, default=7, help="random seed for deterministic runs")
+    args = parser.parse_args()
+
+    result = ConsortiumExperimentRunner(_default_config(rounds=args.rounds, seed=args.seed)).run()
+    result.write_json(args.out)
+
+    print("Tapestry consortium-training PoC metrics")
+    print(f"  output dir                 : {args.out}")
+    print(f"  rounds                     : {result.summary.rounds}")
+    print(f"  policy                     : {result.summary.policy_name}")
+    print(f"  final artifact count       : {result.summary.final_artifact_count}")
+    print(f"  rejected contributions     : {result.summary.total_rejected_contributions}")
+    print(f"  max observed node weight   : {result.summary.max_observed_node_weight:.3f}")
+    print(f"  final shared-base delta L2 : {result.summary.final_shared_base_delta_norm:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/jneums-consortium-experiment/tests/test_experiment.py
+++ b/contrib/jneums-consortium-experiment/tests/test_experiment.py
@@ -1,0 +1,140 @@
+"""Tests for deterministic consortium-training PoC experiments."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from consortium_experiment import (
+    ConsortiumExperimentRunner,
+    ExperimentConfig,
+    NodeSpec,
+    PolicySpec,
+)
+from consortium_experiment.metrics import state_delta_norm
+
+
+def _corpus(offset: int = 0) -> list[list[int]]:
+    return [
+        [1 + offset, 2 + offset, 3 + offset, 4 + offset],
+        [2 + offset, 3 + offset, 4 + offset, 5 + offset],
+        [3 + offset, 4 + offset, 5 + offset, 6 + offset],
+    ]
+
+
+def _node(node_id: str, quality_score: float, offset: int = 0) -> NodeSpec:
+    return NodeSpec(
+        node_id=node_id,
+        jurisdiction=node_id.title(),
+        corpus=_corpus(offset),
+        quality_score=quality_score,
+        local_epochs=1,
+        lr=0.01,
+    )
+
+
+def _config(policy: PolicySpec, rounds: int = 2, seed: int = 11) -> ExperimentConfig:
+    return ExperimentConfig(
+        seed=seed,
+        rounds=rounds,
+        policy=policy,
+        nodes=[
+            _node("vietnam", 0.9, 0),
+            _node("swiss", 0.8, 10),
+            _node("india", 0.7, 20),
+        ],
+        model_vocab_size=64,
+        model_hidden_size=16,
+    )
+
+
+def test_experiment_runner_is_deterministic_for_seeded_runs() -> None:
+    """The same experiment config should produce the same PoC metrics."""
+    config = _config(PolicySpec(name="quality_weighted", quality_floor=0.1))
+
+    first = ConsortiumExperimentRunner(config).run()
+    second = ConsortiumExperimentRunner(config).run()
+
+    assert first.summary == second.summary
+    assert first.rounds == second.rounds
+
+
+def test_experiment_records_rejected_low_quality_contribution() -> None:
+    """Quality floors should be visible in round metrics and summaries."""
+    config = _config(PolicySpec(name="quality_floor", quality_floor=0.75), rounds=1)
+
+    result = ConsortiumExperimentRunner(config).run()
+    round_metrics = result.rounds[0]
+
+    assert round_metrics.accepted_nodes == ["vietnam", "swiss"]
+    assert round_metrics.rejected_nodes == ["india"]
+    assert "india" not in round_metrics.contribution_weights
+    assert result.summary.total_rejected_contributions == 1
+    assert result.summary.final_artifact_count == 3
+
+
+def test_experiment_records_anti_capture_cap() -> None:
+    """A dominant quality score should be capped by policy and recorded in metrics."""
+    config = ExperimentConfig(
+        seed=3,
+        rounds=1,
+        policy=PolicySpec(name="quality_weighted_capped", max_node_weight=0.5),
+        nodes=[
+            _node("dominant", 10.0, 0),
+            _node("peer_a", 1.0, 10),
+            _node("peer_b", 1.0, 20),
+        ],
+        model_vocab_size=64,
+        model_hidden_size=16,
+    )
+
+    result = ConsortiumExperimentRunner(config).run()
+    round_metrics = result.rounds[0]
+
+    assert round_metrics.max_node_weight <= 0.5
+    assert result.summary.max_observed_node_weight <= 0.5
+    assert round_metrics.contribution_weights["dominant"] == pytest.approx(0.5)
+    assert sum(round_metrics.contribution_weights.values()) == pytest.approx(1.0)
+
+
+def test_experiment_records_n_plus_one_artifacts_and_shared_base_change() -> None:
+    """The metrics should preserve N sovereign artifacts and show base movement."""
+    config = _config(PolicySpec(name="quality_weighted", quality_floor=0.1), rounds=1)
+
+    result = ConsortiumExperimentRunner(config).run()
+    round_metrics = result.rounds[0]
+
+    assert round_metrics.sovereign_artifact_count == len(config.nodes)
+    assert result.summary.final_artifact_count == len(config.nodes)
+    assert round_metrics.shared_base_delta_norm > 0.0
+    assert set(round_metrics.node_losses) == {"vietnam", "swiss", "india"}
+
+
+def test_experiment_writes_json_metrics_and_summary(tmp_path) -> None:
+    """Experiment output should be machine-readable JSONL plus summary JSON."""
+    config = _config(PolicySpec(name="quality_weighted", quality_floor=0.1), rounds=2)
+    output_dir = tmp_path / "experiment"
+
+    result = ConsortiumExperimentRunner(config).run()
+    result.write_json(output_dir)
+
+    metrics_path = output_dir / "metrics.jsonl"
+    summary_path = output_dir / "summary.json"
+    assert metrics_path.exists()
+    assert summary_path.exists()
+
+    metric_lines = [json.loads(line) for line in metrics_path.read_text(encoding="utf-8").splitlines()]
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert len(metric_lines) == 2
+    assert metric_lines[0]["round_num"] == 1
+    assert metric_lines[1]["round_num"] == 2
+    assert summary["rounds"] == 2
+    assert summary["policy_name"] == "quality_weighted"
+
+
+def test_state_delta_norm_rejects_mismatched_model_states() -> None:
+    """Metric helpers should fail clearly on incompatible model states."""
+    with pytest.raises(ValueError, match="same keys"):
+        state_delta_norm({}, {"unexpected": pytest.importorskip("torch").tensor([1.0])})

--- a/src/tapestry/training/consortium/README.md
+++ b/src/tapestry/training/consortium/README.md
@@ -21,6 +21,35 @@ front and center.
 | `coordinator.py` | `ConsortiumCoordinator`, which evolves the shared base from governed contributions. |
 | `policy.py` | `ContributionPolicy`, a minimal quality-floor and anti-capture weighting policy. |
 | `messages.py` | Data classes for sovereign artifacts, contributions, and round results. |
+| `../../../../contrib/jneums-consortium-experiment/` | Contrib experiment runner and metrics helpers that record round metrics and summaries without changing core training logic. |
+
+## Experiment Runner
+
+The experiment runner is a small measurement layer around this PoC. It keeps the
+existing tiny model and coordinator/node abstractions, then writes machine-readable
+metrics so contribution policies can be compared without claiming frontier-scale
+results.
+
+Run the default experiment:
+
+```shell
+PYTHONPATH="$PWD/src:$PWD/contrib/jneums-consortium-experiment" \
+  uv run python contrib/jneums-consortium-experiment/run.py --out runs/consortium_experiment
+```
+
+This writes:
+
+- `metrics.jsonl` with one JSON object per consortium round.
+- `summary.json` with aggregate experiment metrics.
+
+The first metrics are intentionally limited to consortium-specific PoC invariants:
+accepted/rejected nodes, contribution weights, maximum node influence, shared-base
+movement, sovereign artifact count, and local node losses.
+
+This runner is **not** a replacement for established FL or LLM evaluation tooling.
+Larger experiments should align with existing systems such as Flower/NIID-Bench for
+non-IID FL baselines, OpenDiLoCo for low-communication distributed LLM training, and
+lm-evaluation-harness or Unitxt for downstream model evaluation.
 
 ## What This Demonstrates
 


### PR DESCRIPTION
## Summary
- Add a deterministic consortium-training PoC experiment runner with config/result dataclasses and JSONL/summary output.
- Record consortium-specific metrics: accepted/rejected nodes, contribution weights, max node influence, shared-base delta norm, artifact count, and node losses.
- Add a runnable `make consortium-experiment` target, README docs, and tests for determinism, rejection, anti-capture caps, artifact retention, and JSON output.

This is intentionally a CI-scale measurement scaffold around the existing tiny-model PoC, not a replacement for Flower/NIID-Bench, OpenDiLoCo, lm-evaluation-harness, Unitxt, or other larger external tooling.

Refs #24

## Test plan
- [x] `make ruff`
- [x] `make pylint`
- [x] `make type-check`
- [x] `make consortium-tests` — 10 passed, 1 CUDA-driver warning from local torch environment
- [x] `make consortium-demo` — demo completed
- [x] `make consortium-experiment` — wrote `runs/consortium_experiment/{metrics.jsonl,summary.json}`
- [x] `make unit-tests` — 10 passed, 1 CUDA-driver warning from local torch environment
