### PR TITLE
Compare contribution weighting policies

### DIFF
--- a/examples/consortium_training_demo.py
+++ b/examples/consortium_training_demo.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import argparse
 import random
 import sys
 from pathlib import Path
@@ -16,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from tapestry.training.consortium import (
     ConsortiumCoordinator,
     ContributionPolicy,
+    ContributionWeighting,
     SovereignTrainingNode,
     TinyCausalModel,
 )
@@ -51,7 +53,7 @@ def _encode(texts: list[str]) -> list[list[int]]:
     return [[token % 128 for token in text.encode("utf-8")] for text in texts]
 
 
-def run_demo(rounds: int = 3, seed: int = 7) -> None:
+def run_demo(rounds: int = 3, seed: int = 7, weighting: ContributionWeighting = "quality") -> None:
     """Run a small N+1 consortium-training loop."""
     random.seed(seed)
     torch.manual_seed(seed)
@@ -59,6 +61,7 @@ def run_demo(rounds: int = 3, seed: int = 7) -> None:
     print("=" * 72)
     print("  TAPESTRY -- Consortium Training Proof of Concept")
     print("  One governed shared base + N sovereign participant models")
+    print(f"  Contribution weighting: {weighting}")
     print("=" * 72)
 
     base_model = TinyCausalModel(vocab_size=128, hidden_size=32)
