### PR TITLE
For issue 105, automatically support common make targets for contributions

### DIFF
--- a/.github/workflows/collect_metrics.yaml
+++ b/.github/workflows/collect_metrics.yaml
@@ -1,92 +1,92 @@
-name: Collect Repo Metrics and Upload to S3  
-  
-on:  
-  workflow_dispatch: # Allows manual triggering  
-  schedule:  
-    - cron: '0 0 * * *' # Run daily at 5 AM UTC  
-  
-jobs:  
-  collect-and-upload-metrics:  
+name: Collect Repo Metrics and Upload to S3
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: '0 0 * * *' # Run daily at 5 AM UTC
+
+jobs:
+  collect-and-upload-metrics:
     # Disable the workflow, because started failing regularly in early 2026
     # for reasons we were unable to diagnose!
-    if: false  
-    runs-on: ubuntu-latest  
-    permissions:  
-      contents: read  # Read repo content (needed for repo object)  
-  
-    steps:  
-      - name: Checkout code  
-        uses: actions/checkout@v7  
-  
-      - name: Set up Python  
-        uses: actions/setup-python@v6  
-        with:  
-          python-version: '3.10' # Or your preferred version  
-  
-      - name: Install dependencies  
-        run: pip install PyGithub pandas pyarrow  
-  
-      # --- Configure AWS Credentials ---  
-      # Recommended: Use OpenID Connect (OIDC) if your AWS setup supports it.  
-      # Requires setting up a trust relationship in AWS IAM.  
-      # See: https://github.com/aws-actions/configure-aws-credentials#configure-aws-credentials-action-for-github-actions  
-      # - name: Configure AWS Credentials (OIDC)  
-      #   uses: aws-actions/configure-aws-credentials@v6  
-      #   with:  
-      #     role-to-assume: arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:role/YOUR_GITHUB_ACTIONS_ROLE # Replace with your IAM role ARN  
-      #     aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1  
-  
-      # Alternative: Use Access Keys (Store as GitHub Secrets)  
-      - name: Configure AWS Credentials (Access Keys)  
-        uses: aws-actions/configure-aws-credentials@v6  
-        with:  
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}  
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}  
-          aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1  
-  
-      # --- Run Python Script to Generate Parquet ---  
-      - name: Run metrics collection script  
-        id: collect_metrics # Give the step an id to potentially reference output later if needed  
-        env:  
-          GITHUB_TOKEN: ${{ secrets.SPECIAL_GH_TOKEN }} # Use the default action token  
-          # GITHUB_REPOSITORY is automatically set by the runner  
-        run: python .github/scripts/collect_metrics.py # Assuming your script is named this  
-  
-      # --- Upload Parquet File to S3 ---  
-      - name: Upload Parquet to S3  
-        env:  
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}  
-          # GITHUB_REPOSITORY format is 'owner/repo'  
-          SOURCE_FILE_PATTERN: "github_metrics_*.parquet" # Pattern from the python script  
-          S3_DESTINATION_FILENAME: "blob.parquet"  
+    if: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Read repo content (needed for repo object)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10' # Or your preferred version
+
+      - name: Install dependencies
+        run: pip install PyGithub pandas pyarrow
+
+      # --- Configure AWS Credentials ---
+      # Recommended: Use OpenID Connect (OIDC) if your AWS setup supports it.
+      # Requires setting up a trust relationship in AWS IAM.
+      # See: https://github.com/aws-actions/configure-aws-credentials#configure-aws-credentials-action-for-github-actions
+      # - name: Configure AWS Credentials (OIDC)
+      #   uses: aws-actions/configure-aws-credentials@v6
+      #   with:
+      #     role-to-assume: arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:role/YOUR_GITHUB_ACTIONS_ROLE # Replace with your IAM role ARN
+      #     aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1
+
+      # Alternative: Use Access Keys (Store as GitHub Secrets)
+      - name: Configure AWS Credentials (Access Keys)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1
+
+      # --- Run Python Script to Generate Parquet ---
+      - name: Run metrics collection script
+        id: collect_metrics # Give the step an id to potentially reference output later if needed
+        env:
+          GITHUB_TOKEN: ${{ secrets.SPECIAL_GH_TOKEN }} # Use the default action token
+          # GITHUB_REPOSITORY is automatically set by the runner
+        run: python .github/scripts/collect_metrics.py # Assuming your script is named this
+
+      # --- Upload Parquet File to S3 ---
+      - name: Upload Parquet to S3
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          # GITHUB_REPOSITORY format is 'owner/repo'
+          SOURCE_FILE_PATTERN: "github_metrics_*.parquet" # Pattern from the python script
+          S3_DESTINATION_FILENAME: "blob.parquet"
         run: |
-          # Check if source file exists  
-          if ! ls $SOURCE_FILE_PATTERN 1> /dev/null 2>&1; then  
-            echo "Error: No parquet file matching '$SOURCE_FILE_PATTERN' found."  
-            exit 1  
-          fi  
-          # Assume only one file matches the pattern from the script run  
-          SOURCE_FILE=$(ls $SOURCE_FILE_PATTERN)  
-  
-          # Format repository name for S3 path (replace '/' with '-')  
-          # Adjust sed expression if your repo names need different handling  
-          REPOSITORY_NAME_FORMATTED=$(echo "${{ github.repository }}" | sed 's/\//-/g')  
-  
-          # Get current date in YYYY-MM-DD format  
-          CURRENT_DATE=$(date +%Y-%m-%d)  
-  
-          # Construct the S3 destination path  
-          S3_PATH="s3://${AWS_S3_BUCKET}/service=github/repository=${REPOSITORY_NAME_FORMATTED}/date=${CURRENT_DATE}/${S3_DESTINATION_FILENAME}"  
-  
-          echo "Uploading '$SOURCE_FILE' to '$S3_PATH'..."  
-          aws s3 cp "$SOURCE_FILE" "$S3_PATH"  
-          echo "Upload to S3 complete."  
-  
-      # --- Optional: Upload Parquet artifact to GitHub Actions ---  
-      # Useful for debugging or if you need the file directly from the Actions run  
-      - name: Upload Parquet artifact (Optional)  
-        if: always() # Run even if S3 upload fails, for debugging  
-        uses: actions/upload-artifact@v7  
-        with:  
-          name: github-metrics-parquet  
-          path: github_metrics_*.parquet # Upload the generated parquet file  
+          # Check if source file exists
+          if ! ls $SOURCE_FILE_PATTERN 1> /dev/null 2>&1; then
+            echo "Error: No parquet file matching '$SOURCE_FILE_PATTERN' found."
+            exit 1
+          fi
+          # Assume only one file matches the pattern from the script run
+          SOURCE_FILE=$(ls $SOURCE_FILE_PATTERN)
+
+          # Format repository name for S3 path (replace '/' with '-')
+          # Adjust sed expression if your repo names need different handling
+          REPOSITORY_NAME_FORMATTED=$(echo "${{ github.repository }}" | sed 's/\//-/g')
+
+          # Get current date in YYYY-MM-DD format
+          CURRENT_DATE=$(date +%Y-%m-%d)
+
+          # Construct the S3 destination path
+          S3_PATH="s3://${AWS_S3_BUCKET}/service=github/repository=${REPOSITORY_NAME_FORMATTED}/date=${CURRENT_DATE}/${S3_DESTINATION_FILENAME}"
+
+          echo "Uploading '$SOURCE_FILE' to '$S3_PATH'..."
+          aws s3 cp "$SOURCE_FILE" "$S3_PATH"
+          echo "Upload to S3 complete."
+
+      # --- Optional: Upload Parquet artifact to GitHub Actions ---
+      # Useful for debugging or if you need the file directly from the Actions run
+      - name: Upload Parquet artifact (Optional)
+        if: always() # Run even if S3 upload fails, for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: github-metrics-parquet
+          path: github_metrics_*.parquet # Upload the generated parquet file

