### PR TITLE
Add contrib/ staging area for contributed ideas and techniques

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ make format-lint-type-check  # Equivalent to 'make format lint type-check'
 
 ## Project Code Structure
 
-In addition to the top-level directories `tech-docs`, discussed above, and `docs`, discussed below, the code structure is as follows. At this time, there are three major _subsystems_:
+In addition to the top-level directories `tech-docs`, discussed above, `docs`, discussed below, and [`contrib`](contrib/README.md), the staging area for contributed ideas and techniques, the code structure is as follows. At this time, there are three major _subsystems_:
 
 * `data` for all data governance and management capabilities.
 * `training` for all distributed training and tuning capabilities.
@@ -178,6 +178,7 @@ In addition to the top-level directories `tech-docs`, discussed above, and `docs
 
 ```
 tapestry/
+├── contrib/        # Contributed ideas & techniques, proposed via PR
 ├── src/
 │   └── tapestry/
 │       └── data/
@@ -197,6 +198,8 @@ tapestry/
 We welcome contributions as [pull requests](https://github.com/The-AI-Alliance/tapestry/pulls), [issues](https://github.com/The-AI-Alliance/tapestry/issues), and [discussions](https://github.com/The-AI-Alliance/tapestry/discussions). 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. In particular, [read this section](CONTRIBUTING.md#developer-certificate-of-origin-dco) on using _DCO_ with any commits.
+
+Have an idea, technique, or experiment you'd like the project to consider? The [**`contrib/`**](contrib/README.md) directory is a lightweight staging area where contributors can propose work via a PR into their own subdirectory. See [**`contrib/README.md`**](contrib/README.md) for the simple workflow and contribution policy.
 
 You can also join one or more work groups that are being organized to identify requirements in several areas and to start the engineering work to prototype and test ideas, followed by the initial implementation iterations. Details are are being documented in [**`tech-docs/work-groups/`**](tech-docs/work-groups/).
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,73 @@
+# Contributed Ideas & Techniques (`contrib/`)
+
+This directory is a staging area for **contributed ideas, techniques, and experiments** offered to Project Tapestry for consideration. It is intentionally lightweight: a place to share work-in-progress proposals, prototypes, notes, datasets-pointers, and references without first having to fit them into the main package or `tech-docs/` taxonomy.
+
+Think of `contrib/` as the front porch. Promising contributions may later be promoted into `src/`, `tech-docs/`, or `examples/` after discussion and review. Material here is **not** part of the supported codebase and carries no stability guarantees.
+
+## How to Contribute
+
+We follow normal _GitOps_ practices (see the top-level [`CONTRIBUTING.md`](../CONTRIBUTING.md)). To add a contribution:
+
+1. **Fork and branch** the repository.
+2. **Create your own subdirectory** under `contrib/`, named with your handle/org and a short topic, e.g.:
+   - `contrib/jane-doe-cultural-eval/`
+   - `contrib/acme-labs-federated-tuning/`
+3. **Add your contents** to that subdirectory. At minimum include:
+   - A short `README.md` describing the idea, motivation, status, and how to use or evaluate it.
+   - A `LICENSE` (or `LICENSE` reference) covering the contents — see [Licensing](#licensing) below.
+4. **Open a Pull Request.** Keep each PR focused on a single contribution. Use the PR description to explain what you're proposing and what feedback you're looking for.
+5. **Sign your commits** with DCO (`git commit -s ...`). See the [DCO section](../CONTRIBUTING.md#developer-certificate-of-origin-dco) for details.
+
+A maintainer will review, discuss, and either request changes, merge for further consideration, or suggest a better home for the work. Merging into `contrib/` signals "accepted for consideration," not endorsement or production-readiness.
+
+### Suggested Subdirectory Layout
+
+```
+contrib/
+└── <your-handle>-<topic>/
+    ├── README.md      # what it is, why, status, how to try it
+    ├── LICENSE        # license for this contribution (see below)
+    └── ...            # code, notes, diagrams, data pointers, etc.
+```
+
+## Contribution Policy
+
+Keep it simple, but please respect the following:
+
+### Licensing
+
+Every contribution must be clearly licensed. Unless you state otherwise (compatibly), Tapestry's default licenses apply:
+
+| Content type | Default license |
+| :----------- | :-------------- |
+| Code | [Apache 2.0](../LICENSE.Apache-2.0) |
+| Documentation | [CC BY 4.0](../LICENSE.CC-BY-4.0) |
+| Data | [CDLA Permissive 2.0](../LICENSE.CDLA-2.0) |
+
+If your contribution uses a different (but compatible, permissive) license, state it explicitly in your subdirectory's `LICENSE` and `README.md`. Contributions without a clear, compatible license cannot be accepted.
+
+### Copyright & Data Clearance
+
+By opening a PR you affirm (via DCO) that:
+
+- The contribution is **yours to give**, or you have the rights/permission to contribute it.
+- It does **not** include copyrighted text, code, model weights, or data that you are not licensed to redistribute.
+- Any included or referenced **datasets are cleared** for the intended use — no scraped/restricted/PII-laden data without appropriate rights and handling. When in doubt, contribute a *pointer and description* rather than the raw data, and flag any handling constraints.
+- It does not violate third-party terms of service, NDAs, or export-control restrictions.
+
+### Security
+
+- **Do not commit secrets** — no API keys, credentials, tokens, or private endpoints.
+- Don't include malicious, obfuscated, or unsafe-to-run code. Note any external dependencies or commands a reviewer would execute.
+- Flag anything that touches authentication, networking, or executes untrusted input so reviewers can take a closer look.
+
+### Conduct
+
+All activity here follows the [AI Alliance Code of Conduct](https://github.com/The-AI-Alliance/community/blob/main/CODE_OF_CONDUCT.md) and the policies in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Questions / Contacts
+
+Not sure if something fits, or want to discuss before opening a PR? Start a [GitHub Discussion](https://github.com/The-AI-Alliance/tapestry/discussions) or reach out to the maintainers:
+
+- **Christopher Nguyen** ([@ctn](https://github.com/ctn))
+- **Dean Wampler** ([@deanwampler](https://github.com/deanwampler))


### PR DESCRIPTION
## Summary

- Add `contrib/README.md` establishing `contrib/` as a lightweight staging area to receive contributed ideas, techniques, and experiments for consideration.
- Define a simple PR-based GitOps workflow: contributors fork, create their own `contrib/<handle>-<topic>/` subdirectory, add a `README.md` + `LICENSE`, and open a focused PR with DCO sign-off.
- Specify a light-but-sufficient contribution policy covering licensing (defaulting to the repo's Apache 2.0 / CC BY 4.0 / CDLA-2.0 split), copyright & data clearance, and security (no secrets, no unsafe code).
- List Christopher Nguyen (@ctn) and Dean Wampler (@deanwampler) as contacts.
- Update the top-level `README.md` for consistency: reference `contrib/` in **Getting Involved** and add it to the project structure diagram.

## Test plan

- [x] Verify `contrib/README.md` renders correctly on GitHub.
- [ ] Verify relative links to `CONTRIBUTING.md`, the `LICENSE.*` files, and the DCO section resolve.
- [ ] Confirm the top-level `README.md` links to `contrib/README.md` correctly.

Made with [Cursor](https://cursor.com)