### PR TITLE
docs: add sovereign evaluation evidence proposal

### DIFF
--- a/contrib/oli-sovereign-eval-evidence/LICENSE
+++ b/contrib/oli-sovereign-eval-evidence/LICENSE
@@ -1,0 +1,8 @@
+This contribution follows the repository default licenses:
+
+- Documentation: Creative Commons Attribution 4.0 International. See ../../LICENSE.CC-BY-4.0.
+- Code, if added later: Apache License, Version 2.0. See ../../LICENSE.Apache-2.0.
+- Data, if added later: CDLA Permissive 2.0. See ../../LICENSE.CDLA-2.0.
+
+This contribution does not include raw training data, private notes, model
+weights, credentials, or restricted datasets.

--- a/contrib/oli-sovereign-eval-evidence/README.md
+++ b/contrib/oli-sovereign-eval-evidence/README.md
@@ -1,0 +1,133 @@
+# Sovereign Evaluation Evidence Layer
+
+Status: proposal / evaluation design scaffold.
+
+This contribution proposes a small evidence layer for Tapestry's Evaluation &
+Certification work. It connects cultural-alignment evaluation, data-sovereignty
+evidence, privacy/security checks, and release gates so a Tapestry-derived model
+can show what has been demonstrated before public claims are made.
+
+It is intentionally scoped as documentation and templates. It does not include
+raw datasets, private notes, model weights, or a runnable benchmark.
+
+## Motivation
+
+Tapestry's Phase 0 work already has active paths for:
+
+- cultural-alignment experiments using the Inglehart-Welzel Cultural Map
+  ([issue #22](https://github.com/The-AI-Alliance/tapestry/issues/22));
+- policy and evaluation tooling choices
+  ([issue #34](https://github.com/The-AI-Alliance/tapestry/issues/34));
+- dataset discovery and data-management requirements
+  ([issue #23](https://github.com/The-AI-Alliance/tapestry/issues/23) and
+  [issue #27](https://github.com/The-AI-Alliance/tapestry/issues/27));
+- consortium-training metrics and governed contribution policies
+  ([issue #24](https://github.com/The-AI-Alliance/tapestry/issues/24)).
+
+The missing bridge is an explicit evidence format:
+
+1. Which claim is being made?
+2. What evidence supports it?
+3. Which evidence can be public?
+4. Which evidence should remain private to a participant or consortium reviewer?
+5. What result should block a release or certification claim?
+
+This contribution provides a first pass at that bridge.
+
+## Grounded Input From Adjacent Work
+
+The examples below come from adjacent technical work in privacy-preserving
+systems, security migration, and strict benchmark design. They are included as
+transferable patterns, not as Tapestry data uploads.
+
+### Aggregate-only evidence
+
+Privacy-sensitive systems can still produce useful operational evidence when
+reports stay aggregate-only and avoid re-identification. Useful signals include
+system-level totals, coverage proxies, workflow counts, and caveats about what
+the observable data can and cannot prove.
+
+Evaluation lesson: useful operational evidence can be produced without turning a
+privacy system into a surveillance system. Tapestry evaluation reports should
+separate public aggregate metrics, consortium-private review artifacts, and
+participant-private logs.
+
+### Security-migration evidence
+
+Security migration work often succeeds or fails on inventory, ownership, and
+claim boundaries. The useful pattern is surface-based evidence: identify the
+systems, artifacts, operators, and governance surfaces affected by a claim;
+assign owners; track readiness levels; and avoid saying a system fully satisfies
+a property before every relevant surface has been reviewed.
+
+Evaluation lesson: Tapestry certification should reward precise, bounded claims.
+For example, "this sovereign model has an auditable data-residency process for
+these datasets" is stronger than "this model is sovereign."
+
+### Strict benchmark gates
+
+Strict technical benchmarks work best when they define pass/fail invariants
+alongside scores. A result should fail when it violates correctness,
+reproducibility, cleanup, leakage, or other stated invariants, even if the
+headline metric improves.
+
+Evaluation lesson: Tapestry release gates should define pass/fail invariants,
+not only leaderboards. Cultural-alignment gains should not count as wins if they
+break safety baselines, leak restricted data, destroy core capability, or hide
+evaluation caveats.
+
+### Claim hygiene
+
+Adjacent evaluation and security work repeatedly benefits from separating claim
+classes. Related ideas can connect under one architecture, but they should not
+be collapsed into one vague promise.
+
+Evaluation lesson: Tapestry evidence should keep claim classes separate:
+cultural alignment, language capability, data sovereignty, privacy, safety,
+capability, and portability each need their own evidence.
+
+## Proposed Artifacts
+
+This contribution starts with three documents:
+
+- [evaluation-matrix.md](evaluation-matrix.md): claim classes, evidence, tools,
+  visibility tiers, and blocking conditions.
+- [dataset-card-template.md](dataset-card-template.md): a minimum dataset and
+  provenance record for data that may support Tapestry training, tuning, or
+  evaluation.
+- [release-gate-checklist.md](release-gate-checklist.md): practical gates before
+  a shared-base update, sovereign model release, or certification claim.
+
+## Where This Could Fit
+
+This proposal could remain in `contrib/` as an experimental evaluation scaffold,
+or it could seed work in:
+
+- `tech-docs/work-groups/evaluation-certification/`
+- `tech-docs/work-groups/data-governance/`
+- `tech-docs/work-groups/security-privacy/`
+
+## Non-goals
+
+- It does not solve cultural alignment.
+- It does not propose a new model-training algorithm.
+- It does not upload datasets.
+- It does not imply that aggregate telemetry is an acceptable substitute for
+  participant consent, privacy review, or data-governance policy.
+- It does not collapse domain expertise into culture. Domain-specific evaluation
+  can complement cultural evaluation, but it cannot replace it.
+
+## Candidate Public References
+
+- Project Tapestry issue #22:
+  <https://github.com/The-AI-Alliance/tapestry/issues/22>
+- Project Tapestry issue #34:
+  <https://github.com/The-AI-Alliance/tapestry/issues/34>
+- Project Tapestry issue #27:
+  <https://github.com/The-AI-Alliance/tapestry/issues/27>
+- AI Alliance Evaluation Reference Stack:
+  <https://the-ai-alliance.github.io/eval-ref-stack/>
+- AI Alliance Evaluation Is for Everyone:
+  <https://the-ai-alliance.github.io/trust-safety-evals/>
+- Unitxt:
+  <https://www.unitxt.ai/en/latest/>

--- a/contrib/oli-sovereign-eval-evidence/dataset-card-template.md
+++ b/contrib/oli-sovereign-eval-evidence/dataset-card-template.md
@@ -1,0 +1,91 @@
+# Minimum Dataset And Provenance Card
+
+This template is for datasets, corpus pointers, evaluation prompts, preference
+sets, or domain-review material proposed for Tapestry training, tuning, or
+evaluation. It is designed for metadata-first intake. Do not attach raw sensitive
+data unless Tapestry maintainers have explicitly approved the handling path.
+
+## Basic Identity
+
+- Dataset or corpus name:
+- Version:
+- Proposed contributor:
+- Contact:
+- Data type:
+  - open corpus
+  - restricted corpus
+  - local-only corpus
+  - evaluation prompt set
+  - preference data
+  - domain-review rubric
+  - other:
+- Language(s):
+- Community, jurisdiction, or domain represented:
+- Intended use:
+  - Stage 0 data preparation
+  - Stage A continued pretraining
+  - Stage B instruction tuning
+  - Stage C alignment
+  - evaluation only
+  - other:
+
+## Rights And Restrictions
+
+- License or rights basis:
+- Commercial use permitted:
+- Model training permitted:
+- Redistribution permitted:
+- Attribution required:
+- Personal data present:
+- Sensitive or regulated data present:
+- Export-control or sanctions risk:
+- Terms-of-service concerns:
+- Known excluded sources:
+
+## Sovereignty And Residency
+
+- Required residency boundary:
+- Raw data may leave participant infrastructure:
+- Derived artifacts may leave participant infrastructure:
+- Model updates may leave participant infrastructure:
+- Required technical controls:
+  - none
+  - access controls
+  - anonymization or redaction
+  - differential privacy
+  - secure aggregation
+  - trusted execution environment
+  - other:
+- Required legal or organizational controls:
+- Audit evidence available:
+
+## Provenance
+
+- Source origin:
+- Collection method:
+- Collection dates:
+- Consent or public-access basis:
+- Curation method:
+- Deduplication method:
+- Quality filters:
+- Known bias or coverage limits:
+- Community or domain expert review performed:
+
+## Evaluation Use
+
+- Claim class supported:
+- Evaluation rubric available:
+- Expected failure modes:
+- Public evidence allowed:
+- Consortium-private evidence allowed:
+- Participant-private evidence only:
+
+## Release Decision
+
+- Accepted for public metadata catalog:
+- Accepted for evaluation-only use:
+- Accepted for training/tuning use:
+- Blocked pending rights review:
+- Blocked pending privacy review:
+- Blocked pending community/domain review:
+- Notes:

--- a/contrib/oli-sovereign-eval-evidence/evaluation-matrix.md
+++ b/contrib/oli-sovereign-eval-evidence/evaluation-matrix.md
@@ -1,0 +1,47 @@
+# MVP Evaluation Matrix
+
+This matrix describes the minimum evidence layer for Tapestry-derived model
+claims. It is designed to be small enough for Phase 0 while leaving room for
+participant-specific private evidence.
+
+## Evidence Visibility Tiers
+
+| Tier | Audience | Examples |
+| --- | --- | --- |
+| Public | Anyone | Summary metrics, model card, dataset metadata, claim boundaries |
+| Consortium | Tapestry reviewers and participating organizations | Full evaluation runs, red-team details, restricted data-review notes |
+| Participant | Data/model owner only | Raw sensitive data, private logs, regulated records, internal annotation details |
+
+## Claim Matrix
+
+| Claim class | Example claim | Minimum evidence | Candidate tools | Blocking condition |
+| --- | --- | --- | --- | --- |
+| Cultural alignment shift | Model output moved toward the target community on WVS/Inglehart-Welzel style axes | Before/after eval, prompt set version, target community definition, uncertainty notes, adversarial prompt-order checks | Unitxt, lm-evaluation-harness, custom WVS harness | Apparent shift disappears under prompt-order or paraphrase checks |
+| Cultural grounding | Stage 0/A data reflects a community's institutions, norms, and domain context | Dataset card, coverage analysis, contributor review, excluded-source list | Dataset cards, data catalogs | Dataset is language-local but culturally thin, or source authority is unclear |
+| Capability preservation | Alignment or CPT did not degrade general quality beyond tolerance | Baseline and post-update benchmark deltas, model/version hashes, regression thresholds | lm-evaluation-harness, Unitxt | General capability drop exceeds predeclared threshold |
+| Safety preservation | Continued pretraining or sovereign alignment did not remove baseline safety constraints | Safety suite before/after, blocked behavior checks, red-team summary, release notes | AI Alliance eval stack, policy tools, custom red-team suites | Known baseline safety gate fails after update |
+| Data sovereignty | Restricted data stayed under the promised legal, organizational, and technical controls | Dataset card, residency rule, allowed-use statement, audit evidence, operator attestation | Provenance records, OPA, logs, data catalog | Raw restricted data leaves its permitted boundary without governed exception |
+| Privacy/leakage control | Model or update artifacts do not expose protected records under the stated threat model | Canary tests, extraction tests, memorization checks, update-leakage review | Custom extraction harnesses, DP or secure aggregation reports | Protected examples are recoverable or memorized beyond threshold |
+| Contribution integrity | Training updates are accepted through a governed policy | Contribution weights, quality floor/cap config, rejected-update reasons, artifact hashes | Consortium metrics runner, governance logs | A single participant exceeds influence cap or policy is not reproducible |
+| Portability | Sovereign artifacts remain usable across base changes or exit scenarios | Artifact schema, export test, dependency list, base-model compatibility notes | Model cards, artifact manifests | Participant cannot retain usable sovereign work after exit or base replacement |
+| Domain expertise | Model handles high-stakes technical domains without overclaiming | Domain-specific eval set, expert review notes, uncertainty and source-boundary checks | Custom task set, expert rubric | Model confidently gives unsafe or unsupported domain guidance |
+
+## Example Rubric Shape
+
+Each evaluation item should include:
+
+- `id`: stable identifier.
+- `claim_class`: one of the claim classes above.
+- `prompt`: original prompt text.
+- `expected_behavior`: concise expected behavior.
+- `failure_modes`: unacceptable behaviors.
+- `visibility`: public, consortium, or participant.
+- `source_basis`: public source URL or internal source category.
+- `reviewer_role`: domain expert, community reviewer, security reviewer, or data steward.
+
+Example failure modes:
+
+- treats aggregate telemetry as consent to identify individual users;
+- claims a system satisfies a broad property because one control passed;
+- rewards a benchmark score even when a required invariant fails;
+- treats language fluency as cultural alignment.

--- a/contrib/oli-sovereign-eval-evidence/release-gate-checklist.md
+++ b/contrib/oli-sovereign-eval-evidence/release-gate-checklist.md
@@ -1,0 +1,82 @@
+# Release Gate Checklist
+
+This checklist is a first pass at gates before public claims are made about a
+Tapestry-derived shared base, sovereign derivative, or certification status.
+
+## Gate 1: Claim Boundary
+
+- The claim is written in one sentence.
+- The claim class is identified:
+  - cultural alignment
+  - language capability
+  - domain expertise
+  - data sovereignty
+  - privacy
+  - safety
+  - capability
+  - portability
+  - contribution integrity
+- The claim does not collapse separate concepts into one vague promise.
+- The claim states what is not covered.
+
+## Gate 2: Evidence Inventory
+
+- Evaluation run IDs are recorded.
+- Model hashes and versions are recorded.
+- Dataset or prompt-set versions are recorded.
+- Tool versions and configuration are recorded.
+- Public evidence summary is prepared.
+- Consortium-private evidence bundle is prepared when needed.
+- Participant-private evidence remains within the promised boundary.
+
+## Gate 3: Data And Sovereignty Review
+
+- Every dataset has a dataset/provenance card.
+- Restricted or local-only data is clearly marked.
+- Residency controls match the stated tier.
+- Raw data movement is recorded or prohibited.
+- Allowed uses match the proposed training/evaluation step.
+- Data stewards have approved the use.
+
+## Gate 4: Capability And Safety Regression
+
+- General capability baselines were run before and after the update.
+- Cultural or domain gains are not counted if core capability falls past the
+  predeclared threshold.
+- Safety baselines were run before and after the update.
+- Known safety regressions are either fixed or block release.
+- Red-team findings are summarized at the right visibility tier.
+
+## Gate 5: Privacy And Leakage Review
+
+- Memorization or extraction tests were run when restricted data was used.
+- Canary tests were run where appropriate.
+- Update-leakage risk was reviewed for contributed model weights.
+- Public metrics do not expose individual or restricted behavior.
+- Logs and telemetry are checked for accidental data leakage.
+
+## Gate 6: Cultural Or Domain Review
+
+- The represented community or domain is explicitly named.
+- Reviewers are identified by role, not only by organization.
+- Prompt sets are checked for cultural flattening or domain oversimplification.
+- Language fluency is not treated as cultural alignment.
+- Community/domain reviewers can dispute or qualify the public claim.
+
+## Gate 7: Governance And Anti-capture
+
+- Contribution weighting policy is recorded.
+- Quality floor and influence cap are recorded.
+- Rejected contributions include reasons.
+- Any exception has a governance record.
+- No single participant can silently dominate the public claim.
+
+## Gate 8: Release Decision
+
+- Release approved:
+- Release blocked:
+- Certification claim approved:
+- Certification claim blocked:
+- Public caveats:
+- Private follow-up:
+- Owner for next review:


### PR DESCRIPTION
## Description of Changes

Adds a lightweight `contrib/oli-sovereign-eval-evidence/` proposal for a sovereign evaluation evidence layer.

The contribution is docs/templates only. It proposes:

- an MVP evaluation matrix for cultural alignment, data sovereignty, privacy/leakage, safety, capability, portability, contribution integrity, and domain expertise claims;
- a minimum dataset/provenance card template;
- a release-gate checklist for shared-base updates, sovereign derivatives, and certification claims.

The examples are grounded in adjacent technical patterns around aggregate-only evidence, security-migration inventories, strict benchmark gates, and claim hygiene. No raw datasets, private notes, credentials, or model weights are included.

## Related Issues

Relates to #22, #27, #34, and #24.

## Testing Performed

- `git diff --check`
- searched the contribution for private-note leakage, credentials, and disallowed wording

No code or runnable benchmark is added.

## Code Changes

- Added `contrib/oli-sovereign-eval-evidence/README.md`
- Added `contrib/oli-sovereign-eval-evidence/evaluation-matrix.md`
- Added `contrib/oli-sovereign-eval-evidence/dataset-card-template.md`
- Added `contrib/oli-sovereign-eval-evidence/release-gate-checklist.md`
- Added `contrib/oli-sovereign-eval-evidence/LICENSE`

## Example Usage

Reviewers can use the matrix to decide which evidence should accompany a Tapestry-derived claim, which evidence can be public, which evidence belongs at consortium or participant scope, and which failures should block a release.

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For documentation changes, including `tech-docs` and the "microsite" `docs` content:

- [x] I have followed the documentation style guide.
- [x] I have included appropriate screenshots, example code, etc. (not applicable for this docs/template proposal)

For code changes:

- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation.
