### PR TITLE
Fix contrib make portability issues

### DIFF
--- a/.github/workflows/collect_metrics.yaml
+++ b/.github/workflows/collect_metrics.yaml
@@ -1,92 +1,92 @@
-name: Collect Repo Metrics and Upload to S3  
-  
-on:  
-  workflow_dispatch: # Allows manual triggering  
-  schedule:  
-    - cron: '0 0 * * *' # Run daily at 5 AM UTC  
-  
-jobs:  
-  collect-and-upload-metrics:  
+name: Collect Repo Metrics and Upload to S3
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: '0 0 * * *' # Run daily at 5 AM UTC
+
+jobs:
+  collect-and-upload-metrics:
     # Disable the workflow, because started failing regularly in early 2026
     # for reasons we were unable to diagnose!
-    if: false  
-    runs-on: ubuntu-latest  
-    permissions:  
-      contents: read  # Read repo content (needed for repo object)  
-  
-    steps:  
-      - name: Checkout code  
-        uses: actions/checkout@v7  
-  
-      - name: Set up Python  
-        uses: actions/setup-python@v6  
-        with:  
-          python-version: '3.10' # Or your preferred version  
-  
-      - name: Install dependencies  
-        run: pip install PyGithub pandas pyarrow  
-  
-      # --- Configure AWS Credentials ---  
-      # Recommended: Use OpenID Connect (OIDC) if your AWS setup supports it.  
-      # Requires setting up a trust relationship in AWS IAM.  
-      # See: https://github.com/aws-actions/configure-aws-credentials#configure-aws-credentials-action-for-github-actions  
-      # - name: Configure AWS Credentials (OIDC)  
-      #   uses: aws-actions/configure-aws-credentials@v6  
-      #   with:  
-      #     role-to-assume: arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:role/YOUR_GITHUB_ACTIONS_ROLE # Replace with your IAM role ARN  
-      #     aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1  
-  
-      # Alternative: Use Access Keys (Store as GitHub Secrets)  
-      - name: Configure AWS Credentials (Access Keys)  
-        uses: aws-actions/configure-aws-credentials@v6  
-        with:  
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}  
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}  
-          aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1  
-  
-      # --- Run Python Script to Generate Parquet ---  
-      - name: Run metrics collection script  
-        id: collect_metrics # Give the step an id to potentially reference output later if needed  
-        env:  
-          GITHUB_TOKEN: ${{ secrets.SPECIAL_GH_TOKEN }} # Use the default action token  
-          # GITHUB_REPOSITORY is automatically set by the runner  
-        run: python .github/scripts/collect_metrics.py # Assuming your script is named this  
-  
-      # --- Upload Parquet File to S3 ---  
-      - name: Upload Parquet to S3  
-        env:  
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}  
-          # GITHUB_REPOSITORY format is 'owner/repo'  
-          SOURCE_FILE_PATTERN: "github_metrics_*.parquet" # Pattern from the python script  
-          S3_DESTINATION_FILENAME: "blob.parquet"  
+    if: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Read repo content (needed for repo object)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10' # Or your preferred version
+
+      - name: Install dependencies
+        run: pip install PyGithub pandas pyarrow
+
+      # --- Configure AWS Credentials ---
+      # Recommended: Use OpenID Connect (OIDC) if your AWS setup supports it.
+      # Requires setting up a trust relationship in AWS IAM.
+      # See: https://github.com/aws-actions/configure-aws-credentials#configure-aws-credentials-action-for-github-actions
+      # - name: Configure AWS Credentials (OIDC)
+      #   uses: aws-actions/configure-aws-credentials@v6
+      #   with:
+      #     role-to-assume: arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:role/YOUR_GITHUB_ACTIONS_ROLE # Replace with your IAM role ARN
+      #     aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1
+
+      # Alternative: Use Access Keys (Store as GitHub Secrets)
+      - name: Configure AWS Credentials (Access Keys)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }} # e.g., us-east-1
+
+      # --- Run Python Script to Generate Parquet ---
+      - name: Run metrics collection script
+        id: collect_metrics # Give the step an id to potentially reference output later if needed
+        env:
+          GITHUB_TOKEN: ${{ secrets.SPECIAL_GH_TOKEN }} # Use the default action token
+          # GITHUB_REPOSITORY is automatically set by the runner
+        run: python .github/scripts/collect_metrics.py # Assuming your script is named this
+
+      # --- Upload Parquet File to S3 ---
+      - name: Upload Parquet to S3
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          # GITHUB_REPOSITORY format is 'owner/repo'
+          SOURCE_FILE_PATTERN: "github_metrics_*.parquet" # Pattern from the python script
+          S3_DESTINATION_FILENAME: "blob.parquet"
         run: |