--- a/Makefile
+++ b/Makefile
@@ -1,88 +1,20 @@
-
-SRC_DIR      := src
-CONTRIB_DIR  := contrib
+include common.mk
 
 PAGES_URL    := https://the-ai-alliance.github.io/tapestry/
-DOCS_DIR     := website
-SITE_DIR     := ${DOCS_DIR}/_site
-CLEAN_DIRS   := ${SITE_DIR} ${DOCS_DIR}/.sass-cache
-CONTRIB_MAKEFILES := $(wildcard ${CONTRIB_DIR}/*/Makefile)
-# Environment variables
-MAKEFLAGS            = --warn-undefined-variables
-UNAME               ?= $(shell uname)
-ARCHITECTURE        ?= $(shell uname -m)
+WEBSITE_DIR  := website
+SITE_DIR     := ${WEBSITE_DIR}/_site
+CLEAN_DIRS   += ${SITE_DIR} ${WEBSITE_DIR}/.sass-cache
 
 # Override when running `make view-local` using e.g., `JEKYLL_PORT=8000 make view-local`
-JEKYLL_PORT         ?= 4000
+JEKYLL_PORT  ?= 4000
 
-# Used for version tagging release artifacts.
-GIT_HASH            ?= $(shell git show --pretty="%H" --abbrev-commit |head -1)
-NOW                 ?= $(shell date +"%Y%m%d-%H%M%S")
+ifndef WEBSITE_DIR
+$(error ERROR: There is no ${WEBSITE_DIR} directory!)
+endif
 
-# Colors used to make some messages stand out more than others...
-RED          = \033[31m
-BOLD_RED     = \033[1;31m
-GREEN        = \033[32m
-BOLD_GREEN   = \033[1;32m
-YELLOW       = \033[33m
-BOLD_YELLOW  = \033[1;33m
-BLUE         = \033[34m
-BOLD_BLUE    = \033[1;34m
-PURPLE       = \033[35m
-BOLD_PURPLE  = \033[1;35m
-CYAN         = \033[36m
-BOLD_CYAN    = \033[1;36m
+define help_website_message
 
-ERROR        = ${BOLD_RED}ERROR:
-WARN         = ${BOLD_YELLOW}WARNING:
-NOTE         = ${BOLD_PURPLE}NOTE:
-INFO         = ${BOLD_PURPLE}
-TIP          = ${BOLD_BLUE}TIP:
-HIGHLIGHT    = ${BOLD_GREEN}
-_END         = \033[0m
-
-
-define help_message
-Quick help for this make process.
-
-Building code:
-
-make all                # Makes the 'help' and 'print-info' targets (see below). 
-make tests              # Run the test suite.
-make clean              # Remove built artifacts, etc.
-
-make format             # Format the Python code with 'black'.
-make lint               # Lint the Python code by making the ruff and pylint targets.
-make ruff               # Lint the Python code with 'ruff'.
-make pylint             # Lint the Python code with 'pylint'.
-make type-check         # Type check the Python code with 'ty'.
-make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
-                        # so you can fix mistakes and keep it updating.
-make before-pr          # Make format, lint, type-check, and tests for "src" AND "contrib". 
-                        # DO THIS BEFORE SUBMITTING A PR!
-
-For contributed code in "contrib", any of the targets format, lint, ruff, pylint,
-type-check, type-check-watch, and before-pr, can be invoked by prefixing the targets
-name with "contrib-". This will run the corresponding target :
-
-make contrib-tests      # Run contrib tests defined by contrib/*/Makefile.
-make contrib-lint       # Run contrib lint checks defined by contrib/*/Makefile.
-
-For the consortium-training prototype:
-
-make consortium-demo    # Run the N+1 consortium-training proof-of-concept demo.
-make consortium-experiment
-                        # Run deterministic PoC metrics for consortium-training rounds.
-make consortium-tests   # Run only the consortium-training prototype tests.
-
-For the EXP-001 cultural-CPT validation harness (contrib):
-
-make cultural-cpt-validation   # Run the arms experiment, single seed (smoke mode).
-make cultural-cpt-aggregation  # Run the FedAvg aggregation-survival experiment.
-make cultural-cpt-stats        # Run the multi-seed go/no-go decision (smoke mode).
-make cultural-cpt-tests        # Run the cultural-CPT harness tests.
-
-For the documentation website:
+Help for the documentation website:
 
 make view-pages         # View the published GitHub pages in a browser.
 make view-local         # View the pages locally (requires Jekyll).
@@ -93,54 +25,30 @@ make setup-jekyll       # Install Jekyll. Make sure Ruby is installed.
 make run-jekyll         # Used by "view-local"; assumes everything is already built.
                         # Tip: Build this target instead of 'view-local' to avoid repeating 'setup-jekyll'.
                         # Tip: "JEKYLL_PORT=8000 make run-jekyll" uses port 8000 instead of 4000!
-
-Help, etc.:
-
-make help               # Prints this output.
-make print-info         # Print the current values of some make and env. variables.
 endef
 
-define missing_shell_command_error_message
-is needed by ${PWD}/Makefile. Try 'make help' and look at the README.
+define help_programs_message
+
+For the EXP-001 cultural-CPT validation harness (contrib):
+
+make cultural-cpt-validation   # Run the arms experiment, single seed (smoke mode).
+make cultural-cpt-aggregation  # Run the FedAvg aggregation-survival experiment.
+make cultural-cpt-stats        # Run the multi-seed go/no-go decision (smoke mode).
+make cultural-cpt-tests        # Run the cultural-CPT harness tests.
+
+For the consortium-training prototype:
+
+make consortium-demo    # Run the N+1 consortium-training proof-of-concept demo.
+make consortium-experiment
+                        # Run deterministic PoC metrics for consortium-training rounds.
+make consortium-tests   # Run only the consortium-training prototype tests.
 endef
 
-ifndef DOCS_DIR
-$(error ERROR: There is no ${DOCS_DIR} directory!)
-endif
-
-
-.PHONY: all help print-info clean
-all:: help print-info
-
-help::
-	$(info ${help_message})
-	@echo
-
-clean::
-	rm -rf ${CLEAN_DIRS} 
-
-print-info:
-	@echo "source               ${SRC_DIR}"
-	@echo "tests                ${SRC_DIR}/tests"
-	@echo "current dir:         ${PWD}"
-	@echo "MAKEFLAGS:           ${MAKEFLAGS}"
-	@echo "UNAME:               ${UNAME}"
-	@echo "ARCHITECTURE:        ${ARCHITECTURE}"
-	@echo "GIT_HASH:            ${GIT_HASH}"
-	@echo "NOW:                 ${NOW}"
+print-info::
 	@echo
 	@echo "GitHub Pages URL:    ${PAGES_URL}"
-	@echo "Website files:       ${DOCS_DIR}"
+	@echo "Website files:       ${WEBSITE_DIR}"
 	@echo "JEKYLL_PORT:         ${JEKYLL_PORT}"
-
-.PHONY: tests unit-tests
-tests:: unit-tests
-tests:: contrib-tests
-
-unit-tests::
-	@echo "${INFO}Running the unit tests...${_END}"
-	cd ${SRC_DIR} && \
-	  uv run python -m pytest tests -q
 
 .PHONY: consortium-demo consortium-tests consortium-experiment cultural-cpt-validation cultural-cpt-aggregation cultural-cpt-stats cultural-cpt-tests cultural-cpt-fetch-seed cultural-cpt-validate-corpus
 
@@ -191,100 +99,6 @@ cultural-cpt-validate-corpus::
 	PYTHONPATH="${PWD}/src:${PWD}/${CULTURAL_CPT_DIR}" \
 		uv run python ${CULTURAL_CPT_DIR}/fetch_corpus.py --validate ${CORPUS}
 
-.PHONY: before-pr format-lint-type-check flt contrib-format-lint-type-check contrib-tests 
-.PHONY: format lint ruff pylint type-check type-check-watch
-.PHONY: contrib-before-prcontrib-format contrib-lint contrib-tests contrib-type-check run-contrib-target
-
-before-pr:: format-lint-type-check contrib-format-lint-type-check tests contrib-tests 
-format-lint-type-check flt:: format ruff pylint type-check
-contrib-format-lint-type-check:: format ruff pylint type-check
-
-
-
-format::
-	@echo "${INFO}$@: Running 'black' on the code in ${SRC_DIR}.${_END}"
-	uv run black ${SRC_DIR}
-format:: contrib-format
-
-lint:: ruff pylint
-lint:: contrib-lint
-
-ruff::
-	@echo "${INFO}$@: Running 'ruff' to lint the code in ${SRC_DIR}.${_END}"
-	uv run ruff check --fix ${SRC_DIR}
-
-pylint::
-	@echo "${INFO}$@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
-	uv run pylint ${SRC_DIR}
-
-type-check::
-	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR}.${_END}"
-	uv run ty check ${SRC_DIR} 
-type-check:: contrib-type-check
-type-check-watch::
-	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
-	uv run ty check --watch ${SRC_DIR} 
-
-contrib-check::
-	@${MAKE} run-contrib-target TARGET=check
-
-contrib-format::
-	@${MAKE} run-contrib-target TARGET=format
-
-contrib-lint::
-	@${MAKE} run-contrib-target TARGET=lint
-
-contrib-tests::
-	@${MAKE} run-contrib-target TARGET=tests
-
-contrib-type-check::
-	@${MAKE} run-contrib-target TARGET=type-check
-
-run-contrib-target::
-	@if [ -z "${CONTRIB_MAKEFILES}" ]; then \
-		echo "${INFO}No ${CONTRIB_DIR}/*/Makefile files found; skipping contrib ${TARGET}.${_END}"; \
-	else \
-		for makefile in ${CONTRIB_MAKEFILES}; do \
-			dir=$$(dirname $$makefile); \
-			echo "${INFO}Running '${TARGET}' in $$dir...${_END}"; \
-			${MAKE} -C $$dir ${TARGET}; \
-		done; \
-	fi
-
-.PHONY: one-time-setup clean-setup 
-.PHONY: install-uv uv-venv install-dev-dependencies command-check-uv
-
-setup one-time-setup:: install-uv uv-venv install-dev-dependencies
-
-install-%:: 
-	@cmd=${@:install-%=%} && command -v $$cmd > /dev/null && \
-		echo "${INFO}$$cmd is already installed${_END}" || ${MAKE} help-command-$$cmd
-
-uv-venv:: command-check-uv 
-	@test -d .venv && echo "'.venv' already exists; not running 'uv venv'." || uv venv
-	@echo "run: 'source .venv/bin/activate' if subsequent commands fail!"
-
-install-dev-dependencies::
-	uv pip install -e ".[dev]"
-
-command-check-uv::
-	@command -v uv > /dev/null || ! ${MAKE} help-command-uv
-
-help-command-uv help-command-uvx::
-	$(info ${help-message-uv})
-	@echo
-
-define help-message-uv
-
-The Python environment management tool "uv" is required.
-See https://docs.astral.sh/uv/ for installation instructions.
-
-If you want to uninstall uv and you used HomeBrew to install it,
-use 'brew uninstall uv'. Otherwise, if you executed one of the
-installation commands on the website above, find the installation
-location and delete uv.
-
-endef
 
 .PHONY: view-pages view-local
 .PHONY: setup-jekyll run-jekyll