@@ -67,6 +70,7 @@ def run_demo(rounds: int = 3, seed: int = 7) -> None:
         contribution_policy=ContributionPolicy(
             quality_floor=0.75,
             max_node_weight=0.5,
+            weighting=weighting,
         ),
     )
     nodes = [
@@ -103,5 +107,29 @@ def run_demo(rounds: int = 3, seed: int = 7) -> None:
     print("=" * 72)
 
 
+def run_comparison(rounds: int = 3, seed: int = 7) -> None:
+    """Run the same scenario with quality-weighted and equal influence policies."""
+    for weighting in ("quality", "equal"):
+        run_demo(rounds=rounds, seed=seed, weighting=weighting)
+        print()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Tapestry consortium-training proof of concept.")
+    parser.add_argument("--rounds", type=int, default=3, help="Number of consortium-training rounds to run.")
+    parser.add_argument("--seed", type=int, default=7, help="Random seed used for deterministic demo setup.")
+    parser.add_argument(
+        "--weighting",
+        choices=("quality", "equal", "compare"),
+        default="quality",
+        help="Contribution weighting policy to run. Use 'compare' to run quality and equal policies back to back.",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    run_demo()
+    args = _parse_args()
+    if args.weighting == "compare":
+        run_comparison(rounds=args.rounds, seed=args.seed)
+    else:
+        run_demo(rounds=args.rounds, seed=args.seed, weighting=args.weighting)

--- a/examples/consortium_training_demo.py
+++ b/examples/consortium_training_demo.py
@@ -53,15 +53,20 @@ def _encode(texts: list[str]) -> list[list[int]]:
     return [[token % 128 for token in text.encode("utf-8")] for text in texts]
 
 
-def run_demo(rounds: int = 3, seed: int = 7, weighting: ContributionWeighting = "quality") -> None:
+def run_demo(
+    rounds: int = 3,
+    seed: int = 7,
+    weighting: ContributionWeighting | str = ContributionWeighting.QUALITY,
+) -> None:
     """Run a small N+1 consortium-training loop."""
+    weighting = ContributionWeighting(weighting)
     random.seed(seed)
     torch.manual_seed(seed)
 
     print("=" * 72)
     print("  TAPESTRY -- Consortium Training Proof of Concept")
     print("  One governed shared base + N sovereign participant models")
-    print(f"  Contribution weighting: {weighting}")
+    print(f"  Contribution weighting: {weighting.value}")
     print("=" * 72)
 
     base_model = TinyCausalModel(vocab_size=128, hidden_size=32)
@@ -109,7 +114,7 @@ def run_demo(rounds: int = 3, seed: int = 7, weighting: ContributionWeighting = 
 
 def run_comparison(rounds: int = 3, seed: int = 7) -> None:
     """Run the same scenario with quality-weighted and equal influence policies."""
-    for weighting in ("quality", "equal"):
+    for weighting in (ContributionWeighting.QUALITY, ContributionWeighting.EQUAL):
         run_demo(rounds=rounds, seed=seed, weighting=weighting)
         print()
 
@@ -120,7 +125,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=7, help="Random seed used for deterministic demo setup.")
     parser.add_argument(
         "--weighting",
-        choices=("quality", "equal", "compare"),
+        choices=(ContributionWeighting.QUALITY.value, ContributionWeighting.EQUAL.value, "compare"),
         default="quality",
         help="Contribution weighting policy to run. Use 'compare' to run quality and equal policies back to back.",
     )

--- a/src/tapestry/training/consortium/README.md
+++ b/src/tapestry/training/consortium/README.md
@@ -8,9 +8,10 @@ front and center.
 - **N sovereign model artifacts** are produced and owned by participant nodes.
 - Nodes train locally on sovereign corpora (Contributed CPT) and share **local model
   weight vectors** with the coordinator.
-- A governed contribution policy applies a quality floor and anti-capture cap
-  before integrating accepted weights into the shared base (FedAvg-class averaging
-  by default).
+- A governed contribution policy applies a quality floor before integrating
+  accepted weights into the shared base (FedAvg-class averaging by default).
+  The PoC can compare quality-weighted influence with an equal-influence MVP
+  policy where every accepted node receives the same weight.
 
 ## Modules
 
@@ -19,7 +20,7 @@ front and center.
 | `model.py` | `TinyCausalModel`, a small next-token model for fast tests and demos. |
 | `node.py` | `SovereignTrainingNode`, which runs local Contributed CPT and keeps a sovereign model artifact. |
 | `coordinator.py` | `ConsortiumCoordinator`, which evolves the shared base from governed contributions. |
-| `policy.py` | `ContributionPolicy`, a minimal quality-floor and anti-capture weighting policy. |
+| `policy.py` | `ContributionPolicy`, a minimal quality-floor policy with quality-weighted and equal-influence modes. |
 | `messages.py` | Data classes for sovereign artifacts, contributions, and round results. |
 | `../../../../contrib/jneums-consortium-experiment/` | Contrib experiment runner and metrics helpers that record round metrics and summaries without changing core training logic. |
 
@@ -50,6 +51,30 @@ This runner is **not** a replacement for established FL or LLM evaluation toolin
 Larger experiments should align with existing systems such as Flower/NIID-Bench for
 non-IID FL baselines, OpenDiLoCo for low-communication distributed LLM training, and
 lm-evaluation-harness or Unitxt for downstream model evaluation.
+
+## Comparing Contribution Weighting Options
+
+Issue #68 asks whether the PoC should compare the current quality-weighted
+integration with an MVP policy where everyone above the quality bar has equal
+influence. The coordinator now supports both policies through
+`ContributionPolicy(weighting=...)`:
+
+- `weighting="quality"` keeps the existing behavior: accepted nodes are weighted
+  by their quality scores, with `max_node_weight` limiting single-node dominance.
+- `weighting="equal"` accepts nodes through the same quality floor, then assigns
+  each accepted node the same integration weight.
+
+Run the demo with one policy:
+
+```shell
+PYTHONPATH="$PWD/src" uv run python examples/consortium_training_demo.py --weighting equal
+```
+
+Run both policies back to back with the same seed and round count:
+
+```shell
+PYTHONPATH="$PWD/src" uv run python examples/consortium_training_demo.py --weighting compare
+```
 
 ## What This Demonstrates
 

--- a/src/tapestry/training/consortium/README.md
+++ b/src/tapestry/training/consortium/README.md
@@ -8,10 +8,11 @@ front and center.
 - **N sovereign model artifacts** are produced and owned by participant nodes.
 - Nodes train locally on sovereign corpora (Contributed CPT) and share **local model
   weight vectors** with the coordinator.
-- A governed contribution policy applies a quality floor before integrating
-  accepted weights into the shared base (FedAvg-class averaging by default).
-  The PoC can compare quality-weighted influence with an equal-influence MVP
-  policy where every accepted node receives the same weight.
+- A governed contribution policy applies a quality floor and anti-capture
+  controls before integrating accepted weights into the shared base
+  (FedAvg-class averaging by default). The PoC can compare quality-weighted
+  influence with an equal-influence MVP policy where every accepted node receives
+  the same weight.
 
 ## Modules
 
@@ -20,7 +21,7 @@ front and center.
 | `model.py` | `TinyCausalModel`, a small next-token model for fast tests and demos. |
 | `node.py` | `SovereignTrainingNode`, which runs local Contributed CPT and keeps a sovereign model artifact. |
 | `coordinator.py` | `ConsortiumCoordinator`, which evolves the shared base from governed contributions. |
-| `policy.py` | `ContributionPolicy`, a minimal quality-floor policy with quality-weighted and equal-influence modes. |
+| `policy.py` | `ContributionPolicy`, a minimal quality-floor and anti-capture policy with quality-weighted and equal-influence modes. |
 | `messages.py` | Data classes for sovereign artifacts, contributions, and round results. |
 | `../../../../contrib/jneums-consortium-experiment/` | Contrib experiment runner and metrics helpers that record round metrics and summaries without changing core training logic. |
 
@@ -54,15 +55,15 @@ lm-evaluation-harness or Unitxt for downstream model evaluation.
 
 ## Comparing Contribution Weighting Options
 
-Issue #68 asks whether the PoC should compare the current quality-weighted
-integration with an MVP policy where everyone above the quality bar has equal
-influence. The coordinator now supports both policies through
-`ContributionPolicy(weighting=...)`:
+The coordinator supports multiple governed weighting choices through
+`ContributionPolicy(weighting=...)`, making it possible to compare policy
+outcomes without changing the training loop:
 
 - `weighting="quality"` keeps the existing behavior: accepted nodes are weighted
   by their quality scores, with `max_node_weight` limiting single-node dominance.
 - `weighting="equal"` accepts nodes through the same quality floor, then assigns
-  each accepted node the same integration weight.
+  each accepted node the same integration weight so influence is distributed
+  uniformly across the accepted set.
 
 Run the demo with one policy:
 

--- a/src/tapestry/training/consortium/__init__.py
+++ b/src/tapestry/training/consortium/__init__.py
@@ -9,7 +9,7 @@ weight vectors for FedAvg-class integration back into the shared base.
 from .coordinator import ConsortiumCoordinator
 from .model import TinyCausalModel
 from .node import SovereignTrainingNode
-from .policy import ContributionPolicy
+from .policy import ContributionPolicy, ContributionWeighting
 from .messages import (
     ConsortiumRoundResult,
     SovereignContribution,
@@ -21,6 +21,7 @@ __all__ = [
     "ConsortiumCoordinator",
     "ConsortiumRoundResult",
     "ContributionPolicy",
+    "ContributionWeighting",
     "SovereignContribution",
     "SovereignCycleResult",
     "SovereignModelArtifact",

--- a/src/tapestry/training/consortium/policy.py
+++ b/src/tapestry/training/consortium/policy.py
@@ -2,22 +2,38 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
+ContributionWeighting = Literal["quality", "equal"]
+
 
 class ContributionPolicy:  # pylint: disable=too-few-public-methods
     """Compute governed integration weights from contribution quality scores.
 
-    The default policy is intentionally simple: reject contributions below a
-    quality floor, then normalize quality scores while capping any one node's
-    influence. The cap is an anti-capture control, not an optimizer trick.
+    The default ``quality`` policy is intentionally simple: reject contributions
+    below a quality floor, then normalize quality scores while capping any one
+    node's influence. The cap is an anti-capture control, not an optimizer trick.
+
+    The ``equal`` policy supports the early-MVP comparison from issue #68:
+    everyone who passes the quality floor receives equal influence, independent
+    of quality score magnitude.
     """
 
-    def __init__(self, quality_floor: float = 0.0, max_node_weight: float = 1.0) -> None:
+    def __init__(
+        self,
+        quality_floor: float = 0.0,
+        max_node_weight: float = 1.0,
+        weighting: ContributionWeighting = "quality",
+    ) -> None:
         if quality_floor < 0.0:
             raise ValueError("quality_floor must be non-negative")
         if not 0.0 < max_node_weight <= 1.0:
             raise ValueError("max_node_weight must be in (0, 1]")
+        if weighting not in ("quality", "equal"):
+            raise ValueError("weighting must be 'quality' or 'equal'")
         self.quality_floor = quality_floor
         self.max_node_weight = max_node_weight
+        self.weighting = weighting
 
     def weights(self, quality_scores: dict[str, float]) -> dict[str, float]:
         """Return normalized contribution weights for accepted nodes."""
@@ -26,6 +42,10 @@ class ContributionPolicy:  # pylint: disable=too-few-public-methods
         }
         if not accepted:
             return {}
+
+        if self.weighting == "equal":
+            equal_weight = 1.0 / len(accepted)
+            return {node_id: equal_weight for node_id in accepted}
 
         weights = self._normalize(accepted)
         capped: dict[str, float] = {}

--- a/src/tapestry/training/consortium/policy.py
+++ b/src/tapestry/training/consortium/policy.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from enum import Enum
 
-ContributionWeighting = Literal["quality", "equal"]
+
+class ContributionWeighting(str, Enum):
+    """Supported contribution weighting policies."""
+
+    QUALITY = "quality"
+    EQUAL = "equal"
 
 
 class ContributionPolicy:  # pylint: disable=too-few-public-methods
@@ -14,26 +19,24 @@ class ContributionPolicy:  # pylint: disable=too-few-public-methods
     below a quality floor, then normalize quality scores while capping any one
     node's influence. The cap is an anti-capture control, not an optimizer trick.
 
-    The ``equal`` policy supports the early-MVP comparison from issue #68:
-    everyone who passes the quality floor receives equal influence, independent
-    of quality score magnitude.
+    The ``equal`` policy supports comparisons where everyone who passes the
+    quality floor receives equal influence, independent of quality score
+    magnitude.
     """
 
     def __init__(
         self,
         quality_floor: float = 0.0,
         max_node_weight: float = 1.0,
-        weighting: ContributionWeighting = "quality",
+        weighting: ContributionWeighting | str = ContributionWeighting.QUALITY,
     ) -> None:
         if quality_floor < 0.0:
             raise ValueError("quality_floor must be non-negative")
         if not 0.0 < max_node_weight <= 1.0:
             raise ValueError("max_node_weight must be in (0, 1]")
-        if weighting not in ("quality", "equal"):
-            raise ValueError("weighting must be 'quality' or 'equal'")
         self.quality_floor = quality_floor
         self.max_node_weight = max_node_weight
-        self.weighting = weighting
+        self.weighting = ContributionWeighting(weighting)
 
     def weights(self, quality_scores: dict[str, float]) -> dict[str, float]:
         """Return normalized contribution weights for accepted nodes."""
@@ -43,7 +46,7 @@ class ContributionPolicy:  # pylint: disable=too-few-public-methods
         if not accepted:
             return {}
 
-        if self.weighting == "equal":
+        if self.weighting is ContributionWeighting.EQUAL:
             equal_weight = 1.0 / len(accepted)
             return {node_id: equal_weight for node_id in accepted}
 

--- a/src/tests/tapestry/training/consortium/test_consortium_training.py
+++ b/src/tests/tapestry/training/consortium/test_consortium_training.py
@@ -79,6 +79,25 @@ def test_contribution_policy_applies_quality_floor_and_capture_cap() -> None:
     assert sum(weights.values()) == pytest.approx(1.0)
 
 
+def test_equal_contribution_policy_ignores_quality_magnitude_after_floor() -> None:
+    """The equal MVP option gives every accepted participant the same influence."""
+    policy = ContributionPolicy(quality_floor=0.7, weighting="equal")
+
+    weights = policy.weights(
+        {
+            "strong": 0.95,
+            "dominant": 5.0,
+            "weak": 0.4,
+        }
+    )
+
+    assert "weak" not in weights
+    assert weights == {
+        "strong": pytest.approx(0.5),
+        "dominant": pytest.approx(0.5),
+    }
+
+
 def test_coordinator_maintains_n_plus_one_model_outcome() -> None:
     """One evolved base plus one sovereign artifact per node are retained."""
     torch.manual_seed(1)
@@ -121,6 +140,33 @@ def test_coordinator_maintains_n_plus_one_model_outcome() -> None:
         )
         for name in result.shared_base_state
     )
+
+
+def test_weighting_modes_produce_different_integration_results() -> None:
+    """The current experiment setup can compare quality-weighted and equal influence policies."""
+    local_states = {
+        "strong": {"weight": torch.tensor([2.0])},
+        "dominant": {"weight": torch.tensor([10.0])},
+    }
+    quality_weights = ContributionPolicy(weighting="quality").weights(
+        {
+            "strong": 1.0,
+            "dominant": 3.0,
+        }
+    )
+    equal_weights = ContributionPolicy(weighting="equal").weights(
+        {
+            "strong": 1.0,
+            "dominant": 3.0,
+        }
+    )
+
+    quality_state = ConsortiumCoordinator._apply_weighted_average(local_states, quality_weights)
+    equal_state = ConsortiumCoordinator._apply_weighted_average(local_states, equal_weights)
+
+    assert quality_weights["dominant"] > equal_weights["dominant"]
+    assert quality_state["weight"].item() == pytest.approx(8.0)
+    assert equal_state["weight"].item() == pytest.approx(6.0)
 
 
 def test_low_quality_contribution_does_not_update_shared_base() -> None:

--- a/src/tests/tapestry/training/consortium/test_consortium_training.py
+++ b/src/tests/tapestry/training/consortium/test_consortium_training.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 from tapestry.training.consortium import (
     ConsortiumCoordinator,
     ContributionPolicy,
+    ContributionWeighting,
     SovereignTrainingNode,
     TinyCausalModel,
 )
@@ -81,7 +82,7 @@ def test_contribution_policy_applies_quality_floor_and_capture_cap() -> None:
 
 def test_equal_contribution_policy_ignores_quality_magnitude_after_floor() -> None:
     """The equal MVP option gives every accepted participant the same influence."""
-    policy = ContributionPolicy(quality_floor=0.7, weighting="equal")
+    policy = ContributionPolicy(quality_floor=0.7, weighting=ContributionWeighting.EQUAL)
 
     weights = policy.weights(
         {
@@ -154,7 +155,7 @@ def test_weighting_modes_produce_different_integration_results() -> None:
             "dominant": 3.0,
         }
     )
-    equal_weights = ContributionPolicy(weighting="equal").weights(
+    equal_weights = ContributionPolicy(weighting=ContributionWeighting.EQUAL).weights(
         {
             "strong": 1.0,
             "dominant": 3.0,


### PR DESCRIPTION
## Description of the PR

Addresses #68 by making contribution weighting an explicit, comparable policy in the consortium-training PoC.

This PR:

- Keeps the existing quality-weighted behavior as the default: `ContributionPolicy(weighting="quality")`.
- Adds `ContributionPolicy(weighting="equal")`, where every node that passes the quality floor receives equal integration influence.
- Adds `--weighting quality|equal|compare` to `examples/consortium_training_demo.py`.
- Documents how to run the comparison in `src/tapestry/training/consortium/README.md`.
- Adds regression tests for the equal policy and for quality vs. equal integration producing different shared-base outcomes.

This directly supports the comparison requested in #68:

- quality-weighted: accepted nodes are weighted by quality score, with `max_node_weight` limiting single-node dominance.
- equal MVP: accepted nodes pass the same quality floor, then receive equal influence independent of score magnitude.

## Related Issues

Related issues or PRs (#number, ...): #68

## Testing

- `python3 -m py_compile src/tapestry/training/consortium/policy.py src/tapestry/training/consortium/__init__.py examples/consortium_training_demo.py src/tests/tapestry/training/consortium/test_consortium_training.py`
- Direct policy validation:

```text
quality {'dominant': 0.6, 'strong': 0.4}
equal {'strong': 0.5, 'dominant': 0.5}
invalid weighting must be 'quality' or 'equal'
```

- `git diff --check`

I also attempted the targeted pytest command:

```shell
PYTHONPATH=src python3 -m pytest src/tests/tapestry/training/consortium/test_consortium_training.py -q
```

That could not run in my local environment because `pytest` and `torch` are not installed. Earlier `make tests` also could not run because `uv` is unavailable locally. The new tests are included, but CI or a local environment with the project dependencies will need to execute them.

## Checklist

Confirm that the following have been completed.

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For code changes:

- [x] I have added or updated relevant tests, where applicable.
- [x] I have updated any related documentation.

For documentation changes, including `tech-docs`:

- [x] I have followed the existing documentation styles and conventions.
- [ ] I have included helpful diagrams, screenshots, tables, etc.
