### PR TITLE
chore: align pyproject.toml with the project's actual stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tapestry"
 version = "0.1.0"
-description = "A Python project managed with uv"
+description = "A Python implementation of Project Tapestry's consortium training prototype"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -34,20 +34,14 @@ python_functions = ["test_*"]
 
 [tool.black]
 line-length = 120
-target-version = ['py39']
+target-version = ['py312']
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py312"
 
 [tool.pylint.format]
 max-line-length = 120
 
 [tool.pylint.main]
 init-hook = "import sys; sys.path.insert(0, 'src')"
-
-[tool.mypy]
-python_version = "3.9"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tapestry"
 version = "0.1.0"
-description = "A Python implementation of Project Tapestry's consortium training prototype"
+description = "The Python code for Project Tapestry"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Description of the PR

A few values in `pyproject.toml` still reflect the initial project scaffold rather than how the project is actually built:

- `description` was the generic placeholder `"A Python project managed with uv"`.
- `[tool.black]` and `[tool.ruff]` set `target-version = py39`, but the project sets `requires-python = ">=3.12"`.
- A `[tool.mypy]` block remained, even though `mypy` is not a dependency and `ty` is the configured type checker (`make type-check` runs `uv run ty check`).

This brings those values in line with the real toolchain. No source code is changed.

## Related Issues

None.

## Description of Code Changes

`pyproject.toml` only:

- Set a real `description`.
- `[tool.black]` / `[tool.ruff]` `target-version`: `py39` to `py312`.
- Removed the unused `[tool.mypy]` block.

## Testing Performed

Ran the checks locally on this branch:

- `uv run ruff check src`: all checks passed
- `uv run ty check src`: all checks passed
- `uv run python -m pytest tests -q` (from `src`): 4 passed

The `target-version` bump produces no change in black or ruff output on the current code, so this is configuration alignment only.

## Checklist

- [x] I have read and understood the CONTRIBUTING guide.
- [x] I have tested the code changes in my local development environment.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