@@ -301,7 +115,7 @@ run-jekyll: clean
 	@echo
 	@echo "Once you see the http://127.0.0.1:${JEKYLL_PORT}/ URL printed, open it with command+click..."
 	@echo
-	cd ${DOCS_DIR} && \
+	cd ${WEBSITE_DIR} && \
 		bundle exec jekyll serve --port ${JEKYLL_PORT} --baseurl '' --incremental || \
 		${MAKE} jekyll-error
 
@@ -311,7 +125,7 @@ setup-jekyll:: ruby-installed-check ruby-gem-installation bundle-command-check b
 .PHONY: jekyll-error ruby-missing-error gem-missing-error gem-error bundle-error bundle-missing-error
 
 ruby-gem-installation::
-	@echo "Updating Ruby gems required for local viewing of the ${DOCS_DIR}, including jekyll."
+	@echo "Updating Ruby gems required for local viewing of the ${WEBSITE_DIR}, including jekyll."
 	gem install jekyll bundler jemoji || ${MAKE} gem-error
 
 bundle-installation::

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,6 @@ make all                # Makes the 'help' and 'print-info' targets (see below).
 make tests              # Run the test suite.
 make clean              # Remove built artifacts, etc.
 
-make format-lint-type-check
-                        # Do formating, linting, and type checking.
-make flt                # Synonym for format-lint-type-check.
 make format             # Format the Python code with 'black'.
 make lint               # Lint the Python code by making the ruff and pylint targets.
 make ruff               # Lint the Python code with 'ruff'.
@@ -61,12 +58,13 @@ make pylint             # Lint the Python code with 'pylint'.
 make type-check         # Type check the Python code with 'ty'.
 make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
                         # so you can fix mistakes and keep it updating.
-make before-pr          # Make format-lint-type-check and tests. 
+make before-pr          # Make format, lint, type-check, and tests for "src" AND "contrib". 
                         # DO THIS BEFORE SUBMITTING A PR!
 
