### PR TITLE
Document contrib make target protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ For contributed ideas and techniques:
 make contrib-check      # Run all standard contrib checks defined by contrib/*/Makefile.
 make contrib-tests      # Run contrib tests defined by contrib/*/Makefile.
 make contrib-lint       # Run contrib lint checks defined by contrib/*/Makefile.
+make contrib-help       # Show custom target help for contrib/*/Makefile files.
 
 For the consortium-training prototype:
 
@@ -198,7 +199,7 @@ before-pr:: format-lint-type-check tests
 format-lint-type-check flt:: format lint type-check
 
 .PHONY: format lint ruff pylint type-check type-check-watch
-.PHONY: contrib-check contrib-format contrib-lint contrib-tests contrib-type-check run-contrib-target
+.PHONY: contrib-check contrib-format contrib-lint contrib-tests contrib-type-check contrib-help run-contrib-target
 
 format::
 	@echo "${INFO}$@: Running 'black' on the code.${_END}"
@@ -238,6 +239,18 @@ contrib-tests::
 
 contrib-type-check::
 	@${MAKE} run-contrib-target TARGET=type-check
+
+contrib-help::
+	@if [ -z "${CONTRIB_MAKEFILES}" ]; then \
+		echo "${INFO}No ${CONTRIB_DIR}/*/Makefile files found; skipping contrib help.${_END}"; \
+	else \
+		for makefile in ${CONTRIB_MAKEFILES}; do \
+			dir=$$(dirname $$makefile); \
+			echo; \
+			echo "${INFO}Contribution targets in $$dir:${_END}"; \
+			${MAKE} -C $$dir help || echo "${WARN}No working help target found in $$dir.${_END}"; \
+		done; \
+	fi
 
 run-contrib-target::
 	@if [ -z "${CONTRIB_MAKEFILES}" ]; then \

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -58,8 +58,8 @@ Tell reviewers how to run the contribution from beginning to end:
 - Expected runtime, approximate resource use, and expected outputs.
 - Known limitations, shortcuts, skipped steps, or non-deterministic results.
 
-When possible, automate the workflow with scripts or a local `Makefile` so a
-reviewer does not have to reconstruct the command sequence manually.
+When possible, automate any custom workflow with scripts or a local `Makefile`
+so a reviewer does not have to reconstruct the command sequence manually.
 
 ### State the Readiness Level
 
@@ -86,8 +86,8 @@ For code that might be adopted later, reduce integration friction:
 
 If your contribution needs its own workflow commands, prefer a
 `contrib/<your-handle>-<topic>/Makefile` over adding specialized targets to the
-top-level `Makefile`. The root Makefile will discover contribution Makefiles
-and run these conventional targets when present:
+top-level `Makefile`. The root Makefile discovers contribution Makefiles and
+runs these conventional targets when present:
 
 | Target | Purpose |
 | :----- | :------ |
@@ -96,12 +96,24 @@ and run these conventional targets when present:
 | `lint` | Run the contribution's lint checks. |
 | `format` | Format contribution code or docs. |
 | `type-check` | Run type checks when the contribution has typed code. |
+| `help` | List custom commands that are local to this contribution. |
 
 The top-level commands `make contrib-check`, `make contrib-tests`,
 `make contrib-lint`, `make contrib-format`, and `make contrib-type-check`
 delegate to those per-contribution targets. `make before-pr` also runs
 `contrib-tests`, so a contribution with a Makefile should keep its `tests`
 target reliable enough for PR validation.
+
+Keep custom targets local to the contribution:
+
+```shell
+make -C contrib/<your-handle>-<topic> help
+make -C contrib/<your-handle>-<topic> <custom-target>
+```
+
+The root `make contrib-help` target runs `make help` in each contribution that
+provides a `Makefile`, so custom commands remain discoverable without
+hard-coding them into the root `Makefile`.
 
 ## Contribution Policy
 


### PR DESCRIPTION
## Summary

- add `make contrib-help` to discover local contribution Makefile help targets
- document `help` as part of the optional `contrib/*/Makefile` contract
- keep custom contribution commands local to each contribution instead of expanding the root `Makefile`

## Related Issues

Related issues or PRs: #78, #106

## Testing

- `git diff --check`
- `make contrib-help`
- `make contrib-tests`

## Notes

This revision intentionally keeps the root `Makefile` small. It does not try to solve automatic root-level lint/test/format behavior for contributions without Makefiles; that can be handled separately after maintainers decide how much common contrib automation they want.
