### PR TITLE
Added a note and link to technical meeting notes as GDocs

### DIFF
--- a/docs/work-groups/README.md
+++ b/docs/work-groups/README.md
@@ -17,6 +17,10 @@ The structure is meant to be necessary and sufficient for the current architectu
 | Deployment & Adoption | [`deployment-adoption/`](deployment-adoption/README.md) | Serving, chat/product harnesses, integration patterns, participant rollout, developer experience, and adoption feedback loops |
 | Governance & Participation | [`governance-participation/`](governance-participation/README.md) | Anti-capture mechanics, contribution credit, decision rights, consortium process, and interfaces with [`../governance/`](../governance/README.md) |
 
+### Technical meeting notes
+
+In addition, some running meetings maintain Google docs for notes. All of them can be found in folders under this [GDrive location](https://drive.google.com/drive/folders/1kyDleaoORp4zzZHk8gw7YzcVU50VUVh0?usp=sharing).
+
 ## Lifecycle view
 
 ```mermaid


### PR DESCRIPTION
# [Update] Added a note and link to technical meeting notes as GDocs

## Description of the PR

Some meetings will keep notes in GDocs. This update adds a link to the enclosing folder in GDrive.

## Related Issues

Related issues or PRs (#number, ...): N/A

## Checklist

Confirm that the following have been completed.

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

Ignore (or delete) any of the following check list sections or items that aren't applicable, like the code-related check list items when this is a documentation-only PR:

For documentation changes, including `docs`:

- [x] I have followed the existing documentation styles and conventions.
- [ ] I have included helpful diagrams, screenshots, tables, etc.
