### PR TITLE
docs(contrib): add scope & vendor-neutrality policy

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -34,6 +34,16 @@ contrib/
 
 Keep it simple, but please respect the following:
 
+### Scope & Neutrality
+
+`contrib/` is a staging area for ideas that advance Project Tapestry — not a place to advertise products or steer the project toward a single vendor or ecosystem. Even a "merged for consideration" contribution lives permanently under the AI Alliance's name, so we keep this space vendor-neutral. This mirrors the [Kubernetes Documentation Content Guide](https://kubernetes.io/docs/contribute/style/content-guide/): _"feature docs aren't a place for vendors to advertise their products."_
+
+- **On-mission.** Contributions should be relevant to Tapestry's work (sovereign/consortium training, data governance, evaluation, supporting infrastructure). Material whose primary purpose is to promote an external project, product, token, or ecosystem does not belong here, even if it is technically adjacent.
+- **Cite, don't promote.** You may reference external open-source tools, datasets, or standards when they are genuinely relevant (e.g. evaluation harnesses, public benchmarks, published standards). Name them plainly and link to their canonical source. Do **not** add marketing language, calls to action, or links to commercial product, rewards, airdrop, or token pages.
+- **No personal-portfolio padding.** Examples should illustrate a principle, not showcase a contributor's own products or unrelated work. Anonymize or generalize examples so the point survives without the brand name.
+
+If you're unsure whether something fits, open a [Discussion](https://github.com/The-AI-Alliance/tapestry/discussions) before submitting a PR.
+
 ### Licensing
 
 Every contribution must be clearly licensed. Unless you state otherwise (compatibly), Tapestry's default licenses apply:


### PR DESCRIPTION
## Summary

Adds a **Scope & Neutrality** section to the `contrib/` contribution policy, modeled on and crediting the [Kubernetes Documentation Content Guide](https://kubernetes.io/docs/contribute/style/content-guide/).

It establishes three rules for `contrib/` submissions:

- **On-mission** — contributions must be relevant to Tapestry's work; material whose primary purpose is to promote an external project/product/token/ecosystem doesn't belong, even if technically adjacent.
- **Cite, don't promote** — external OSS tools/datasets/standards may be referenced when genuinely relevant, linked to their canonical source, but no marketing, CTAs, or links to commercial/rewards/airdrop/token pages.
- **No personal-portfolio padding** — examples should illustrate a principle, not showcase a contributor's own products.

## Why

`contrib/` currently has no written guidance on scope or vendor-neutrality, only licensing/security/conduct. Since `contrib/` is empty on `develop` and the first contributions are now arriving, codifying this now sets a consistent, depersonalized standard for reviewing PRs (e.g. #51, #47) rather than making ad-hoc calls. It also aligns `contrib/` with the vendor-neutrality norms standard to the Linux Foundation / CNCF world the AI Alliance sits in.

## Test plan

- [x] Markdown renders correctly (new `### Scope & Neutrality` subsection under Contribution Policy)
- [x] Links resolve (K8s Content Guide, Discussions)

Made with [Cursor](https://cursor.com)