-          # Check if source file exists  
-          if ! ls $SOURCE_FILE_PATTERN 1> /dev/null 2>&1; then  
-            echo "Error: No parquet file matching '$SOURCE_FILE_PATTERN' found."  
-            exit 1  
-          fi  
-          # Assume only one file matches the pattern from the script run  
-          SOURCE_FILE=$(ls $SOURCE_FILE_PATTERN)  
-  
-          # Format repository name for S3 path (replace '/' with '-')  
-          # Adjust sed expression if your repo names need different handling  
-          REPOSITORY_NAME_FORMATTED=$(echo "${{ github.repository }}" | sed 's/\//-/g')  
-  
-          # Get current date in YYYY-MM-DD format  
-          CURRENT_DATE=$(date +%Y-%m-%d)  
-  
-          # Construct the S3 destination path  
-          S3_PATH="s3://${AWS_S3_BUCKET}/service=github/repository=${REPOSITORY_NAME_FORMATTED}/date=${CURRENT_DATE}/${S3_DESTINATION_FILENAME}"  
-  
-          echo "Uploading '$SOURCE_FILE' to '$S3_PATH'..."  
-          aws s3 cp "$SOURCE_FILE" "$S3_PATH"  
-          echo "Upload to S3 complete."  
-  
-      # --- Optional: Upload Parquet artifact to GitHub Actions ---  
-      # Useful for debugging or if you need the file directly from the Actions run  
-      - name: Upload Parquet artifact (Optional)  
-        if: always() # Run even if S3 upload fails, for debugging  
-        uses: actions/upload-artifact@v7  
-        with:  
-          name: github-metrics-parquet  
-          path: github_metrics_*.parquet # Upload the generated parquet file  
+          # Check if source file exists
+          if ! ls $SOURCE_FILE_PATTERN 1> /dev/null 2>&1; then
+            echo "Error: No parquet file matching '$SOURCE_FILE_PATTERN' found."
+            exit 1
+          fi
+          # Assume only one file matches the pattern from the script run
+          SOURCE_FILE=$(ls $SOURCE_FILE_PATTERN)
+
+          # Format repository name for S3 path (replace '/' with '-')
+          # Adjust sed expression if your repo names need different handling
+          REPOSITORY_NAME_FORMATTED=$(echo "${{ github.repository }}" | sed 's/\//-/g')
+
+          # Get current date in YYYY-MM-DD format
+          CURRENT_DATE=$(date +%Y-%m-%d)
+
+          # Construct the S3 destination path
+          S3_PATH="s3://${AWS_S3_BUCKET}/service=github/repository=${REPOSITORY_NAME_FORMATTED}/date=${CURRENT_DATE}/${S3_DESTINATION_FILENAME}"
+
+          echo "Uploading '$SOURCE_FILE' to '$S3_PATH'..."
+          aws s3 cp "$SOURCE_FILE" "$S3_PATH"
+          echo "Upload to S3 complete."
+
+      # --- Optional: Upload Parquet artifact to GitHub Actions ---
+      # Useful for debugging or if you need the file directly from the Actions run
+      - name: Upload Parquet artifact (Optional)
+        if: always() # Run even if S3 upload fails, for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: github-metrics-parquet
+          path: github_metrics_*.parquet # Upload the generated parquet file

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Project Tapestry has big plans, and we're starting with some fundamental buildin
 
 > [!NOTE]
 > Make sure to read [**Getting Involved**](#getting-involved-anchor) below for information on contribution guidelines, etc.
-> 
+>
 > We use the [`develop`](https://github.com/The-AI-Alliance/tapestry/tree/develop) branch as our default (integration) branch, reserving `main` for occasional "baked" releases.
 
 ### Working with the Source Code
@@ -50,7 +50,7 @@ The technical documentation lives under [**`docs`**](docs/README.md). This is wh
 * [**Architecture**](docs/architecture/README.md)
 	* The _TVA methodology_: phased outputs (stakeholder map through design goals), architectural options and core thesis, plus:
 		* [**Architecture Decision Records**](docs/architecture/decisions/)
-		* [**Diagrams**](docs/architecture/diagrams/) 
+		* [**Diagrams**](docs/architecture/diagrams/)
 * [**Governance**](docs/governance/)
 * [**Strategic Plan**](docs/strategic-plan/)
 * [**Reference Materials**](docs/reference/) (e.g. [**training paradigms**](docs/reference/training-approaches.md))
@@ -183,7 +183,7 @@ Before submitting a PR, please run the format, lint, and type checking commands,
 make before-pr  # Equivalent to 'make format lint type-check tests contrib-tests'
 ```
 
-This ensures that the _production_ code under `src` is properly formatted, linted, type checked, and the tests pass (and stays that way, even if you aren't working on it with your PR...), and it also ensures that all the `contrib` contribution tests pass. 
+This ensures that the _production_ code under `src` is properly formatted, linted, type checked, and the tests pass (and stays that way, even if you aren't working on it with your PR...), and it also ensures that all the `contrib` contribution tests pass.
 
 Note that since contributions are often quick PoCs, we don't run the `format`, `lint`, and `type-check` targets on them. However, you can run these targets on one or more contributions as follows. Let's use `contrib/foo` and target `format` as an example:
 
@@ -222,7 +222,7 @@ tapestry/
 
 ## Getting Involved
 
-We welcome contributions as [pull requests](https://github.com/The-AI-Alliance/tapestry/pulls), [issues](https://github.com/The-AI-Alliance/tapestry/issues), and [discussions](https://github.com/The-AI-Alliance/tapestry/discussions). 
+We welcome contributions as [pull requests](https://github.com/The-AI-Alliance/tapestry/pulls), [issues](https://github.com/The-AI-Alliance/tapestry/issues), and [discussions](https://github.com/The-AI-Alliance/tapestry/discussions).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. In particular, [read this section](CONTRIBUTING.md#developer-certificate-of-origin-dco) on using _DCO_ with any commits.
 

--- a/common.mk
+++ b/common.mk
@@ -1,8 +1,8 @@
 
 SRC_DIR      := src
-CLEAN_DIRS   := 
+CLEAN_DIRS   :=
 CONTRIB_DIR  := contrib
-CONTRIB_DIRS = $(patsubst %/,%,$(wildcard ${CONTRIB_DIR}/*/))
+CONTRIB_DIRS = $(patsubst %/.,%,$(wildcard ${CONTRIB_DIR}/*/.))
 
 # Environment variables
 MAKEFLAGS     = --warn-undefined-variables
@@ -39,7 +39,7 @@ _END         := \033[0m
 define help_message
 Quick help for this make process.
 
-make all                # Makes the 'help' and 'print-info' targets (see below). 
+make all                # Makes the 'help' and 'print-info' targets (see below).
 make help               # Prints this output.
 make print-info         # Print the current values of some make and env. variables.
 
@@ -55,7 +55,7 @@ make type-check         # Type check the Python code with 'ty'.
 make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
                         # so you can fix mistakes and keep it updating.
 make before-pr          # Make format, lint, type-check, and tests for "src" AND makes
-                        # tests in every "contrib" directory (but not the other targets...). 
+                        # tests in every "contrib" directory (but not the other targets...).
                         # DO THIS BEFORE SUBMITTING A PR!
 
 For contributed code in "contrib", any of the targets help, format, lint, ruff, pylint,
@@ -84,7 +84,7 @@ help-%::
 	@echo
 
 clean::
-	rm -rf ${CLEAN_DIRS} 
+	rm -rf ${CLEAN_DIRS}
 
 print-info::
 	@echo "source               ${SRC_DIR}"
@@ -101,7 +101,7 @@ tests:: unit-tests
 
 unit-tests::
 	@echo "${INFO}Running the unit tests in ${SRC_DIR}/tests:${_END}"
-	@if [[ ! -d ${SRC_DIR}/tests ]]; then echo "${WARN}No test directory ${SRC_DIR}/tests found!${_END}"; \
+	@if [ ! -d "${SRC_DIR}/tests" ]; then echo "${WARN}No test directory ${SRC_DIR}/tests found!${_END}"; \
 	else echo "cd ${SRC_DIR}; uv run python -m pytest tests -q"; \
 		cd ${SRC_DIR}; uv run python -m pytest tests -q; \
 	fi
@@ -130,11 +130,11 @@ pylint::
 
 type-check::
 	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR}.${_END}"
-	uv run ty check ${SRC_DIR} 
+	uv run ty check ${SRC_DIR}
 
 type-check-watch::
 	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
-	uv run ty check --watch ${SRC_DIR} 
+	uv run ty check --watch ${SRC_DIR}
 
 # Exists primarily for testing the contrib-% target pattern:
 ls::
@@ -143,20 +143,20 @@ ls::
 
 contrib-%::
 	for d in ${CONTRIB_DIRS}; \
-	do [[ -f $$d ]] && continue; \
+	do [ -d "$$d" ] || continue; \
 		${MAKE} SRC_DIR=$$d ${@:contrib-%=%} || exit $$?; \
 	done
 
-.PHONY: one-time-setup clean-setup 
+.PHONY: one-time-setup clean-setup
 .PHONY: install-uv uv-venv install-dev-dependencies command-check-uv
 
 setup one-time-setup:: install-uv uv-venv install-dev-dependencies
 
-install-%:: 
+install-%::
 	@cmd=${@:install-%=%} && command -v $$cmd > /dev/null && \
 		echo "${INFO}$$cmd is already installed${_END}" || ${MAKE} help-command-$$cmd
 
-uv-venv:: command-check-uv 
+uv-venv:: command-check-uv
 	@test -d .venv && echo "'.venv' already exists; not running 'uv venv'." || uv venv
 	@echo "run: 'source .venv/bin/activate' if subsequent commands fail!"
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -34,7 +34,7 @@ contrib/
 
 ## Pass the Code Quality "Gates"
 
-The top-level `Makefile` has a target `before-pr`, which we ask everyone to run before opening a pull request. 
+The top-level `Makefile` has a target `before-pr`, which we ask everyone to run before opening a pull request.
 
 ```shell
 make before-pr
@@ -62,7 +62,7 @@ make SRC_DIR=contrib/johndoe-foo format ruff pylint type-check tests
 ## Reviewer-Friendly Checklist
 
 Contributions are much easier to review, discuss, and eventually adopt when
-they are small, runnable, and explicit about their maturity. It is preferable to submit many small PRs for a single contribution. 
+they are small, runnable, and explicit about their maturity. It is preferable to submit many small PRs for a single contribution.
 
 ### Keep the Review Manageable
 
@@ -95,8 +95,8 @@ Be clear about the kind of contribution you are making:
 - **Speculative / exploratory:** a proof of concept, research sketch,
   comparison, or early experiment. These can be lightweight, but they should
   still be runnable or clearly marked as design-only.
-- **Candidate for adoption:** code that could move into the production 
-  `src/` or `examples/`, or documentation that could move to `docs`. 
+- **Candidate for adoption:** code that could move into the production
+  `src/` or `examples/`, or documentation that could move to `docs`.
   Try to minimize the follow-up work required. Code will need good test coverage
   type checking, etc.
 


### PR DESCRIPTION
## Summary

- make contrib target iteration directory-only so files like `contrib/README.md` are not included
- replace Bash-style `[[ ... ]]` checks in shared Make recipes with POSIX-compatible `[ ... ]`
- remove trailing whitespace reported by `git diff --check`

## Testing

- `git diff --check`
- `git diff --check review-123..HEAD`
- `make -n contrib-tests`
- `make SRC_DIR=contrib/oli-sovereign-eval-evidence tests`
- `make help-programs`

Related to #123.
