### PR TITLE
Consolidate reference docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,7 @@ This directory organizes the technical documentation under development for Proje
 | [`architecture/`](architecture/README.md) | TVA methodology, phased outputs (1–5), architectural options analysis, ADRs, diagrams — **see [Architecture documents](#architecture-documents)** |
 | [`governance/`](governance/README.md) | Anti-capture principle and governance design |
 | [`strategic-plan/`](strategic-plan/README.md) | Overall strategy for execution — the [vision](strategic-plan/VISION.md) and the [product requirements (PRD)](strategic-plan/PRD.md) |
-| [`tapestry-reference/`](tapestry-reference/README.md) | Consolidated technical reference, including a single-page [architecture synthesis](tapestry-reference/ARCHITECTURE.md) |
-| [`reference/`](reference/README.md) | Reference docs (e.g. training paradigms, deployment and usage material) |
+| [`reference/`](reference/README.md) | Reference docs, including the single-page [architecture synthesis](reference/architecture.md), training paradigms, deployment notes, and usage material |
 | [`work-groups/`](work-groups/README.md) | Lifecycle work-group charters for data governance, base training, sovereign alignment, evaluation/certification, security/privacy, infrastructure, deployment, and governance participation (subject to change) |
 
 ## Architecture documents
@@ -32,6 +31,7 @@ The [`reference/`](reference/README.md) directory holds material outside the TVA
 
 | Document | Description |
 | :------- | :---------- |
+| [`reference/architecture.md`](reference/architecture.md) | Single-page synthesis of Tapestry's architecture and design invariants |
 | [`reference/glossary.md`](reference/glossary.md) | Definitions of Tapestry-specific terms (consortium training, Shared-Base Loop, Sovereign Build, etc.) |
 | [`reference/training-approaches.md`](reference/training-approaches.md) | Centralized vs. federated vs. consortium training |
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,9 +1,18 @@
 # README for the `reference` Directory
 
-Long-lived reference material that supports Tapestry design and operations: conceptual comparisons, deployment notes, and usage-oriented docs that are not part of the phased TVA architecture chain under [`architecture/`](../architecture/README.md).
+Long-lived reference material that supports Tapestry design and operations:
+architecture syntheses, conceptual comparisons, deployment notes, and
+usage-oriented docs that are not part of the phased TVA architecture chain under
+[`architecture/`](../architecture/README.md).
 
 | Document | Description |
 | :------- | :---------- |
+| [`architecture.md`](architecture.md) | Single-page synthesis of Tapestry's architecture (core-plus-sovereign, consortium training, the training loop, the sovereign pipeline, data sovereignty, and the design invariants), with links to the source-of-truth ADRs |
 | [`glossary.md`](glossary.md) | Definitions of Tapestry-specific terms (consortium training, Shared-Base Loop, Sovereign Build, etc.); links to the canonical ADR for each |
 | [`training-approaches.md`](training-approaches.md) | Centralized vs. federated vs. **consortium** training — comparison table, shared [`consortium-training-loop.svg`](../architecture/diagrams/consortium-training-loop.svg), links to ADRs |
 | [`training-pipeline-data.md`](training-pipeline-data.md) | LLM training pipeline stages, data type taxonomy, quality framework, and implications for Tapestry's consortium model |
+
+The architecture synthesis summarizes the design chain under
+[`../architecture/`](../architecture/README.md) and the decision records under
+[`../architecture/decisions/`](../architecture/decisions/README.md). Where the
+synthesis and an ADR disagree, the ADR is authoritative.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -22,7 +22,7 @@ The ratio starts at roughly **80/20** centralized-to-sovereign and shifts toward
 
 ## Consortium Training — Not Federated Learning
 
-Tapestry uses **consortium training** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) — the paradigm defined there and contrasted in full with centralized and federated training in [`training-approaches.md`](../reference/training-approaches.md). In brief: a small number of large, trusted, heterogeneous members collaboratively train a shared model, where data sovereignty is a first-order constraint and cultural alignment is the goal. It is deliberately distinguished from federated learning. *Tapestry-specific term definitions are consolidated in [`glossary.md`](../reference/glossary.md).*
+Tapestry uses **consortium training** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) — the paradigm defined there and contrasted in full with centralized and federated training in [`training-approaches.md`](training-approaches.md). In brief: a small number of large, trusted, heterogeneous members collaboratively train a shared model, where data sovereignty is a first-order constraint and cultural alignment is the goal. It is deliberately distinguished from federated learning. *Tapestry-specific term definitions are consolidated in [`glossary.md`](glossary.md).*
 
 Consortium training has two phases, run in order:
 

--- a/docs/strategic-plan/PRD.md
+++ b/docs/strategic-plan/PRD.md
@@ -451,7 +451,7 @@ Phase 3 — Planetary Scale (Jul 2027 – Dec 2027)
 | Milestone | Target Date | Owner | Deliverable |
 |---|---|---|---|
 | Hardware partnerships signed (NVIDIA, AMD) | Mar 2026 | Yann LeCun | Signed MOUs or Letters of Intent |
-| Technical specifications finalized | Mar 15, 2026 | Christopher Nguyen | ARCHITECTURE.md ratified |
+| Technical specifications finalized | Mar 15, 2026 | Christopher Nguyen | [`reference/architecture.md`](../reference/architecture.md) ratified |
 | Governance Committee chartered | May 2026 | Anthony Annunziata | Charter + founding membership |
 | G7 Summit announcement | Jun 2026 | Macron + Takaichi | Public multi-nation commitment |
 | France sovereign node live | Jul 15, 2026 | Nguyen + France AI Commission | Production node, live public demo |

--- a/docs/tapestry-reference/README.md
+++ b/docs/tapestry-reference/README.md
@@ -1,9 +1,0 @@
-# Tapestry Reference
-
-Consolidated technical reference for Tapestry — concise, synthesized views of the architecture intended as a fast orientation for contributors and work groups.
-
-| Document | Description |
-| :------- | :---------- |
-| [`ARCHITECTURE.md`](ARCHITECTURE.md) | Single-page synthesis of Tapestry's architecture (core-plus-sovereign, consortium training, the training loop, the sovereign pipeline, data sovereignty, and the design invariants), with links to the source-of-truth ADRs |
-
-This material summarizes the design chain under [`../architecture/`](../architecture/README.md) and the decision records under [`../architecture/decisions/`](../architecture/decisions/README.md). Where this reference and an ADR disagree, the ADR is authoritative.


### PR DESCRIPTION
## Description of the PR

This PR resolves the reference-directory consolidation requested in #82 after the repository's `docs/` rename.

It:

- Moves the architecture synthesis from `docs/tapestry-reference/ARCHITECTURE.md` to `docs/reference/architecture.md`.
- Merges the old `docs/tapestry-reference/README.md` index content into `docs/reference/README.md`.
- Updates the top-level docs index so `reference/` is the single reference home.
- Updates one PRD milestone reference to point to the new architecture synthesis path.
- Removes the now-redundant `docs/tapestry-reference/` directory.

## Related Issues

Related issues or PRs: #82

## Testing Performed

- `rg -n "tapestry-reference|docs/tapestry-reference|tech-docs" docs README.md website AGENTS.md .github`
- `git diff --check`

## Checklist

- [x] I have read and understood the CONTRIBUTING guide.

For documentation changes, including `docs`:

- [x] I have followed the existing documentation styles and conventions.