-For contributed ideas and techniques:
+For contributed code in "contrib", any of the targets format, lint, ruff, pylint,
+type-check, type-check-watch, and before-pr, can be invoked by prefixing the targets
+name with "contrib-". This will run the corresponding target :
 
-make contrib-check      # Run all standard contrib checks defined by contrib/*/Makefile.
 make contrib-tests      # Run contrib tests defined by contrib/*/Makefile.
 make contrib-lint       # Run contrib lint checks defined by contrib/*/Makefile.
 
@@ -193,15 +191,18 @@ cultural-cpt-validate-corpus::
 	PYTHONPATH="${PWD}/src:${PWD}/${CULTURAL_CPT_DIR}" \
 		uv run python ${CULTURAL_CPT_DIR}/fetch_corpus.py --validate ${CORPUS}
 
-.PHONY: before-pr format-lint-type-check flt
-before-pr:: format-lint-type-check tests
-format-lint-type-check flt:: format lint type-check
-
+.PHONY: before-pr format-lint-type-check flt contrib-format-lint-type-check contrib-tests 
 .PHONY: format lint ruff pylint type-check type-check-watch
-.PHONY: contrib-check contrib-format contrib-lint contrib-tests contrib-type-check run-contrib-target
+.PHONY: contrib-before-prcontrib-format contrib-lint contrib-tests contrib-type-check run-contrib-target
+
+before-pr:: format-lint-type-check contrib-format-lint-type-check tests contrib-tests 
+format-lint-type-check flt:: format ruff pylint type-check
+contrib-format-lint-type-check:: format ruff pylint type-check
+
+
 
 format::
-	@echo "${INFO}$@: Running 'black' on the code.${_END}"
+	@echo "${INFO}$@: Running 'black' on the code in ${SRC_DIR}.${_END}"
 	uv run black ${SRC_DIR}
 format:: contrib-format
 
@@ -209,19 +210,19 @@ lint:: ruff pylint
 lint:: contrib-lint
 
 ruff::
-	@echo "${INFO}$@: Running 'ruff' to lint the code.${_END}"
+	@echo "${INFO}$@: Running 'ruff' to lint the code in ${SRC_DIR}.${_END}"
 	uv run ruff check --fix ${SRC_DIR}
 
 pylint::
-	@echo "${INFO}$@: Running 'pylint' on the code.${_END} (configuration in pylintrc.toml)"
+	@echo "${INFO}$@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
 	uv run pylint ${SRC_DIR}
 
 type-check::
-	@echo "${INFO}$@: Running 'ty' to type check the code.${_END}"
+	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR}.${_END}"
 	uv run ty check ${SRC_DIR} 
 type-check:: contrib-type-check
 type-check-watch::
-	@echo "${INFO}$@: Running 'ty' to type check the code in 'watch' mode.${_END}"
+	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
 	uv run ty check --watch ${SRC_DIR} 
 
 contrib-check::

--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ Project Tapestry has big plans, and we're starting with some fundamental buildin
 
 ### Working with the Source Code
 
