### PR TITLE
docs: clarify Tapestry's two objectives in the README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 #### Project Tapestry aims to give every nation and participant frontier AI they can call their own.
 
-#### A global consortium of partners pools data and compute to train a shared **frontier** base model — stronger than any single party could build alone, thanks to a larger and more diverse corpus than ever before.
+#### It brings together talented people, data, and compute from a global consortium of partners to train a shared **frontier** base model — stronger than any single party could build alone, thanks to a larger and more diverse corpus than ever before.
 
 #### From that shared base, each partner builds and owns **sovereign** models, aligned to their own **national**, **socio-cultural**, and **industrial** needs, using the Tapestry open source training platform. Ownership of data and compute stays with the partners throughout.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Welcome to Project Tapestry
 
-#### Project Tapestry aims to give every nation and participant frontier AI they can call their own.
+#### At Project Tapestry, we aim to give every nation and participant frontier AI they can call their own.
 
-#### It brings together talented people, data, and compute from a global consortium of partners to train a shared **frontier** base model — stronger than any single party could build alone, thanks to a larger and more diverse corpus than ever before.
+#### We bring together talented people, data, and compute from a global consortium of partners to train a shared **frontier** base model — stronger than any single party could build alone, thanks to a larger and more diverse corpus than ever before.
 
 #### From that shared base, each partner builds and owns **sovereign** models, aligned to their own **national**, **socio-cultural**, and **industrial** needs, using the Tapestry open source training platform. Ownership of data and compute stays with the partners throughout.
 
-#### The aim is AI that is frontier and sovereign at once — not a tradeoff between the two.
+#### Our aim is AI that is frontier and sovereign at once — not a tradeoff between the two.
 
 Learn more from our [Kickoff Workshop Blog](https://thealliance.ai/blog/project-tapestry-the-path-to-frontier-sovereign-ai) and check out the [Project Tapestry](https://thealliance.ai/projects/tapestry/) website for more information about partnering, events, and how to support Project Tapestry.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 # Welcome to Project Tapestry
 
-#### Project Tapestry is bringing together talented people, data, and compute from a global consortium of partners to build a new foundation model system trained on a larger and more diverse corpus than ever before. 
+#### Project Tapestry aims to give every nation and participant frontier AI they can call their own.
 
-#### Tapestry will enable sovereign AI by ensuring ownership of data and compute remains with partners, and that partners can continue to train sovereign derivatives of the consortium-trained base model that they own using the Tapestry open source training platform.
+#### A global consortium of partners pools data and compute to train a shared **frontier** base model — stronger than any single party could build alone, thanks to a larger and more diverse corpus than ever before.
+
+#### From that shared base, each partner builds and owns **sovereign** models, aligned to their own **national**, **socio-cultural**, and **industrial** needs, using the Tapestry open source training platform. Ownership of data and compute stays with the partners throughout.
+
+#### The aim is AI that is frontier and sovereign at once — not a tradeoff between the two.
 
 Learn more from our [Kickoff Workshop Blog](https://thealliance.ai/blog/project-tapestry-the-path-to-frontier-sovereign-ai) and check out the [Project Tapestry](https://thealliance.ai/projects/tapestry/) website for more information about partnering, events, and how to support Project Tapestry.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Welcome to Project Tapestry
 
-#### At Project Tapestry, we aim to give every nation and participant frontier AI they can call their own.
+#### Project Tapestry aims to give every nation and participant frontier AI they can call their own.
 
 #### We bring together talented people, data, and compute from a global consortium of partners to train a shared **frontier** base model — stronger than any single party could build alone, thanks to a larger and more diverse corpus than ever before.
 
 #### From that shared base, each partner builds and owns **sovereign** models, aligned to their own **national**, **socio-cultural**, and **industrial** needs, using the Tapestry open source training platform. Ownership of data and compute stays with the partners throughout.
 
-#### Our aim is AI that is frontier and sovereign at once — not a tradeoff between the two.
+#### The aim is AI that is frontier and sovereign at once — not a tradeoff between the two.
 
 Learn more from our [Kickoff Workshop Blog](https://thealliance.ai/blog/project-tapestry-the-path-to-frontier-sovereign-ai) and check out the [Project Tapestry](https://thealliance.ai/projects/tapestry/) website for more information about partnering, events, and how to support Project Tapestry.
 


### PR DESCRIPTION
## Summary

Rewrites the README opening so the project's goal is unmistakable: to give every nation and participant AI that is **both frontier-class and sovereign**.

The current intro describes building a shared model and preserving ownership, but doesn't name the "frontier" objective in the body or convey that sovereignty spans more than data/compute ownership. This update:

- States the **frontier** objective explicitly — a stronger shared base model, made possible by a larger, more diverse consortium corpus than any single party could assemble.
- Frames **sovereignty** across its **national**, **socio-cultural**, and **industrial** dimensions, with partners owning their data, compute, and the models they build on the shared base.
- Closes with the core aim stated plainly: frontier and sovereign at once, not a tradeoff.

Wording is aligned with the repository description and topics. @deanwampler — flagging for your review of the framing before we merge.

## Test plan

- [x] Markdown renders; intro reads cleanly
- [x] Existing blog/website links preserved

Made with [Cursor](https://cursor.com)