### PR TITLE
docs: add in-repo Tapestry glossary + cross-links

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -22,7 +22,7 @@ The AI Alliance [launched](https://thealliance.ai/blog/ai-alliance-launches-proj
 {: .note }
 > * **Join Us!** We are looking for collaborators. See our [contributing]({{site.baseurl}}/contributing) page for details.
 > * Use the search box at the top of this page to find specific content.
-> * The links for Capitalized Terms go to [this glossary]({{site.glossaryurl}}){:target="_glossary"}.
+> * The links for Capitalized Terms go to [this glossary]({{site.glossaryurl}}){:target="_glossary"}. Tapestry-specific terms (e.g., *Consortium training*, *Shared-Base Loop*, *Sovereign Build*) are defined in the [in-repo glossary]({{page.tech_docs}}/reference/glossary.md){:target="repo-tech-docs"}.
  
 This website is for technical contributors. As Project Tapestry evolves, this website will provide links to technical requirements, architecture and design documentation, and implementation source code.
 

--- a/tech-docs/README.md
+++ b/tech-docs/README.md
@@ -32,6 +32,7 @@ The [`reference/`](reference/README.md) directory holds material outside the TVA
 
 | Document | Description |
 | :------- | :---------- |
+| [`reference/glossary.md`](reference/glossary.md) | Definitions of Tapestry-specific terms (consortium training, Shared-Base Loop, Sovereign Build, etc.) |
 | [`reference/training-approaches.md`](reference/training-approaches.md) | Centralized vs. federated vs. consortium training |
 
 Repository root [**`README.md`**](../README.md) and [**`AGENTS.md`**](../AGENTS.md) summarize how `tech-docs/` fits with `docs/`, `src/`, and contributor workflows.

--- a/tech-docs/architecture/3-value-propositions.md
+++ b/tech-docs/architecture/3-value-propositions.md
@@ -12,7 +12,7 @@ This document also distinguishes between value that Tapestry can deliver on Day 
 
 ## Architectural Premise
 
-Tapestry's training model is a **core-plus-sovereign architecture**: a frontier-competitive base model (initially adopted from existing open weights, eventually trained by the consortium) enriched by sovereign contributions — cultural alignment, domain expertise, institutional knowledge — from participating nodes. The ratio starts at roughly 80/20 centralized-to-distributed and shifts over time as the consortium's own training capacity matures.
+Tapestry's training model is a **core-plus-sovereign architecture**: a frontier-competitive base model (initially adopted from existing open weights, eventually trained by the consortium) enriched by sovereign contributions — cultural alignment, domain expertise, institutional knowledge — from participating members. The ratio starts at roughly 80/20 centralized-to-distributed and shifts over time as the consortium's own training capacity matures.
 
 This means Tapestry does not ask participants to accept a worse model for the sake of sovereignty. It starts with frontier-class general capability and adds sovereign value on top. The value proposition is additive, not substitutive.
 

--- a/tech-docs/architecture/5-architectural-options.md
+++ b/tech-docs/architecture/5-architectural-options.md
@@ -167,7 +167,7 @@ This loop differs from traditional federated learning in important ways:
 | **Communication cadence** | Varies by method and deployment | Operational choice — frequent or infrequent |
 | **Heterogeneity** | Hardware (phone vs. tablet) | Hardware, data, culture, policy |
 
-The term "consortium training" more accurately describes what Tapestry does — the paradigm defined in [TAP-002](decisions/adr-002-consortium-training.md): few large, trusted, heterogeneous nodes collaboratively improving a shared model under data-sovereignty and cultural-alignment constraints.
+The term "consortium training" more accurately describes what Tapestry does — the paradigm defined in [TAP-002](decisions/adr-002-consortium-training.md): few large, trusted, heterogeneous members collaboratively improving a shared model under data-sovereignty and cultural-alignment constraints.
 
 ### Workshop decision needed
 

--- a/tech-docs/architecture/decisions/adr-002-consortium-training.md
+++ b/tech-docs/architecture/decisions/adr-002-consortium-training.md
@@ -32,6 +32,8 @@ flowchart LR
   classDef model fill:#7b6aae,stroke:#e0c3fc,color:#fff
 ```
 
+*Term definitions are consolidated in [`glossary.md`](../../reference/glossary.md).*
+
 This is distinct from federated learning (designed for millions of small edge clients with individual privacy concerns) and from centralized training (all data in one place, one organization controls everything).
 
 ![Training paradigms compared](../diagrams/training-paradigms-comparison.svg)

--- a/tech-docs/architecture/decisions/adr-002-consortium-training.md
+++ b/tech-docs/architecture/decisions/adr-002-consortium-training.md
@@ -10,13 +10,13 @@
 
 ## Context
 
-Tapestry's training involves multiple sovereign nodes contributing to a shared model. The approach must be named and distinguished from existing paradigms (centralized training, federated learning) to avoid confusion and to accurately describe what Tapestry does.
+Tapestry's training involves multiple sovereign members contributing to a shared model. The approach must be named and distinguished from existing paradigms (centralized training, federated learning) to avoid confusion and to accurately describe what Tapestry does.
 
 See [`training-approaches.md`](../../reference/training-approaches.md) for a full comparison of centralized, federated, and consortium training.
 
 ## Decision
 
-Tapestry uses **consortium training**: a small number of large, trusted, heterogeneous nodes collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal.
+Tapestry uses **consortium training**: a small number of large, trusted, heterogeneous members collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal.
 
 ```mermaid
 flowchart LR
@@ -55,7 +55,7 @@ Consortium training borrows techniques from the federated learning literature �
 
 ## Rationale
 
-- Tapestry's nodes are few (dozens), large (national GPU clusters), and **collaborating institutions with governance voice** — not millions of mutually untrusted edge clients. See [Design principles for architecture work](../0-tva-methodology.md#design-principles-for-architecture-work).
+- Tapestry's members are few (dozens) and are **collaborating institutions with governance voice** — not millions of mutually untrusted edge clients. Each member operates large nodes (national GPU clusters). See [Design principles for architecture work](../0-tva-methodology.md#design-principles-for-architecture-work).
 - The sovereignty motive is national/institutional, not individual data protection. The governance model, trust assumptions, and communication patterns all differ.
 - Using "federated" to describe Tapestry borrows the right principle (data stays put) but the wrong connotations (edge devices, FedAvg, cross-silo averaging). "Consortium training" accurately describes the participants, the purpose, and the governance.
 

--- a/tech-docs/architecture/decisions/adr-004-training-loop.md
+++ b/tech-docs/architecture/decisions/adr-004-training-loop.md
@@ -14,6 +14,8 @@ Given the core-plus-sovereign architecture ([TAP-001](adr-001-core-plus-sovereig
 
 ## The two phases
 
+> A consolidated glossary of these and other Tapestry terms lives in [`glossary.md`](../../reference/glossary.md).
+
 Consortium training has two phases, run in order:
 
 1. **Shared-Base Loop** — collective and iterative. Members improve one shared base model together. Its output is a *base*, not a deployable product, and it carries **no cultural alignment**.

--- a/tech-docs/architecture/decisions/adr-005-sovereign-pipeline.md
+++ b/tech-docs/architecture/decisions/adr-005-sovereign-pipeline.md
@@ -17,6 +17,8 @@ This revision expands the pipeline to cover the full lifecycle from data curatio
 
 ## Standard terminology mapping
 
+> A consolidated glossary of these and other Tapestry terms lives in [`glossary.md`](../../reference/glossary.md).
+
 Tapestry's pipeline stages map to standard industry terms as follows:
 
 | Tapestry Stage | Industry Term(s) | Training Phase |

--- a/tech-docs/reference/README.md
+++ b/tech-docs/reference/README.md
@@ -4,5 +4,6 @@ Long-lived reference material that supports Tapestry design and operations: conc
 
 | Document | Description |
 | :------- | :---------- |
+| [`glossary.md`](glossary.md) | Definitions of Tapestry-specific terms (consortium training, Shared-Base Loop, Sovereign Build, etc.); links to the canonical ADR for each |
 | [`training-approaches.md`](training-approaches.md) | Centralized vs. federated vs. **consortium** training — comparison table, shared [`consortium-training-loop.svg`](../architecture/diagrams/consortium-training-loop.svg), links to ADRs |
 | [`training-pipeline-data.md`](training-pipeline-data.md) | LLM training pipeline stages, data type taxonomy, quality framework, and implications for Tapestry's consortium model |

--- a/tech-docs/reference/glossary.md
+++ b/tech-docs/reference/glossary.md
@@ -10,9 +10,11 @@ Consortium training is the paradigm; it has two phases run in order. Phase 1, th
 
 Continued pre-training (CPT) appears in both phases, distinguished by where it runs: **Contributed CPT** runs in the loop and its weights flow back to the Shared Base; **Private CPT** runs in a Sovereign Build and stays local. The Sovereign Build is broken into **Stage 0/A/B/C**, with Stage A being where CPT (Contributed or Private) lives.
 
+Two roles recur throughout: a **Member** is the participating organization (governance, sovereignty, exit rights); a **Node** is the compute environment a member operates (where data resides, where training runs, what disconnects in island mode).
+
 ## A–Z
 
-**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous nodes collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.* The umbrella over Shared-Base Loop and Sovereign Build.
+**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous members collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.* The umbrella over Shared-Base Loop and Sovereign Build.
 
 **Contributed CPT** — Continued pre-training performed *inside* the Shared-Base Loop; its post-training weights are contributed back to the Shared Base. *Contrast* Private CPT. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
@@ -20,9 +22,11 @@ Continued pre-training (CPT) appears in both phases, distinguished by where it r
 
 **Cultural Alignment** — The project's primary differentiator: producing models that reflect a member's local knowledge, values, institutions, domains, and interaction norms. Added in the Sovereign Build, not the Shared Base. *See [TAP-003](../architecture/decisions/adr-003-cultural-alignment.md).*
 
-**Member** — An organization that participates in the consortium (a national lab, sovereign AI initiative, HPC center, or research institution). A member provides the compute environment (the "node") and the sovereign data. *Working definition — the member-vs-node naming convention is under discussion; see the review thread on [PR #79](https://github.com/The-AI-Alliance/tapestry/pull/79).*
+**Member** — An organization that participates in the consortium (a national lab, sovereign AI initiative, HPC center, or research institution). Members hold governance voice, sovereignty rights, and exit rights. A member operates one or more **nodes** (the compute environments where its data resides and training runs). *Contrast* Node. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md).*
 
 **N+1** — Tapestry's model-outcome structure: one Shared Base (the shared substrate) plus N Sovereign Models (one per member). *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+
+**Node** — The compute environment a member operates: where sovereign data physically resides, where Contributed CPT and the Sovereign Build run, and what disconnects in island mode. A member may operate one or more nodes. Compound usages like *sovereign node* (a node operated by a member, with sovereignty guarantees) and *member node* (a member's node) follow from this distinction. *Contrast* Member. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) and [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
 **Private CPT** — Continued pre-training performed *inside* a Sovereign Build; stays local and is never contributed. This is how a member adds culturally-grounded knowledge that does not flow back to the consortium. *Contrast* Contributed CPT. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 

--- a/tech-docs/reference/glossary.md
+++ b/tech-docs/reference/glossary.md
@@ -2,38 +2,39 @@
 
 This glossary defines **Tapestry-specific** terms — the vocabulary that is unique to this project and not covered by general AI/ML references. For general AI vocabulary (Alignment, Fine Tuning, RAG, RLHF, Constitutional AI, etc.), see the [AI Alliance glossary](https://the-ai-alliance.github.io/glossary).
 
-Each entry below gives a one-line gloss and links to the canonical source where the term is fully defined. The ADRs are the source of truth; this glossary is a consolidated index.
+Each entry gives a one-line gloss and links to the canonical source where the term is fully defined. The ADRs are the source of truth; this glossary is a consolidated index.
 
-## Consortium training (the two-phase model)
+## How these terms fit together
 
-**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous nodes collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.*
+Consortium training is the paradigm; it has two phases run in order. Phase 1, the **Shared-Base Loop**, is the collective loop that produces the **Shared Base** (the shared substrate). Phase 2, the **Sovereign Build**, is each member's local pipeline that turns the Shared Base into that member's deployable **Sovereign Model**. The pipeline outcome is **N+1**: one Shared Base plus N Sovereign Models.
 
-Consortium training has two phases, run in order:
+Continued pre-training (CPT) appears in both phases, distinguished by where it runs: **Contributed CPT** runs in the loop and its weights flow back to the Shared Base; **Private CPT** runs in a Sovereign Build and stays local. The Sovereign Build is broken into **Stage 0/A/B/C**, with Stage A being where CPT (Contributed or Private) lives.
 
-- **Shared-Base Loop** (Phase 1) — The collective, iterative loop that produces the Shared Base. Members run Contributed CPT on local data and contribute weight vectors (never raw data, never per-step gradients) to the coordinator, which merges them into the next Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
-- **Sovereign Build** (Phase 2) — Each member's local pipeline that turns the Shared Base into its deployable Sovereign Model. Nothing here is contributed back. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+## A–Z
 
-**Shared Base** — The common base model produced by the Shared-Base Loop; the "1" in the N+1 model outcome. It carries **no cultural alignment** — alignment is added in each member's Sovereign Build. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous nodes collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.* The umbrella over Shared-Base Loop and Sovereign Build.
 
-**Sovereign Model** — A member's deployable, culturally-aligned model (one of the "N" in N+1), produced by post-training the Shared Base through the Sovereign Build. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
-
-**Contributed CPT** — Continued pre-training performed *inside* the Shared-Base Loop; its post-training weights are contributed back to the Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
-
-**Private CPT** — Continued pre-training performed *inside* a Sovereign Build; stays local and is never contributed. This is how a member adds culturally-grounded knowledge that does not flow back to the consortium. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
-
-**Stage 0/A/B/C** — The fine-grained breakdown of work *inside* the Sovereign Build: Stage 0 (data preparation), Stage A (CPT — which maps to Contributed CPT in the loop or Private CPT in the build), Stage B (instruction tuning / SFT), Stage C (alignment — RLHF/DPO/Constitutional AI), with Evaluation as a cross-cutting concern. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md) for the stage-by-stage mapping to standard industry terminology.*
-
-## Roles & structure
-
-**Member** — An organization that participates in the consortium (a national lab, sovereign AI initiative, HPC center, or research institution). A member provides the compute environment (the "node") and the sovereign data. *Working definition — the member-vs-node naming convention is under discussion; see the review thread on [PR #79](https://github.com/The-AI-Alliance/tapestry/pull/79).*
+**Contributed CPT** — Continued pre-training performed *inside* the Shared-Base Loop; its post-training weights are contributed back to the Shared Base. *Contrast* Private CPT. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
 **Coordinator** — The role in the Shared-Base Loop that receives contributed weight vectors from members and merges them (FedAvg-class averaging by default; outer optimizer swappable) into the next Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
+**Cultural Alignment** — The project's primary differentiator: producing models that reflect a member's local knowledge, values, institutions, domains, and interaction norms. Added in the Sovereign Build, not the Shared Base. *See [TAP-003](../architecture/decisions/adr-003-cultural-alignment.md).*
+
+**Member** — An organization that participates in the consortium (a national lab, sovereign AI initiative, HPC center, or research institution). A member provides the compute environment (the "node") and the sovereign data. *Working definition — the member-vs-node naming convention is under discussion; see the review thread on [PR #79](https://github.com/The-AI-Alliance/tapestry/pull/79).*
+
 **N+1** — Tapestry's model-outcome structure: one Shared Base (the shared substrate) plus N Sovereign Models (one per member). *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
 
-## Cross-cutting
+**Private CPT** — Continued pre-training performed *inside* a Sovereign Build; stays local and is never contributed. This is how a member adds culturally-grounded knowledge that does not flow back to the consortium. *Contrast* Contributed CPT. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
-**Cultural Alignment** — The project's primary differentiator: producing models that reflect a member's local knowledge, values, institutions, domains, and interaction norms. Added in the Sovereign Build, not the Shared Base. *See [TAP-003](../architecture/decisions/adr-003-cultural-alignment.md).*
+**Shared Base** — The common base model produced by the Shared-Base Loop; the "1" in the N+1 model outcome. It carries **no cultural alignment** — alignment is added in each member's Sovereign Build. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+
+**Shared-Base Loop** — Phase 1 of consortium training: the collective, iterative loop that produces the Shared Base. Members run Contributed CPT on local data and contribute weight vectors (never raw data, never per-step gradients) to the coordinator, which merges them into the next Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).* Output: the Shared Base.
+
+**Sovereign Build** — Phase 2 of consortium training: each member's local pipeline that turns the Shared Base into its deployable Sovereign Model. Nothing here is contributed back. Broken into Stage 0/A/B/C. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+
+**Sovereign Model** — A member's deployable, culturally-aligned model (one of the "N" in N+1), produced by post-training the Shared Base through the Sovereign Build. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+
+**Stage 0/A/B/C** — The fine-grained breakdown of work *inside* the Sovereign Build: Stage 0 (data preparation), Stage A (CPT — which maps to Contributed CPT in the loop or Private CPT in the build), Stage B (instruction tuning / SFT), Stage C (alignment — RLHF/DPO/Constitutional AI), with Evaluation as a cross-cutting concern. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md) for the stage-by-stage mapping to standard industry terminology.*
 
 ## See also
 

--- a/tech-docs/reference/glossary.md
+++ b/tech-docs/reference/glossary.md
@@ -1,0 +1,46 @@
+# Glossary
+
+This glossary defines **Tapestry-specific** terms — the vocabulary that is unique to this project and not covered by general AI/ML references. For general AI vocabulary (Alignment, Fine Tuning, RAG, RLHF, Constitutional AI, etc.), see the [AI Alliance glossary](https://the-ai-alliance.github.io/glossary).
+
+Each entry below gives a one-line gloss and links to the canonical source where the term is fully defined. The ADRs are the source of truth; this glossary is a consolidated index.
+
+## Consortium training (the two-phase model)
+
+**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous nodes collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.*
+
+Consortium training has two phases, run in order:
+
+- **Shared-Base Loop** (Phase 1) — The collective, iterative loop that produces the Shared Base. Members run Contributed CPT on local data and contribute weight vectors (never raw data, never per-step gradients) to the coordinator, which merges them into the next Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+- **Sovereign Build** (Phase 2) — Each member's local pipeline that turns the Shared Base into its deployable Sovereign Model. Nothing here is contributed back. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+
+**Shared Base** — The common base model produced by the Shared-Base Loop; the "1" in the N+1 model outcome. It carries **no cultural alignment** — alignment is added in each member's Sovereign Build. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+
+**Sovereign Model** — A member's deployable, culturally-aligned model (one of the "N" in N+1), produced by post-training the Shared Base through the Sovereign Build. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+
+**Contributed CPT** — Continued pre-training performed *inside* the Shared-Base Loop; its post-training weights are contributed back to the Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+
+**Private CPT** — Continued pre-training performed *inside* a Sovereign Build; stays local and is never contributed. This is how a member adds culturally-grounded knowledge that does not flow back to the consortium. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+
+**Stage 0/A/B/C** — The fine-grained breakdown of work *inside* the Sovereign Build: Stage 0 (data preparation), Stage A (CPT — which maps to Contributed CPT in the loop or Private CPT in the build), Stage B (instruction tuning / SFT), Stage C (alignment — RLHF/DPO/Constitutional AI), with Evaluation as a cross-cutting concern. *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md) for the stage-by-stage mapping to standard industry terminology.*
+
+## Roles & structure
+
+**Member** — An organization that participates in the consortium (a national lab, sovereign AI initiative, HPC center, or research institution). A member provides the compute environment (the "node") and the sovereign data. *Working definition — the member-vs-node naming convention is under discussion; see the review thread on [PR #79](https://github.com/The-AI-Alliance/tapestry/pull/79).*
+
+**Coordinator** — The role in the Shared-Base Loop that receives contributed weight vectors from members and merges them (FedAvg-class averaging by default; outer optimizer swappable) into the next Shared Base. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+
+**N+1** — Tapestry's model-outcome structure: one Shared Base (the shared substrate) plus N Sovereign Models (one per member). *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
+
+## Cross-cutting
+
+**Cultural Alignment** — The project's primary differentiator: producing models that reflect a member's local knowledge, values, institutions, domains, and interaction norms. Added in the Sovereign Build, not the Shared Base. *See [TAP-003](../architecture/decisions/adr-003-cultural-alignment.md).*
+
+## See also
+
+Terms with established canonical homes elsewhere in `tech-docs/` (not duplicated here):
+
+- **DG1–DG9** — the nine design goals. See [`4-design-goals.md`](../architecture/4-design-goals.md).
+- **TAP-001 … TAP-008** — the architecture decision records. See the [ADR index](../architecture/decisions/README.md).
+- **TVA** — the Tapestry Value Architecture methodology. See [`0-tva-methodology.md`](../architecture/0-tva-methodology.md).
+- **TAPESTRY-GLOBAL** and regional/national/entity model variants — see [`VISION.md`](../strategic-plan/VISION.md).
+- **70/30 architecture principle** — see [`VISION.md`](../strategic-plan/VISION.md).

--- a/tech-docs/reference/training-approaches.md
+++ b/tech-docs/reference/training-approaches.md
@@ -75,7 +75,7 @@ FedAvg is *not* the same as per-step gradient sharing. Each client trains locall
 
 > A consolidated glossary of these and other Tapestry terms lives in [`glossary.md`](glossary.md).
 
-**What it is:** A small number of large, trusted, heterogeneous nodes — national labs, sovereign AI initiatives, HPC centers, research institutions — collaboratively train a shared model (as defined in [TAP-002](../architecture/decisions/adr-002-consortium-training.md)). This happens in two phases ([TAP-004](../architecture/decisions/adr-004-training-loop.md)).
+**What it is:** A small number of large, trusted, heterogeneous members — national labs, sovereign AI initiatives, HPC centers, research institutions — collaboratively train a shared model (as defined in [TAP-002](../architecture/decisions/adr-002-consortium-training.md)). This happens in two phases ([TAP-004](../architecture/decisions/adr-004-training-loop.md)).
 
 In the **Shared-Base Loop** (Phase 1), each node performs **Contributed CPT** — full-model continued pre-training on its member data (not adapters-only) — then uploads its **locally trained model weight vector** to a central coordinator. The coordinator performs **quality-weighted model averaging** (FedAvg-class aggregation by default) and redistributes the updated **Shared Base**. The cycle repeats.
 

--- a/tech-docs/reference/training-approaches.md
+++ b/tech-docs/reference/training-approaches.md
@@ -73,6 +73,8 @@ FedAvg is *not* the same as per-step gradient sharing. Each client trains locall
 
 ## Consortium Training
 
+> A consolidated glossary of these and other Tapestry terms lives in [`glossary.md`](glossary.md).
+
 **What it is:** A small number of large, trusted, heterogeneous nodes — national labs, sovereign AI initiatives, HPC centers, research institutions — collaboratively train a shared model (as defined in [TAP-002](../architecture/decisions/adr-002-consortium-training.md)). This happens in two phases ([TAP-004](../architecture/decisions/adr-004-training-loop.md)).
 
 In the **Shared-Base Loop** (Phase 1), each node performs **Contributed CPT** — full-model continued pre-training on its member data (not adapters-only) — then uploads its **locally trained model weight vector** to a central coordinator. The coordinator performs **quality-weighted model averaging** (FedAvg-class aggregation by default) and redistributes the updated **Shared Base**. The cycle repeats.

--- a/tech-docs/strategic-plan/PRD.md
+++ b/tech-docs/strategic-plan/PRD.md
@@ -5,7 +5,7 @@
 **Authority:** OPAN Leadership — LeCun (Chief Scientist), Nguyen (Chief Architect), Annunziata (AI Alliance Chair, Program & Policy)  
 **Status:** Draft for leadership review  
 
-> **v1.1 — Reconciled to the ratified architecture.** Training-mechanism requirements (formerly described as "federated gradient sharing" at "1,000-node" edge scale) are updated to match the two-phase consortium-training model defined in [TAP-002](../architecture/decisions/adr-002-consortium-training.md) and [TAP-004](../architecture/decisions/adr-004-training-loop.md): a collaborative Shared-Base Loop (weight-vector contribution after Contributed CPT) plus per-member Sovereign Builds. Where this PRD and an ADR disagree, the ADR wins.
+> **v1.1 — Reconciled to the ratified architecture.** Training-mechanism requirements (formerly described as "federated gradient sharing" at "1,000-node" edge scale) are updated to match the two-phase consortium-training model defined in [TAP-002](../architecture/decisions/adr-002-consortium-training.md) and [TAP-004](../architecture/decisions/adr-004-training-loop.md): a collaborative Shared-Base Loop (weight-vector contribution after Contributed CPT) plus per-member Sovereign Builds. Where this PRD and an ADR disagree, the ADR wins. *Tapestry-specific term definitions are consolidated in [`glossary.md`](../reference/glossary.md).*
 
 ---
 

--- a/tech-docs/tapestry-reference/ARCHITECTURE.md
+++ b/tech-docs/tapestry-reference/ARCHITECTURE.md
@@ -22,7 +22,7 @@ The ratio starts at roughly **80/20** centralized-to-sovereign and shifts toward
 
 ## Consortium Training — Not Federated Learning
 
-Tapestry uses **consortium training** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) — the paradigm defined there and contrasted in full with centralized and federated training in [`training-approaches.md`](../reference/training-approaches.md). In brief: a small number of large, trusted, heterogeneous institutional nodes collaboratively train a shared model, where data sovereignty is a first-order constraint and cultural alignment is the goal. It is deliberately distinguished from federated learning.
+Tapestry uses **consortium training** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) — the paradigm defined there and contrasted in full with centralized and federated training in [`training-approaches.md`](../reference/training-approaches.md). In brief: a small number of large, trusted, heterogeneous institutional nodes collaboratively train a shared model, where data sovereignty is a first-order constraint and cultural alignment is the goal. It is deliberately distinguished from federated learning. *Tapestry-specific term definitions are consolidated in [`glossary.md`](../reference/glossary.md).*
 
 Consortium training has two phases, run in order:
 

--- a/tech-docs/tapestry-reference/ARCHITECTURE.md
+++ b/tech-docs/tapestry-reference/ARCHITECTURE.md
@@ -8,13 +8,13 @@ A single-page synthesis of Tapestry's architecture — the structural decisions 
 
 ## Core-Plus-Sovereign Architecture
 
-Tapestry's foundational decision ([TAP-001](../architecture/decisions/adr-001-core-plus-sovereign.md)) is a **core-plus-sovereign** architecture: a frontier-competitive **shared base model** enriched by **sovereign layers** (continued pre-training, post-training alignment, domain adapters) produced by each participating node. Data and values stay local; frontier capability is shared.
+Tapestry's foundational decision ([TAP-001](../architecture/decisions/adr-001-core-plus-sovereign.md)) is a **core-plus-sovereign** architecture: a frontier-competitive **shared base model** enriched by **sovereign layers** (continued pre-training, post-training alignment, domain adapters) produced by each participating member. Data and values stay local; frontier capability is shared.
 
 | Layer | Who owns it | What it provides |
 | :---- | :---------- | :--------------- |
 | **Shared base** | Consortium — adopted, then consortium-evolved ([TAP-006](../architecture/decisions/adr-006-phased-base-model.md)) | Frontier-class starting capability; improved via the Shared-Base Loop |
 | **Safety alignment** | Consortium (shared) | Baseline safety properties (preservation through CPT is open question DG6) |
-| **Sovereign layers** | Each participating node / community | Cultural alignment, domain fit, instruction norms — data stays local |
+| **Sovereign layers** | Each participating member | Cultural alignment, domain fit, instruction norms — data stays local |
 
 The ratio starts at roughly **80/20** centralized-to-sovereign and shifts toward sovereign over time as the consortium matures. (This is develop's current framing — not a fixed "70/30" split.)
 
@@ -22,7 +22,7 @@ The ratio starts at roughly **80/20** centralized-to-sovereign and shifts toward
 
 ## Consortium Training — Not Federated Learning
 
-Tapestry uses **consortium training** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) — the paradigm defined there and contrasted in full with centralized and federated training in [`training-approaches.md`](../reference/training-approaches.md). In brief: a small number of large, trusted, heterogeneous institutional nodes collaboratively train a shared model, where data sovereignty is a first-order constraint and cultural alignment is the goal. It is deliberately distinguished from federated learning. *Tapestry-specific term definitions are consolidated in [`glossary.md`](../reference/glossary.md).*
+Tapestry uses **consortium training** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) — the paradigm defined there and contrasted in full with centralized and federated training in [`training-approaches.md`](../reference/training-approaches.md). In brief: a small number of large, trusted, heterogeneous members collaboratively train a shared model, where data sovereignty is a first-order constraint and cultural alignment is the goal. It is deliberately distinguished from federated learning. *Tapestry-specific term definitions are consolidated in [`glossary.md`](../reference/glossary.md).*
 
 Consortium training has two phases, run in order:
 


### PR DESCRIPTION
## Summary

Follow-up to #79 per @deanwampler's review: *"add a glossary in `tech-docs` that defines the terms in one place."*

There was no in-repo glossary — only an external general-AI glossary (https://the-ai-alliance.github.io/glossary) that defines none of the Tapestry consortium-training terms. This PR adds a Tapestry-specific glossary as a consolidated index, with each entry linking to its canonical ADR source.

## New terminology covered

| Term | Canonical source |
| :--- | :--- |
| **Consortium training** | TAP-002 |
| **Shared-Base Loop** (Phase 1) | TAP-004 |
| **Sovereign Build** (Phase 2) | TAP-005 |
| **Shared Base** | TAP-004 |
| **Sovereign Model** | TAP-005 |
| **Contributed CPT** | TAP-004 |
| **Private CPT** | TAP-004 |
| **Stage 0/A/B/C** | TAP-005 |
| **Member** | (working definition; member-vs-node convention under discussion) |
| **Coordinator** | TAP-004 |
| **N+1** | TAP-005 |
| **Cultural Alignment** | TAP-003 |

**Out of scope** (see-also line only, have canonical homes elsewhere): DG1–DG9, TAP-001..008, TVA, TAPESTRY-GLOBAL/regional variants, 70/30 principle.

## Changes

- **New:** `tech-docs/reference/glossary.md` — 12 entries, each a one-line gloss + link to the defining ADR. Intro distinguishes Tapestry-specific terms (this glossary) from general AI vocabulary (the external AI Alliance glossary).
- **Cross-links** (one-line pointer; existing ADR terminology sections retained, not gutted): adr-002, adr-004, adr-005, `ARCHITECTURE.md`, `training-approaches.md`, `PRD.md`.
- **Index wiring:** `tech-docs/reference/README.md` + `tech-docs/README.md` reference-documents tables.
- **Docs-site home:** `docs/index.markdown` "Capitalized Terms" note now distinguishes general AI terms (external) from Tapestry-specific terms (in-repo).

## Test plan

- [x] All glossary outbound links resolve (8 ADR/doc targets).
- [x] All 6 cross-link paths resolve both directions (source → glossary, correct relative paths per source dir).
- [x] Canonical `rg` terminology verification command unchanged from #79's post-merge baseline (no new residuals).
- [ ] Mermaid/Markdown renders correctly on GitHub.

## Notes

- Member-vs-node convention is **not** resolved here — the glossary's Member entry states the working definition and notes the distinction is under discussion (per the open thread with @deanwampler on #79).
- The external `the-ai-alliance/glossary` repo is untouched.

Made with [Cursor](https://cursor.com)