-The source code is under the [`src`](src/) directory.
+Use the [**`Makefile`**](Makefile) targets to run tests and other tools, executables, etc. However, most commands require MacOS or Linux to work. Try `make help` for more information. More details are in the [**Development**](#development-anchor) section below.
 
-* Use the [**`Makefile`**](Makefile) targets, e.g., `make help`. More details are in [**Development**](#development-anchor) below.
-* Runnable demos in [**`examples/`**](examples/) (try `make consortium-demo`).
-* Consortium training prototype in [**`src/tapestry/training/consortium/`**](src/tapestry/training/consortium/README.md) (try `make consortium-demo` and `make consortium-tests`).
-* Contrib experiment metrics for the consortium prototype in [**`contrib/jneums-consortium-experiment/`**](contrib/jneums-consortium-experiment/README.md) (try `make consortium-experiment`).
+The _production_ source code is under the [`src`](src/) directory. The unit tests are under the [`src/tests`](src/tests/) directory. For example, a consortium training prototype is in [**`src/tapestry/training/consortium/`**](src/tapestry/training/consortium/README.md). Try `make consortium-demo` and `make consortium-tests`.
+
+There are runnable demos in [**`examples/`**](examples/). Try `make consortium-demo`.
+
+_Contributions_ are in [**`contrib/`**](contrib/), which are PoCs (proofs of concept), experiments, and modules proposed for possible inclusion in the production code. For example, see the contrib. experiment metrics for the consortium prototype in [**`contrib/jneums-consortium-experiment/`**](contrib/jneums-consortium-experiment/README.md). Try `make consortium-experiment`.
 
 ### Working with the Technical Documentation
 
-The technical documentation lives under [**`docs`**](docs/README.md):
+The technical documentation lives under [**`docs`**](docs/README.md). This is where you will find our requirements, architecture and design work, etc.
 
 * [**Architecture**](docs/architecture/README.md)
 	* The _TVA methodology_: phased outputs (stakeholder map through design goals), architectural options and core thesis, plus:
@@ -59,13 +60,11 @@ For repo layout, conventions, and where to find implementation code, see [**`AGE
 
 <a id="development-anchor"></a>
 
-## Development
-
-### Setup
+## Setting Up for Development
 
 This project uses [`uv`](https://docs.astral.sh/uv/) for Python package management.
 
-#### Install uv
+### Install uv
 
 On macOS/Linux:
 
@@ -82,12 +81,12 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 The rest of the steps discussed next are automated using `make`. Try the following:
 
 ```shell
-make one-time-setup
+make one-time-setup  # Requires MacOS or Linux
 ```
 
-#### Create a Virtual Environment
+### Create a Virtual Environment
 
-The `one-time-setup` target runs the following command (but it only works on macOS or Linux). You can also do this manually:
+The `one-time-setup` target starts by running the following command.
 
 On macOS/Linux:
 
@@ -95,36 +94,41 @@ On macOS/Linux:
 uv venv
 source .venv/bin/activate
 ```
-On Windows:
+
+On Windows, use the following instead:
 
 ```shell
 uv venv
 .venv\Scripts\activate
 ```
 
-#### Install Dependencies
+### Install Dependencies
 
-The `one-time-setup` target runs the first of the following commands (but it only works on macOS or Linux). You can also run either command manually:
+The `one-time-setup` target runs the first of the following two commands. You can also run either command manually.
 
 ```shell
 uv pip install -e ".[dev]"  # full development dependencies
 uv pip install -e .         # minimum dependencies
 ```
 
-### Running Tests
+## Running Tests
 
 We use [pytest](https://docs.pytest.org/) for testing. The easiest way to run the test suite is using `make`:
 
 ```shell
-make unit-tests # or just tests; they are currently the same.
+make unit-tests   # tests is also defined as an alias for unit-tests.
 ```
 
-This runs the following commands, which you can run yourself if you prefer:
+This runs the following commands:
 
 ```shell
 cd src
 uv run python -m pytest tests -q
 ```
+
+## Code Refinement
+
+We use tools for formatting, linting, and type-checking the code.
 
 ### Code Formatting
 
@@ -165,21 +169,35 @@ make type-check-watch
 uv run ty --watch src
 ```
 
-### Before You Submit a PR...
+## _Where_ to Create Your Contribution
+
+If you are enhancing existing code, make the changes under `src`, and when appropriate, the top-level `Makefile` and `common.mk`.
+
+However, for everything else, including proofs of concept (PoCs), experiments, proposed additions, etc., create them under [`contrib`](contrib/README.md), the staging area for new contributions. The `contrib` [`README`](contrib/README.md) describes the requirements you must follow for new contributions.
+
+## Before You Submit a PR...
 
 Before submitting a PR, please run the format, lint, and type checking commands, then run the tests. Make sure everything passes cleanly! Use the convenient `make` target `before-pr`, or run the individual commands above:
 
 ```shell
-make before-pr               # Equivalent to 'make format lint type-check tests'
-make format-lint-type-check  # Equivalent to 'make format lint type-check'
+make before-pr  # Equivalent to 'make format lint type-check tests contrib-tests'
+```
+
+This ensures that the _production_ code under `src` is properly formatted, linted, type checked, and the tests pass (and stays that way, even if you aren't working on it with your PR...), and it also ensures that all the `contrib` contribution tests pass. 
+
+Note that since contributions are often quick PoCs, we don't run the `format`, `lint`, and `type-check` targets on them. However, you can run these targets on one or more contributions as follows. Let's use `contrib/foo` and target `format` as an example:
+
+```shell
+make SRC_DIR=contrib/foo format  # Make "format" just for "contrib/foo"
+make contrib-format              # Make "format" for ALL "contrib/*"
 ```
 
 > [!NOTE]
-> Make sure to read [**Getting Involved**](#getting-involved-anchor) below before submitting a PR.
+> Make sure to read the general guidance in [**Getting Involved**](#getting-involved-anchor) below before submitting a PR.
 
 ## Project Code Structure
 
-In addition to the top-level directories `docs`, discussed above, `website`, discussed below, and [`contrib`](contrib/README.md), the staging area for contributed ideas and techniques, the code structure is as follows. At this time, there are three major _subsystems_:
+In addition to the top-level directories [`docs`](docs/), discussed above, [`website`](website/), discussed below, and [`contrib`](contrib/README.md), the staging area for contributed ideas and techniques, the code structure is as follows. At this time, there are three major _subsystems_:
 
 * `data` for all data governance and management capabilities.
 * `training` for all distributed training and tuning capabilities.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Project Tapestry has big plans, and we're starting with some fundamental buildin
 
 > [!NOTE]
 > Make sure to read [**Getting Involved**](#getting-involved-anchor) below for information on contribution guidelines, etc.
-> 
+>
 > We use the [`develop`](https://github.com/The-AI-Alliance/tapestry/tree/develop) branch as our default (integration) branch, reserving `main` for occasional "baked" releases.
 
 ### Working with the Source Code
@@ -50,7 +50,7 @@ The technical documentation lives under [**`docs`**](docs/README.md). This is wh
 * [**Architecture**](docs/architecture/README.md)
 	* The _TVA methodology_: phased outputs (stakeholder map through design goals), architectural options and core thesis, plus:
 		* [**Architecture Decision Records**](docs/architecture/decisions/)
-		* [**Diagrams**](docs/architecture/diagrams/) 
+		* [**Diagrams**](docs/architecture/diagrams/)
 * [**Governance**](docs/governance/)
 * [**Strategic Plan**](docs/strategic-plan/)
 * [**Reference Materials**](docs/reference/) (e.g. [**training paradigms**](docs/reference/training-approaches.md))
@@ -183,7 +183,7 @@ Before submitting a PR, please run the format, lint, and type checking commands,
 make before-pr  # Equivalent to 'make format lint type-check tests contrib-tests'
 ```
 
-This ensures that the _production_ code under `src` is properly formatted, linted, type checked, and the tests pass (and stays that way, even if you aren't working on it with your PR...), and it also ensures that all the `contrib` contribution tests pass. 
+This ensures that the _production_ code under `src` is properly formatted, linted, type checked, and the tests pass (and stays that way, even if you aren't working on it with your PR...), and it also ensures that all the `contrib` contribution tests pass.
 
 Note that since contributions are often quick PoCs, we don't run the `format`, `lint`, and `type-check` targets on them. However, you can run these targets on one or more contributions as follows. Let's use `contrib/foo` and target `format` as an example:
 
@@ -222,7 +222,7 @@ tapestry/
 
 ## Getting Involved
 
-We welcome contributions as [pull requests](https://github.com/The-AI-Alliance/tapestry/pulls), [issues](https://github.com/The-AI-Alliance/tapestry/issues), and [discussions](https://github.com/The-AI-Alliance/tapestry/discussions). 
+We welcome contributions as [pull requests](https://github.com/The-AI-Alliance/tapestry/pulls), [issues](https://github.com/The-AI-Alliance/tapestry/issues), and [discussions](https://github.com/The-AI-Alliance/tapestry/discussions).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. In particular, [read this section](CONTRIBUTING.md#developer-certificate-of-origin-dco) on using _DCO_ with any commits.
 

--- a/common.mk
+++ b/common.mk
@@ -100,7 +100,7 @@ print-info::
 tests:: unit-tests
 
 unit-tests::
-	@echo "${INFO}Running the unit tests:${_END}"
+	@echo "${INFO}Running the unit tests in ${SRC_DIR}/tests:${_END}"
 	@if [[ ! -d ${SRC_DIR}/tests ]]; then echo "${WARN}No test directory ${SRC_DIR}/tests found!${_END}"; \
 	else echo "cd ${SRC_DIR}; uv run python -m pytest tests -q"; \
 		cd ${SRC_DIR}; uv run python -m pytest tests -q; \
@@ -111,7 +111,7 @@ unit-tests::
 
 before-pr:: do-before-pr do-contrib-before-pr
 do-before-pr:: format ruff pylint type-check tests
-do-contrib-before-pr:: tests
+do-contrib-before-pr:: contrib-tests
 
 # Convenient short hand for the two linters.
 lint:: ruff pylint

--- a/common.mk
+++ b/common.mk
@@ -1,8 +1,8 @@
 
 SRC_DIR      := src
-CLEAN_DIRS   := 
+CLEAN_DIRS   :=
 CONTRIB_DIR  := contrib
-CONTRIB_DIRS = $(patsubst %/,%,$(wildcard ${CONTRIB_DIR}/*/))
+CONTRIB_DIRS = $(patsubst %/.,%,$(wildcard ${CONTRIB_DIR}/*/.))
 
 # Environment variables
 MAKEFLAGS     = --warn-undefined-variables
@@ -39,7 +39,7 @@ _END         := \033[0m
 define help_message
 Quick help for this make process.
 
-make all                # Makes the 'help' and 'print-info' targets (see below). 
+make all                # Makes the 'help' and 'print-info' targets (see below).
 make help               # Prints this output.
 make print-info         # Print the current values of some make and env. variables.
 
@@ -55,7 +55,7 @@ make type-check         # Type check the Python code with 'ty'.
 make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
                         # so you can fix mistakes and keep it updating.
 make before-pr          # Make format, lint, type-check, and tests for "src" AND makes
-                        # tests in every "contrib" directory (but not the other targets...). 
+                        # tests in every "contrib" directory (but not the other targets...).
                         # DO THIS BEFORE SUBMITTING A PR!
 
 For contributed code in "contrib", any of the targets help, format, lint, ruff, pylint,
@@ -84,7 +84,7 @@ help-%::
 	@echo
 
 clean::
-	rm -rf ${CLEAN_DIRS} 
+	rm -rf ${CLEAN_DIRS}
 
 print-info::
 	@echo "source               ${SRC_DIR}"
@@ -101,7 +101,7 @@ tests:: unit-tests
 
 unit-tests::
 	@echo "${INFO}Running the unit tests in ${SRC_DIR}/tests:${_END}"
-	@if [[ ! -d ${SRC_DIR}/tests ]]; then echo "${WARN}No test directory ${SRC_DIR}/tests found!${_END}"; \
+	@if [ ! -d "${SRC_DIR}/tests" ]; then echo "${WARN}No test directory ${SRC_DIR}/tests found!${_END}"; \
 	else echo "cd ${SRC_DIR}; uv run python -m pytest tests -q"; \
 		cd ${SRC_DIR}; uv run python -m pytest tests -q; \
 	fi
@@ -130,11 +130,11 @@ pylint::
 
 type-check::
 	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR}.${_END}"
-	uv run ty check ${SRC_DIR} 
+	uv run ty check ${SRC_DIR}
 
 type-check-watch::
 	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
-	uv run ty check --watch ${SRC_DIR} 
+	uv run ty check --watch ${SRC_DIR}
 
 # Exists primarily for testing the contrib-% target pattern:
 ls::
@@ -143,20 +143,20 @@ ls::
 
 contrib-%::
 	for d in ${CONTRIB_DIRS}; \
-	do [[ -f $$d ]] && continue; \
+	do [ -d "$$d" ] || continue; \
 		${MAKE} SRC_DIR=$$d ${@:contrib-%=%} || exit $$?; \
 	done
 
-.PHONY: one-time-setup clean-setup 
+.PHONY: one-time-setup clean-setup
 .PHONY: install-uv uv-venv install-dev-dependencies command-check-uv
 
 setup one-time-setup:: install-uv uv-venv install-dev-dependencies
 
-install-%:: 
+install-%::
 	@cmd=${@:install-%=%} && command -v $$cmd > /dev/null && \
 		echo "${INFO}$$cmd is already installed${_END}" || ${MAKE} help-command-$$cmd
 
-uv-venv:: command-check-uv 
+uv-venv:: command-check-uv
 	@test -d .venv && echo "'.venv' already exists; not running 'uv venv'." || uv venv
 	@echo "run: 'source .venv/bin/activate' if subsequent commands fail!"
 

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,183 @@
+
+SRC_DIR      := src
+CLEAN_DIRS   := 
+CONTRIB_DIR  := contrib
+CONTRIB_DIRS = $(patsubst %/,%,$(wildcard ${CONTRIB_DIR}/*/))
+
+# Environment variables
+MAKEFLAGS     = --warn-undefined-variables
+UNAME        ?= $(shell uname)
+ARCHITECTURE ?= $(shell uname -m)
+
+# Used for version tagging release artifacts.
+GIT_HASH     ?= $(shell git show --pretty="%H" --abbrev-commit |head -1)
+NOW          ?= $(shell date +"%Y%m%d-%H%M%S")
+
+# Colors used to make some messages stand out more than others...
+RED          := \033[31m
+BOLD_RED     := \033[1;31m
+GREEN        := \033[32m
+BOLD_GREEN   := \033[1;32m
+YELLOW       := \033[33m
+BOLD_YELLOW  := \033[1;33m
+BLUE         := \033[34m
+BOLD_BLUE    := \033[1;34m
+PURPLE       := \033[35m
+BOLD_PURPLE  := \033[1;35m
+CYAN         := \033[36m
+BOLD_CYAN    := \033[1;36m
+
+ERROR        := ${BOLD_RED}ERROR:
+WARN         := ${BOLD_YELLOW}WARNING:
+NOTE         := ${BOLD_PURPLE}NOTE:
+INFO         := ${BOLD_PURPLE}
+TIP          := ${BOLD_BLUE}TIP:
+HIGHLIGHT    := ${BOLD_GREEN}
+_END         := \033[0m
+
+
+define help_message
+Quick help for this make process.
+
+make all                # Makes the 'help' and 'print-info' targets (see below). 
+make help               # Prints this output.
+make print-info         # Print the current values of some make and env. variables.
+
+Working with code:
+
+make tests              # Run the test suite.
+make clean              # Remove built artifacts, etc.
+make format             # Format the Python code with 'black'.
+make lint               # Lint the Python code by making the ruff and pylint targets.
+make ruff               # Lint the Python code with 'ruff'.
+make pylint             # Lint the Python code with 'pylint'.
+make type-check         # Type check the Python code with 'ty'.
+make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
+                        # so you can fix mistakes and keep it updating.
+make before-pr          # Make format, lint, type-check, and tests for "src" AND makes
+                        # tests in every "contrib" directory (but not the other targets...). 
+                        # DO THIS BEFORE SUBMITTING A PR!
+
+For contributed code in "contrib", any of the targets help, format, lint, ruff, pylint,
+type-check, type-check-watch, and before-pr, can be invoked by prefixing the targets
+name with "contrib-". This will run the corresponding target in all the contrib/* directories.
+
+make help-programs      # Print help on executable tools, PoCs, etc. (including "contribs").
+make help-website       # Print help for the documentation website.
+
+endef
+
+define missing_shell_command_error_message
+is needed by ${PWD}/Makefile. Try 'make help' and look at the README.
+endef
+
+
+.PHONY: all help print-info clean
+all:: help print-info
+
+help::
+	$(info ${help_message})
+	@echo
+
+help-%::
+	$(info ${help_${@:help-%=%}_message})
+	@echo
+
+clean::
+	rm -rf ${CLEAN_DIRS} 
+
+print-info::
+	@echo "source               ${SRC_DIR}"
+	@echo "tests                ${SRC_DIR}/tests"
+	@echo "current dir:         ${PWD}"
+	@echo "MAKEFLAGS:           ${MAKEFLAGS}"
+	@echo "UNAME:               ${UNAME}"
+	@echo "ARCHITECTURE:        ${ARCHITECTURE}"
+	@echo "GIT_HASH:            ${GIT_HASH}"
+	@echo "NOW:                 ${NOW}"
+
+.PHONY: tests unit-tests
+tests:: unit-tests
+
+unit-tests::
+	@echo "${INFO}Running the unit tests:${_END}"
+	@if [[ ! -d ${SRC_DIR}/tests ]]; then echo "${WARN}No test directory ${SRC_DIR}/tests found!${_END}"; \
+	else echo "cd ${SRC_DIR}; uv run python -m pytest tests -q"; \
+		cd ${SRC_DIR}; uv run python -m pytest tests -q; \
+	fi
+
+.PHONY: before-pr format ruff pylint type-check type-check-watch
+.PHONY: lint do-before-pr do-contrib-before-pr
+
+before-pr:: do-before-pr do-contrib-before-pr
+do-before-pr:: format ruff pylint type-check tests
+do-contrib-before-pr:: tests
+
+# Convenient short hand for the two linters.
+lint:: ruff pylint
+
+format::
+	@echo "${INFO}$@: Running 'black' on the code in ${SRC_DIR}.${_END}"
+	uv run black ${SRC_DIR}
+
+ruff::
+	@echo "${INFO}$@: Running 'ruff' to lint the code in ${SRC_DIR}.${_END}"
+	uv run ruff check --fix ${SRC_DIR}
+
+pylint::
+	@echo "${INFO}$@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
+	uv run pylint ${SRC_DIR}
+
+type-check::
+	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR}.${_END}"
+	uv run ty check ${SRC_DIR} 
+
+type-check-watch::
+	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
+	uv run ty check --watch ${SRC_DIR} 
+
+# Exists primarily for testing the contrib-% target pattern:
+ls::
+	@echo "${INFO}$@: Running ls -l in ${SRC_DIR}.${_END}"
+	@ls -l ${SRC_DIR}/LICENSE
+
+contrib-%::
+	for d in ${CONTRIB_DIRS}; \
+	do [[ -f $$d ]] && continue; \
+		${MAKE} SRC_DIR=$$d ${@:contrib-%=%} || exit $$?; \
+	done
+
+.PHONY: one-time-setup clean-setup 
+.PHONY: install-uv uv-venv install-dev-dependencies command-check-uv
+
+setup one-time-setup:: install-uv uv-venv install-dev-dependencies
+
+install-%:: 
+	@cmd=${@:install-%=%} && command -v $$cmd > /dev/null && \
+		echo "${INFO}$$cmd is already installed${_END}" || ${MAKE} help-command-$$cmd
+
+uv-venv:: command-check-uv 
+	@test -d .venv && echo "'.venv' already exists; not running 'uv venv'." || uv venv
+	@echo "run: 'source .venv/bin/activate' if subsequent commands fail!"
+
+install-dev-dependencies::
+	uv pip install -e ".[dev]"
+
+command-check-uv::
+	@command -v uv > /dev/null || ! ${MAKE} help-command-uv
+
+help-command-uv help-command-uvx::
+	$(info ${help-message-uv})
+	@echo
+
+define help-message-uv
+
+The Python environment management tool "uv" is required.
+See https://docs.astral.sh/uv/ for installation instructions.
+
+If you want to uninstall uv and you used HomeBrew to install it,
+use 'brew uninstall uv'. Otherwise, if you executed one of the
+installation commands on the website above, find the installation
+location and delete uv.
+
+endef

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -34,7 +34,7 @@ contrib/
 
 ## Pass the Code Quality "Gates"
 
-The top-level `Makefile` has a target `before-pr`, which we ask everyone to run before opening a pull request. 
+The top-level `Makefile` has a target `before-pr`, which we ask everyone to run before opening a pull request.
 
 ```shell
 make before-pr
@@ -62,7 +62,7 @@ make SRC_DIR=contrib/johndoe-foo format ruff pylint type-check tests
 ## Reviewer-Friendly Checklist
 
 Contributions are much easier to review, discuss, and eventually adopt when
-they are small, runnable, and explicit about their maturity. It is preferable to submit many small PRs for a single contribution. 
+they are small, runnable, and explicit about their maturity. It is preferable to submit many small PRs for a single contribution.
 
 ### Keep the Review Manageable
 
@@ -95,8 +95,8 @@ Be clear about the kind of contribution you are making:
 - **Speculative / exploratory:** a proof of concept, research sketch,
   comparison, or early experiment. These can be lightweight, but they should
   still be runnable or clearly marked as design-only.
-- **Candidate for adoption:** code that could move into the production 
-  `src/` or `examples/`, or documentation that could move to `docs`. 
+- **Candidate for adoption:** code that could move into the production
+  `src/` or `examples/`, or documentation that could move to `docs`.
   Try to minimize the follow-up work required. Code will need good test coverage
   type checking, etc.
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -27,21 +27,48 @@ A maintainer will review, discuss, and either request changes, merge for further
 contrib/
 └── <your-handle>-<topic>/
     ├── README.md      # what it is, why, status, how to try it
-    ├── LICENSE        # license for this contribution (see below)
+    ├── LICENSE        # license for this contribution (optional - see below)
+    ├── Makefile       # contains targets for running any custom executables (optional)
     └── ...            # code, notes, diagrams, data pointers, etc.
 ```
+
+## Pass the Code Quality "Gates"
+
+The top-level `Makefile` has a target `before-pr`, which we ask everyone to run before opening a pull request. 
+
+```shell
+make before-pr
+```
+
+It verifies that all existing _production_ code under `src` is properly formatted (the `Makefile`'s `format` target), lints cleanly (the `ruff` and `pylint` targets), type checks (the `type-check` target), and the tests pass (the `tests` target).
+
+Since `contrib` contributions are not necessarily production quality, the `before-pr` target currently only runs the `tests` target for each contribution. (We don't even require the contribution to have tests...) That's the minimum threshold.
+
+However, if you intend for your contribution to become part of the production code, it will eventually be necessary for all the quality checks to pass for the code, including a comprehensive test suite.
+
+You can run the targets for your contribution as follows. Let's assume your contribution is named `contrib/johndoe-foo`, then use this command _in the top-level directory_:
+
+```shell
+make SRC_DIR=contrib/johndoe-foo format ruff pylint type-check tests
+```
+
+> [!TIP]
+> Problems found while type checking often take the most time to fix, use this command to keep running the type checker as you fix issues and save the files:
+> ```shell
+> make SRC_DIR=contrib/johndoe-foo type-check-watch
+> ```
+> Exit using control-C.
 
 ## Reviewer-Friendly Checklist
 
 Contributions are much easier to review, discuss, and eventually adopt when
-they are small, runnable, and explicit about their maturity. Before opening a
-PR, check that your contribution answers the questions below.
+they are small, runnable, and explicit about their maturity. It is preferable to submit many small PRs for a single contribution. 
 
 ### Keep the Review Manageable
 
 - Prefer several focused submissions over one large PR that mixes ideas,
   experiments, data notes, and implementation changes.
-- Make the top-level `README.md` a travel guide through the contribution: what
+- Make the top-level `README.md` a "travel guide" through the contribution: what
   to read first, what to run, where the important code or data pointers live,
   and what result a reviewer should expect.
 - Keep code and documentation readable enough that another contributor can
@@ -68,40 +95,24 @@ Be clear about the kind of contribution you are making:
 - **Speculative / exploratory:** a proof of concept, research sketch,
   comparison, or early experiment. These can be lightweight, but they should
   still be runnable or clearly marked as design-only.
-- **Candidate for adoption:** functionality that could move into `src/`,
-  `examples/`, or the main documentation with modest follow-up work. These
-  should have stronger tests, clearer package boundaries, CLI help, and fewer
-  one-off assumptions.
+- **Candidate for adoption:** code that could move into the production 
+  `src/` or `examples/`, or documentation that could move to `docs`. 
+  Try to minimize the follow-up work required. Code will need good test coverage
+  type checking, etc.
 
 For code that might be adopted later, reduce integration friction:
 
-- Follow the repository's `uv` and `make` conventions where practical.
+- Follow the repository's `uv` and `make` conventions.
 - Match the package/test shape used under `src/` so the contribution can be
   moved later without many small rewrites.
 - Use `argparse` or an equivalent CLI framework for command-line tools, with
   helpful descriptions for every argument.
 - Include automated tests for behavior that Tapestry would rely on.
+- Use type annotations for (almost) everything and make sure the `type-check` target passes.
 
-### Optional Makefile Contract
+### Optional Makefile "Contract"
 
-If your contribution needs its own workflow commands, prefer a
-`contrib/<your-handle>-<topic>/Makefile` over adding specialized targets to the
-top-level `Makefile`. The root Makefile will discover contribution Makefiles
-and run these conventional targets when present:
-
-| Target | Purpose |
-| :----- | :------ |
-| `check` | Run all checks for the contribution. |
-| `tests` | Run the contribution's automated tests. |
-| `lint` | Run the contribution's lint checks. |
-| `format` | Format contribution code or docs. |
-| `type-check` | Run type checks when the contribution has typed code. |
-
-The top-level commands `make contrib-check`, `make contrib-tests`,
-`make contrib-lint`, `make contrib-format`, and `make contrib-type-check`
-delegate to those per-contribution targets. `make before-pr` also runs
-`contrib-tests`, so a contribution with a Makefile should keep its `tests`
-target reliable enough for PR validation.
+If your contribution needs its own workflow commands, include a `Makefile` in your contribution directory. For consistency with the top-level `Makefile`, begin by including `../../common.mk`. Use this `Makefile` your custom executables and build steps, but rely on the top-level `Makefile` for standard targets like `tests`, `lint`, etc.
 
 ## Contribution Policy
 
@@ -119,7 +130,7 @@ If you're unsure whether something fits, open a [Discussion](https://github.com/
 
 ### Licensing
 
-Every contribution must be clearly licensed. Unless you state otherwise (compatibly), Tapestry's default licenses apply:
+Every contribution must be clearly licensed. Unless you state otherwise, Tapestry's default licenses apply:
 
 | Content type | Default license |
 | :----------- | :-------------- |
@@ -127,9 +138,9 @@ Every contribution must be clearly licensed. Unless you state otherwise (compati
 | Documentation | [CC BY 4.0](../LICENSE.CC-BY-4.0) |
 | Data | [CDLA Permissive 2.0](../LICENSE.CDLA-2.0) |
 
-If your contribution uses a different (but compatible, permissive) license, state it explicitly in your subdirectory's `LICENSE` and `README.md`. Contributions without a clear, compatible license cannot be accepted.
+If your contribution uses a different (but compatible, permissive) license, state it explicitly in your subdirectory's `LICENSE` and `README.md`. Contributions without a clear, _compatible_ license cannot be accepted.
 
-### Copyright & Data Clearance
+### Copyright and Data Clearance
 
 By opening a PR you affirm (via DCO) that:
 
@@ -146,11 +157,11 @@ By opening a PR you affirm (via DCO) that:
 
 ### Conduct
 
-All activity here follows the [AI Alliance Code of Conduct](https://github.com/The-AI-Alliance/community/blob/main/CODE_OF_CONDUCT.md) and the policies in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+All activity here follows the [AI Alliance Code of Conduct](https://github.com/The-AI-Alliance/community/blob/main/CODE_OF_CONDUCT.md) and the policies in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ## Questions / Contacts
 
-Not sure if something fits, or want to discuss before opening a PR? Start a [GitHub Discussion](https://github.com/The-AI-Alliance/tapestry/discussions) or reach out to the maintainers:
+Not sure if something fits? Do you want to discuss an idea before opening a PR? Start a [GitHub Discussion](https://github.com/The-AI-Alliance/tapestry/discussions) or reach out to the maintainers:
 
 - **Christopher Nguyen** ([@ctn](https://github.com/ctn))
 - **Dean Wampler** ([@deanwampler](https://github.com/deanwampler))

--- a/src/tests/tapestry/training/consortium/test_consortium_training.py
+++ b/src/tests/tapestry/training/consortium/test_consortium_training.py
@@ -57,10 +57,7 @@ def test_sovereign_node_returns_artifact_and_local_model_state() -> None:
     assert result.contribution.round_num == 1
     assert result.contribution.quality_score == pytest.approx(0.82)
     assert set(result.contribution.local_model_state) == set(base_state)
-    assert any(
-        not torch.equal(result.contribution.local_model_state[name], base_state[name])
-        for name in base_state
-    )
+    assert any(not torch.equal(result.contribution.local_model_state[name], base_state[name]) for name in base_state)
 
 
 def test_contribution_policy_applies_quality_floor_and_capture_cap() -> None:


### PR DESCRIPTION
# [Update] Automatically support common `make` targets for `contrib` contributions

## Description of the PR

This PR does several things:
* Extracts most of the top-level `Makefile` into a `common.mk` that `Makefile` includes and other `Makefile`s under `contrib` can also use.
* Adds a dependency to the `before-pr` target to apply some "quality checks" to all the contributions. However, only `tests` are used, as many contributions are not yet production quality and often won't pass the `lint` or `type-check` targets.
* ... but supports easy invocation of `lint` (and its dependents, `ruff` and `pylint`), `format`, `type-check`, and `tests` on one or all contributions. 
* Modified the top-level `README.md` and `contrib/README.md` with instructions for how to use the new targets and also added content to the latter file to clarify what users should do to prepare their PRs, e.g., run `make before-pr` in the top-level directory.

## Related Issues

Related issues or PRs: #105 

## If Code Changes Are Included

### Description of Code Changes

Provide an overview of the most important details about the changes:

* `Makefile` and new `common.mk` modified as described above.

### Testing Performed

Describe key aspects of automated and/or manual testing of executable code that was performed to validate the changes:

* Manually tested the new make targets.

### Example Usage

Before submitting a PR:

```shell
make before-pr  # makes format, lint (actually ruff and pylint), type-check, tests under src and the contrib/*/src directories.
```

Run the `lint` target on all the contributions (works the same for the other quality targets):

```shell
make contrib-lint
```

Run the `lint` target on just the `contrib/johndoc-foo` contribution (works the same for the other quality targets):

```shell
make SRC_DIR=contrib/johndoc-foo lint
```

## Checklist

Confirm that the following have been completed.

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

Ignore (or delete) any of the following check list sections or items that aren't applicable, like the code-related check list items when this is a documentation-only PR:

For code changes:

- [x] I have tested the code changes in my local development environment.
- [ ] I have added or modified tests for all code changes.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation.

For documentation changes, including `docs`:

- [x] I have followed the existing documentation styles and conventions.
- [ ] I have included helpful diagrams, screenshots, tables, etc.
