### PR TITLE
[New Contribution] Flower WAN weight-transfer spike (#70 de-risk)

### DIFF
--- a/contrib/jneums-flower-wan-spike/LICENSE
+++ b/contrib/jneums-flower-wan-spike/LICENSE
@@ -1,0 +1,5 @@
+This contribution follows the repository default licenses:
+
+- Code: Apache License, Version 2.0. See ../../LICENSE.Apache-2.0.
+- Documentation: Creative Commons Attribution 4.0 International. See ../../LICENSE.CC-BY-4.0.
+- Data, if added later: CDLA Permissive 2.0. See ../../LICENSE.CDLA-2.0.

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -5,6 +5,21 @@ epic: **can a ~2B-parameter model's weights round-trip through a Flower SuperLin
 real WAN, and how long does a round take?** This measures transport only — the "training"
 node echoes the weights back unchanged.
 
+## Bottom line
+
+**Flower's transport is not a performance concern for this epic.** On a healthy ~100 ms
+WAN path, stock flwr 1.32.1 moves weights within ~15 % of raw single-stream TCP in both
+directions with no tuning — **a 2B-parameter (4 GB each way) exchange costs ~10 minutes
+per round** ([field re-run](#field-re-run-2026-07-03-fresh-box-pair)). That comfortably
+supports DiLoCo-cadence sync and is workable even for frequent-sync patterns.
+
+The initial spike measured much worse (~1.5 h per 2B round) — that turned out to be a
+**degraded network path on the first box pair, not Flower**: the identical setup on a
+fresh pair, plus a local latency-simulation A/B, showed gRPC's flow-control auto-tuning
+normally handles high-RTT paths fine. The sections below keep the full investigation
+record, including the optional `patch_lookahead.py` hardening that pins throughput at the
+raw-TCP limit and protects against paths where that auto-tuning fails.
+
 ## Design
 
 - **Payload**: 2,000,000,000 parameters in float16 = **4.0 GB** each direction, split into
@@ -16,11 +31,16 @@ node echoes the weights back unchanged.
   single-node FedAvg round; the client echoes it back; FedAvg aggregates (N=1 identity).
 - **NumPy-only** app: node setup is `pip install flwr numpy`, no torch.
 
-## Results
+## Initial results (first box pair — timings later attributed to a degraded path)
 
 WAN topology used: SuperLink + ServerApp on a Quebec (CA) vast.ai instance, SuperNode +
 ClientApp on a Sweden (SE) instance. Measured path RTT ≈ 106 ms; raw single-stream TCP on
 the same path: 114 Mbit/s (QC→SE), 167 Mbit/s (SE→QC).
+
+> **Note:** the WAN timings in this section did not reproduce on a fresh box pair (see
+> [field re-run](#field-re-run-2026-07-03-fresh-box-pair)) — they characterize that
+> specific path, not Flower. The functional results (payload integrity at 4 GB per
+> direction) stand.
 
 | leg | payload | round-trip (1 round) | effective throughput* |
 | :-- | :-- | :-- | :-- |
@@ -40,16 +60,17 @@ Flower's object store/serialization path, not bandwidth, is the first ceiling. F
 outer loops (sync every ~500+ inner steps) a couple of minutes per exchange is comfortably
 affordable; for frequent-sync patterns it would dominate.
 
-**WAN finding (the important one):** the WAN round is dominated by Flower's object
-transfer layer, not the network. Per-leg reconstruction of the 0.5 GB round: server→node
+**WAN finding (superseded — see field re-run):** on this pair the WAN round ran far below
+the path's raw TCP capacity. Per-leg reconstruction of the 0.5 GB round: server→node
 delivery ran at ~47 Mbit/s (~2.4× below raw TCP on that path), but the node→server **push
 of the reply ran at ~7.5 Mbit/s — ~20× below raw TCP** (167 Mbit/s measured with a plain
 socket seconds later on the same path). The rate corresponds to only ~100 KB in flight
 per 106 ms round trip — a small effective window somewhere in the push path.
 
 The 4.0 GB round scales linearly from the 0.5 GB one (~12.7 vs ~13 Mbit/s effective), so
-the overhead is proportional to bytes moved, not a fixed per-round cost: **a 2B-param
-model exchange on this path costs ~1.5 h per round as shipped.** Arrays are split into
+the overhead is proportional to bytes moved, not a fixed per-round cost: a 2B-param
+model exchange cost ~1.5 h per round *on this pair's path* (a healthy path costs ~10 min —
+see the field re-run). Arrays are split into
 5 MB chunk objects (`FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE`); raising the chunk size 13×
 did not change the round time (table below), so the cost is *per byte in flight*, not
 per chunk boundary — consistent with a small effective in-flight window on the 106 ms
@@ -75,9 +96,10 @@ defeating the auto-tuning — but forcing a large window removes the dependence 
 probing behaving. Flower's channel construction (`flwr/supercore/grpc.py`) sets only
 message-length options, and the window option is not operator-configurable.
 
-**Patch results** (fresh Quebec↔Norway pair, 97 ms RTT; `patch_lookahead.py` in this
-directory adds `("grpc.http2.lookahead_bytes", 16 MB)` to Flower's client channels and
-server options; unpatched same-pair baseline 8 min 13 s for 0.5 GB ×2):
+**Patch results on the original spike's second pair** (Quebec↔Norway, 97 ms RTT — still
+the degraded-path regime; `patch_lookahead.py` in this directory adds
+`("grpc.http2.lookahead_bytes", 16 MB)` to Flower's client channels and server options;
+unpatched same-pair baseline 8 min 13 s for 0.5 GB ×2):
 
 - **Pull leg (SuperLink→node) is reliably fixed**: ~47 Mbit/s unpatched →
   **~90–128 Mbit/s patched**, reproduced across three runs including 4 GB — near raw
@@ -109,10 +131,12 @@ Implications for the epic:
 - **Cost with the patch**: pins the SuperLink→node direction at the raw-TCP limit
   (field-verified) and defends both legs against paths where gRPC's window auto-tuning
   fails (simulation below: push 73→218 Mbit/s with auto-tuning disabled).
-- No matching issue exists in the Flower tracker (checked 2026-07-03) — the right upstream
-  ask is "make the HTTP/2 window options configurable on SuperLink/SuperNode", backed by
-  these numbers and the simulation A/B; until it ships, apply `patch_lookahead.py` on
-  every host (SuperLink and SuperNodes) and check the daemon logs for the patch banner.
+- The patch is **optional hardening, not a requirement**: healthy paths need nothing. For
+  sovereign nodes on links of unknown quality, apply `patch_lookahead.py` on every host
+  (SuperLink and SuperNodes) and check the daemon logs for the patch banner. A low-priority
+  upstream feature request ("expose HTTP/2 window options as SuperLink/SuperNode config")
+  would make this unnecessary; no matching issue exists in the Flower tracker as of
+  2026-07-03.
 - Channel-level gzip compression would not help: weights are near-incompressible and the
   bottleneck is flow-control round trips, not bytes.
 

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -1,0 +1,82 @@
+# Flower WAN Weight-Transfer Spike
+
+De-risk spike for the [issue #70](https://github.com/The-AI-Alliance/tapestry/issues/70)
+epic: **can a ~2B-parameter model's weights round-trip through a Flower SuperLink over a
+real WAN, and how long does a round take?** This measures transport only — the "training"
+node echoes the weights back unchanged.
+
+## Design
+
+- **Payload**: 2,000,000,000 parameters in float16 = **4.0 GB** each direction, split into
+  80 × 50 MB tensors (like a real model's layer tensors; each message object stays far below
+  gRPC size limits). float16 stands in for bfloat16 — NumPy has no bf16; wire size is identical.
+  Values are random so transparent compression can't flatter the numbers.
+- **Topology**: SuperLink + ServerApp on one host (the "central node"), one SuperNode +
+  ClientApp on another (a "sovereign node"). The ServerApp sends the payload via a
+  single-node FedAvg round; the client echoes it back; FedAvg aggregates (N=1 identity).
+- **NumPy-only** app: node setup is `pip install flwr numpy`, no torch.
+
+## Results
+
+| leg | payload | round-trip (1 round) | effective throughput* |
+| :-- | :-- | :-- | :-- |
+| loopback (WSL2, same host) | 0.5 GB ×2 | 20.5 s | ~0.39 Gbit/s |
+| loopback (WSL2, same host) | 4.0 GB ×2 | 138.1 s | ~0.46 Gbit/s |
+| WAN (two vast.ai datacenters) | 4.0 GB ×2 | _pending_ | _pending_ |
+
+\* total bytes moved ÷ round time; includes flwr's serialization and store-and-forward
+through the SuperLink object store, so this is *system* throughput, not link speed.
+
+**Loopback finding:** even with no real network, the stack tops out around ~0.5 Gbit/s —
+Flower's object store/serialization path, not bandwidth, is the first ceiling. For DiLoCo-class
+outer loops (sync every ~500+ inner steps) a couple of minutes per exchange is comfortably
+affordable; for frequent-sync patterns it would dominate.
+
+## Gotchas found (flwr 1.32)
+
+- `FedAvg` defaults to `min_train_nodes=2` / `min_available_nodes=2`; with one node,
+  `strategy.start` waits forever with no message. Set them to 1 for a single-node spike.
+- ClientApp/ServerApp `print` output is block-buffered before it reaches `flwr run --stream`;
+  use `flush=True`.
+- `MetricRecord` values must be numeric — a string value fails the whole client reply.
+
+## Reproducing
+
+Environment (both hosts): Python ≥3.10, `pip install "flwr>=1.32,<1.33" numpy`, plus this
+app installed (`pip install -e .`) wherever the SuperNode and SuperLink run.
+
+Central node:
+
+```shell
+flower-superlink --insecure   # control API :9093, fleet API :9092
+```
+
+Sovereign node:
+
+```shell
+flower-supernode --insecure --superlink <central-host>:9092
+```
+
+Driver (any machine that can reach the control API) — add to `~/.flwr/config.toml`:
+
+```toml
+[superlink.spike]
+address = "<central-host>:9093"
+insecure = true
+```
+
+then, from this directory:
+
+```shell
+flwr run . spike --stream
+# smaller payload: flwr run . spike --run-config "payload-params=250000000" --stream
+```
+
+`--insecure` is acceptable for this throwaway spike on random weights; a real deployment
+uses TLS + SuperNode auth (both built into Flower).
+
+## Scope
+
+This spike informs the "Flower as connectivity layer" recommendation on #70. It does not
+test training, aggregation quality, node failure, or TLS — only that the epic's weight
+payload fits through the pipe and what a round costs.

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -18,11 +18,16 @@ node echoes the weights back unchanged.
 
 ## Results
 
+WAN topology used: SuperLink + ServerApp on a Quebec (CA) vast.ai instance, SuperNode +
+ClientApp on a Sweden (SE) instance. Measured path RTT ≈ 106 ms; raw single-stream TCP on
+the same path: 114 Mbit/s (QC→SE), 167 Mbit/s (SE→QC).
+
 | leg | payload | round-trip (1 round) | effective throughput* |
 | :-- | :-- | :-- | :-- |
 | loopback (WSL2, same host) | 0.5 GB ×2 | 20.5 s | ~0.39 Gbit/s |
 | loopback (WSL2, same host) | 4.0 GB ×2 | 138.1 s | ~0.46 Gbit/s |
-| WAN (two vast.ai datacenters) | 4.0 GB ×2 | _pending_ | _pending_ |
+| WAN Quebec↔Sweden | 0.5 GB ×2 | 10 min 30 s | ~13 Mbit/s |
+| WAN Quebec↔Sweden | 4.0 GB ×2 | 1 h 24 min | ~12.7 Mbit/s |
 
 \* total bytes moved ÷ round time; includes flwr's serialization and store-and-forward
 through the SuperLink object store, so this is *system* throughput, not link speed.
@@ -32,6 +37,49 @@ Flower's object store/serialization path, not bandwidth, is the first ceiling. F
 outer loops (sync every ~500+ inner steps) a couple of minutes per exchange is comfortably
 affordable; for frequent-sync patterns it would dominate.
 
+**WAN finding (the important one):** the WAN round is dominated by Flower's object
+transfer layer, not the network. Per-leg reconstruction of the 0.5 GB round: server→node
+delivery ran at ~47 Mbit/s (~2.4× below raw TCP on that path), but the node→server **push
+of the reply ran at ~7.5 Mbit/s — ~20× below raw TCP** (167 Mbit/s measured with a plain
+socket seconds later on the same path). The rate corresponds to only ~100 KB in flight
+per 106 ms round trip — a small effective window somewhere in the push path.
+
+The 4.0 GB round scales linearly from the 0.5 GB one (~12.7 vs ~13 Mbit/s effective), so
+the overhead is proportional to bytes moved, not a fixed per-round cost: **a 2B-param
+model exchange on this path costs ~1.5 h per round as shipped.** Arrays are split into
+5 MB chunk objects (`FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE`); raising the chunk size 13×
+did not change the round time (table below), so the cost is *per byte in flight*, not
+per chunk boundary — consistent with a small effective in-flight window on the 106 ms
+path rather than chunk-setup overhead.
+
+**Knob A/B tests** (0.5 GB payload, same path, both daemons restarted with the env
+override each time; baseline 10 min 30 s):
+
+| variant | round-trip | conclusion |
+| :-- | :-- | :-- |
+| `FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE` 5 MB → 64 MB | 10 min 21 s | no effect — chunk granularity is not the bottleneck |
+| + `FLWR_PRIVATE_MAX_CONCURRENT_OBJ_{PUSHES,PULLS}` 2 → 16 | 12 min 42 s | no effect — parallel streams over one connection don't help |
+
+(Env vars verified present in the running SuperNode's `/proc/<pid>/environ`.)
+
+**Diagnosis.** Both operator-accessible knobs are exonerated, and the measured ~100 KB
+in flight per RTT matches gRPC's default HTTP/2 flow-control window (64 KB initial,
+applied per connection — which is also why 16 concurrent streams changed nothing).
+The fix lives in Flower's channel construction (HTTP/2 window options / BDP probing),
+which is not operator-configurable in flwr 1.32.
+
+Implications for the epic:
+
+- **Functionally proven**: a 2B-param payload round-trips intact through SuperLink over
+  a real WAN; no message-size or memory failures at 4 GB per direction.
+- **Cost as shipped**: ~1.5 h per 2B exchange on a 106 ms path. DiLoCo-cadence sync
+  (hundreds of inner steps per outer round) absorbs this; frequent-sync patterns cannot.
+- The ~20× gap below raw TCP is Flower-specific (flwr 1.32.1; no matching issue found in
+  the Flower tracker as of 2026-07-03) and worth raising upstream with these numbers —
+  it should be a small fix (channel options) for a large win.
+- Channel-level gzip compression would not help: weights are near-incompressible and the
+  bottleneck is flow-control round trips, not bytes.
+
 ## Gotchas found (flwr 1.32)
 
 - `FedAvg` defaults to `min_train_nodes=2` / `min_available_nodes=2`; with one node,
@@ -39,6 +87,11 @@ affordable; for frequent-sync patterns it would dominate.
 - ClientApp/ServerApp `print` output is block-buffered before it reaches `flwr run --stream`;
   use `flush=True`.
 - `MetricRecord` values must be numeric — a string value fails the whole client reply.
+- If the SuperLink becomes unreachable, the SuperNode retries briefly and then **exits**
+  rather than backing off indefinitely; node-side supervision (systemd restart or similar)
+  is required for unattended sovereign nodes.
+- flwr ≥1.31 requires Python ≥3.11 (common GPU images still ship 3.10; `uv venv --python 3.12`
+  is a quick fix).
 
 ## Reproducing
 

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -65,13 +65,15 @@ override each time; baseline 10 min 30 s):
 
 (Env vars verified present in the running SuperNode's `/proc/<pid>/environ`.)
 
-**Root cause class — confirmed; fix verified for one direction.** The measured
-~100 KB in flight per RTT matches gRPC C-core's per-stream read-ahead limit,
+**Root cause class — confirmed.** The measured ~100 KB in flight per RTT matches gRPC
+C-core's per-stream read-ahead limit,
 [`grpc.http2.lookahead_bytes`](https://grpc.github.io/grpc/core/group__grpc__arg__keys.html)
 (`GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES`, default 64 KB) — documented as the knob to
-raise "on high-latency connections." Flower's channel construction
-(`flwr/supercore/grpc.py`) sets only message-length options, so it runs the 64 KB
-default, and the option is not operator-configurable.
+raise "on high-latency connections." gRPC normally outgrows that default on its own via
+BDP probing (verified in the simulation section below), so the field path was also
+defeating the auto-tuning — but forcing a large window removes the dependence on BDP
+probing behaving. Flower's channel construction (`flwr/supercore/grpc.py`) sets only
+message-length options, and the window option is not operator-configurable.
 
 **Patch results** (fresh Quebec↔Norway pair, 97 ms RTT; `patch_lookahead.py` in this
 directory adds `("grpc.http2.lookahead_bytes", 16 MB)` to Flower's client channels and
@@ -81,13 +83,15 @@ server options; unpatched same-pair baseline 8 min 13 s for 0.5 GB ×2):
   **~90–128 Mbit/s patched**, reproduced across three runs including 4 GB — near raw
   single-stream TCP for the path. Consistent with flow-control mechanics: the pull
   receiver is the patched *client channel*.
-- **Push leg (node→SuperLink) is NOT fixed by the channel arg**: ~10–16 Mbit/s in every
+- **Push leg (node→SuperLink) was NOT fixed in the field runs**: ~10–16 Mbit/s in every
   steady-state run, patched or not (4 GB patched round: 1 h 1 m, vs 1 h 24 m unpatched).
-  The push receiver is Flower's gRPC *server*; the equivalent server-side receive-window
-  fix needs to happen inside Flower/gRPC-core (or the object push path needs streaming/
-  multiple connections). Also ruled out for the push leg: chunk size, app-level transfer
-  concurrency, connection age (fresh-SuperNode rerun), and SuperLink state (fresh-SuperLink
-  rerun).
+  At the time we concluded the server-side receive window couldn't be set from outside
+  gRPC-core — **the local-simulation follow-up below overturned that conclusion**: the
+  same option on the *server* does govern the push leg. The most likely field explanation
+  is that the SuperLink process was not actually running the patched module (the original
+  patch had no runtime verification; it now logs a banner at import). Also ruled out for
+  the push leg: chunk size, app-level transfer concurrency, connection age
+  (fresh-SuperNode rerun), and SuperLink state (fresh-SuperLink rerun).
 - One 0.5 GB patched run completed in 78 s (~103 Mbit/s both legs) but did **not
   reproduce** under identical fresh-restart conditions (6–9 min in three attempts).
   Possible object-store dedup effect (the echo payload's content hashes match objects the
@@ -100,14 +104,59 @@ Implications for the epic:
   a real WAN; no message-size or memory failures at 4 GB per direction.
 - **Cost as shipped**: ~1.5 h per 2B exchange on a ~100 ms path (flwr 1.32.1 defaults).
   DiLoCo-cadence sync absorbs this; frequent-sync patterns cannot.
-- **Cost with the 2-line client-side fix**: the SuperLink→node direction becomes
-  raw-TCP-limited (2–3× on our path); the node→SuperLink push still needs an upstream
-  server-side fix, and it dominates the round (patched 4 GB round: 1 h 1 m).
-- No matching issue exists in the Flower tracker (checked 2026-07-03) — file upstream
-  with these numbers, the patch, and the open push-leg question; until it ships, nodes
-  can apply `patch_lookahead.py` for the pull-leg win.
+- **Cost with the patch**: the SuperLink→node direction becomes raw-TCP-limited (2–3× on
+  our path, field-verified). Per the local simulation below, the same patch applied on the
+  SuperLink fixes the node→SuperLink push too (73→218 Mbit/s in the sim); the field push
+  numbers predate the verifiable patch and need one re-run to confirm.
+- No matching issue exists in the Flower tracker (checked 2026-07-03) — the right upstream
+  ask is "make the HTTP/2 window options configurable on SuperLink/SuperNode", backed by
+  these numbers and the simulation A/B; until it ships, apply `patch_lookahead.py` on
+  every host (SuperLink and SuperNodes) and check the daemon logs for the patch banner.
 - Channel-level gzip compression would not help: weights are near-incompressible and the
   bottleneck is flow-control round trips, not bytes.
+
+## Follow-up: local WAN simulation (2026-07-03)
+
+The field boxes were gone, so to dig further we rebuilt the conditions locally: an
+unprivileged network namespace gives full `tc netem` control over its own loopback with
+no root required (`unshare -rn`, then `tc qdisc add dev lo root netem delay 50ms` =
+100 ms RTT). The entire stack — SuperLink, SuperNode, `flwr run` — runs inside the
+namespace; set `FLWR_DISABLE_RUNTIME_DEPENDENCY_INSTALLATION=1` since the namespace has
+no route to PyPI.
+
+Findings (flwr 1.32.1, grpcio 1.81.1, 100 ms RTT):
+
+1. **Flower is not inherently slow at 100 ms.** Unpatched, 200 MB down + 200 MB up
+   completes in 30 s (pull ~87 Mbit/s, push ~137 Mbit/s): gRPC's default BDP probing
+   grows the flow-control windows fine on a clean path. The field path was defeating BDP
+   probing (trigger not yet reproduced locally — pure delay, jitter, 0.05–0.3 % loss, and
+   a 200 Mbit rate limit all still ramp).
+2. **The server-side window option works** — the field conclusion above was wrong.
+   `grpcbench.py` (in this directory) isolates the two directions; with BDP probing
+   disabled to emulate the field's frozen-window regime, `grpc.http2.lookahead_bytes`
+   16 MB on the *server* takes the push leg 73 → 218 Mbit/s, while the same option on
+   the client does nothing for push (as HTTP/2 flow control predicts: the receiver's
+   window governs). The option is harmless with BDP probing left on.
+3. `patch_lookahead.py` therefore covers **both** legs when applied on both hosts. It now
+   appends an import-time log banner (`wan-spike lookahead patch active`) so a running
+   daemon proves it loaded the patched module — the missing verification that most likely
+   explains the field push result.
+4. One repro hazard worth knowing: `uv pip install` hardlinks files from its cache, so
+   patching a venv's flwr in place can silently poison the cached wheel — later "fresh"
+   installs come up already patched. `uv cache clean flwr` before reinstalling.
+
+Example `grpcbench.py` A/B at 100 ms RTT (8 MB unary messages, BDP probing disabled,
+first message includes ramp):
+
+| variant | push (node→server analog) |
+| :-- | :-- |
+| no lookahead | 51, 73, 74 Mbit/s |
+| lookahead 16 MB on client only | 51, 73, 74 Mbit/s |
+| lookahead 16 MB on server only | 66, 215, 219 Mbit/s |
+
+Remaining open item: one field re-run with the verifiable patch on both hosts, to confirm
+the push leg reaches raw-TCP speeds over a real WAN and to close the question of what
+breaks BDP probing on that path.
 
 ## Gotchas found (flwr 1.32)
 
@@ -126,6 +175,10 @@ Implications for the epic:
 
 Environment (both hosts): Python ≥3.10, `pip install "flwr>=1.32,<1.33" numpy`, plus this
 app installed (`pip install -e .`) wherever the SuperNode and SuperLink run.
+
+For the patched configuration, run `python patch_lookahead.py` with each daemon's own
+interpreter on **both** hosts, restart the daemons, and confirm each daemon's log prints
+`wan-spike lookahead patch active` — a daemon without the banner is running unpatched code.
 
 Central node:
 

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -26,8 +26,11 @@ the same path: 114 Mbit/s (QC→SE), 167 Mbit/s (SE→QC).
 | :-- | :-- | :-- | :-- |
 | loopback (WSL2, same host) | 0.5 GB ×2 | 20.5 s | ~0.39 Gbit/s |
 | loopback (WSL2, same host) | 4.0 GB ×2 | 138.1 s | ~0.46 Gbit/s |
-| WAN Quebec↔Sweden | 0.5 GB ×2 | 10 min 30 s | ~13 Mbit/s |
-| WAN Quebec↔Sweden | 4.0 GB ×2 | 1 h 24 min | ~12.7 Mbit/s |
+| WAN Quebec↔Sweden (106 ms) | 0.5 GB ×2 | 10 min 30 s | ~13 Mbit/s |
+| WAN Quebec↔Sweden (106 ms) | 4.0 GB ×2 | 1 h 24 min | ~12.7 Mbit/s |
+| WAN Quebec↔Norway (97 ms), unpatched | 0.5 GB ×2 | 8 min 13 s | ~16 Mbit/s |
+| WAN Quebec↔Norway, lookahead patch | 0.5 GB ×2 | 6–9 min (3 runs; one 78 s outlier) | pull fixed, push not |
+| WAN Quebec↔Norway, lookahead patch | 4.0 GB ×2 | 1 h 1 min | pull ~128 Mbit/s, push ~10 Mbit/s |
 
 \* total bytes moved ÷ round time; includes flwr's serialization and store-and-forward
 through the SuperLink object store, so this is *system* throughput, not link speed.
@@ -62,21 +65,47 @@ override each time; baseline 10 min 30 s):
 
 (Env vars verified present in the running SuperNode's `/proc/<pid>/environ`.)
 
-**Diagnosis.** Both operator-accessible knobs are exonerated, and the measured ~100 KB
-in flight per RTT matches gRPC's default HTTP/2 flow-control window (64 KB initial,
-applied per connection — which is also why 16 concurrent streams changed nothing).
-The fix lives in Flower's channel construction (HTTP/2 window options / BDP probing),
-which is not operator-configurable in flwr 1.32.
+**Root cause class — confirmed; fix verified for one direction.** The measured
+~100 KB in flight per RTT matches gRPC C-core's per-stream read-ahead limit,
+[`grpc.http2.lookahead_bytes`](https://grpc.github.io/grpc/core/group__grpc__arg__keys.html)
+(`GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES`, default 64 KB) — documented as the knob to
+raise "on high-latency connections." Flower's channel construction
+(`flwr/supercore/grpc.py`) sets only message-length options, so it runs the 64 KB
+default, and the option is not operator-configurable.
+
+**Patch results** (fresh Quebec↔Norway pair, 97 ms RTT; `patch_lookahead.py` in this
+directory adds `("grpc.http2.lookahead_bytes", 16 MB)` to Flower's client channels and
+server options; unpatched same-pair baseline 8 min 13 s for 0.5 GB ×2):
+
+- **Pull leg (SuperLink→node) is reliably fixed**: ~47 Mbit/s unpatched →
+  **~90–128 Mbit/s patched**, reproduced across three runs including 4 GB — near raw
+  single-stream TCP for the path. Consistent with flow-control mechanics: the pull
+  receiver is the patched *client channel*.
+- **Push leg (node→SuperLink) is NOT fixed by the channel arg**: ~10–16 Mbit/s in every
+  steady-state run, patched or not (4 GB patched round: 1 h 1 m, vs 1 h 24 m unpatched).
+  The push receiver is Flower's gRPC *server*; the equivalent server-side receive-window
+  fix needs to happen inside Flower/gRPC-core (or the object push path needs streaming/
+  multiple connections). Also ruled out for the push leg: chunk size, app-level transfer
+  concurrency, connection age (fresh-SuperNode rerun), and SuperLink state (fresh-SuperLink
+  rerun).
+- One 0.5 GB patched run completed in 78 s (~103 Mbit/s both legs) but did **not
+  reproduce** under identical fresh-restart conditions (6–9 min in three attempts).
+  Possible object-store dedup effect (the echo payload's content hashes match objects the
+  store may still hold) or transient path conditions — flagged as an open question for
+  upstream rather than claimed as a result.
 
 Implications for the epic:
 
 - **Functionally proven**: a 2B-param payload round-trips intact through SuperLink over
   a real WAN; no message-size or memory failures at 4 GB per direction.
-- **Cost as shipped**: ~1.5 h per 2B exchange on a 106 ms path. DiLoCo-cadence sync
-  (hundreds of inner steps per outer round) absorbs this; frequent-sync patterns cannot.
-- The ~20× gap below raw TCP is Flower-specific (flwr 1.32.1; no matching issue found in
-  the Flower tracker as of 2026-07-03) and worth raising upstream with these numbers —
-  it should be a small fix (channel options) for a large win.
+- **Cost as shipped**: ~1.5 h per 2B exchange on a ~100 ms path (flwr 1.32.1 defaults).
+  DiLoCo-cadence sync absorbs this; frequent-sync patterns cannot.
+- **Cost with the 2-line client-side fix**: the SuperLink→node direction becomes
+  raw-TCP-limited (2–3× on our path); the node→SuperLink push still needs an upstream
+  server-side fix, and it dominates the round (patched 4 GB round: 1 h 1 m).
+- No matching issue exists in the Flower tracker (checked 2026-07-03) — file upstream
+  with these numbers, the patch, and the open push-leg question; until it ships, nodes
+  can apply `patch_lookahead.py` for the pull-leg win.
 - Channel-level gzip compression would not help: weights are near-incompressible and the
   bottleneck is flow-control round trips, not bytes.
 

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -102,12 +102,13 @@ Implications for the epic:
 
 - **Functionally proven**: a 2B-param payload round-trips intact through SuperLink over
   a real WAN; no message-size or memory failures at 4 GB per direction.
-- **Cost as shipped**: ~1.5 h per 2B exchange on a ~100 ms path (flwr 1.32.1 defaults).
-  DiLoCo-cadence sync absorbs this; frequent-sync patterns cannot.
-- **Cost with the patch**: the SuperLink→node direction becomes raw-TCP-limited (2–3× on
-  our path, field-verified). Per the local simulation below, the same patch applied on the
-  SuperLink fixes the node→SuperLink push too (73→218 Mbit/s in the sim); the field push
-  numbers predate the verifiable patch and need one re-run to confirm.
+- **Cost as shipped**: ~1.5 h per 2B exchange *on the original degraded path* — the field
+  re-run below shows a healthy ~100 ms path costs **~10 min per 2B round with no patch at
+  all** (~75 s for 0.5 GB each way). Even the degraded-path worst case is absorbed by
+  DiLoCo-cadence sync; frequent-sync patterns need a healthy path or the window fix.
+- **Cost with the patch**: pins the SuperLink→node direction at the raw-TCP limit
+  (field-verified) and defends both legs against paths where gRPC's window auto-tuning
+  fails (simulation below: push 73→218 Mbit/s with auto-tuning disabled).
 - No matching issue exists in the Flower tracker (checked 2026-07-03) — the right upstream
   ask is "make the HTTP/2 window options configurable on SuperLink/SuperNode", backed by
   these numbers and the simulation A/B; until it ships, apply `patch_lookahead.py` on
@@ -154,9 +155,37 @@ first message includes ramp):
 | lookahead 16 MB on client only | 51, 73, 74 Mbit/s |
 | lookahead 16 MB on server only | 66, 215, 219 Mbit/s |
 
-Remaining open item: one field re-run with the verifiable patch on both hosts, to confirm
-the push leg reaches raw-TCP speeds over a real WAN and to close the question of what
-breaks BDP probing on that path.
+## Field re-run (2026-07-03, fresh box pair)
+
+Same topology rebuilt from scratch the same day: fresh Quebec (SuperLink) and Norway
+(SuperNode) vast.ai instances, same stack (flwr 1.32.1, grpcio 1.81.1, Python 3.12 venv),
+same vast Docker-NAT port mappings, measured path RTT ~101–107 ms, raw single-stream TCP
+215 Mbit/s (NO→QC) / 138 Mbit/s (QC→NO) — a faithful stand-in for the original pair.
+
+| run (0.5 GB down + 0.5 GB up) | round | pull leg | push leg |
+| :-- | :-- | :-- | :-- |
+| unpatched #1 | 81.6 s | 32.8 s (~122 Mbit/s) | 48.8 s (~82 Mbit/s) |
+| patched, banner-verified both hosts | 65.5 s | 29.1 s (~137 Mbit/s, at raw-TCP limit) | 36.5 s (~110 Mbit/s) |
+| unpatched #2 (flwr reinstalled, banner absent) | 72.7 s | 32.8 s (~122 Mbit/s) | 39.9 s (~100 Mbit/s) |
+
+Compare the original pair's consistent **8 min 13 s** unpatched (pull ~47, push ~7.5
+Mbit/s). Conclusions:
+
+- **The original slowness does not reproduce** on a fresh identical-topology pair. Two
+  unpatched runs land at 73–82 s — within ~15 % of raw TCP on both legs, with TCP
+  autotuning reaching ~3 MB receive windows during the push (`ss -ti` sampled on the
+  SuperLink during the run). The original spike's one unexplained "78 s outlier" was the
+  healthy behavior; the 6–9 min runs were the anomaly, specific to that box pair/path.
+- **The patch is field-verified as harmless and mildly beneficial**: it pins the pull leg
+  at the raw-TCP limit and the round improves ~10–20 %. The import-banner verification
+  works in the field (present in both patched daemon logs, absent after reinstall).
+- Practical cost for the epic: at these rates a 2B-param (4 GB each way) exchange costs
+  **~10 min per round, not ~1.5 h** — the original spike's headline number reflected a
+  degraded path, not Flower's design. What exactly degraded the original path (that
+  specific host's link, middlebox, or transient conditions) is no longer testable — the
+  boxes are gone; the local simulation above shows the *mechanism* such a path uses to
+  hurt Flower (frozen flow-control windows) and that forcing large windows defends
+  against it.
 
 ## Gotchas found (flwr 1.32)
 

--- a/contrib/jneums-flower-wan-spike/grpcbench.py
+++ b/contrib/jneums-flower-wan-spike/grpcbench.py
@@ -1,0 +1,114 @@
+"""Minimal gRPC throughput bench for HTTP/2 flow-control experiments.
+
+Isolates the two transfer directions Flower uses:
+  push = big unary request  (client -> server data; the node->SuperLink leg)
+  pull = big unary response (server -> client data; the SuperLink->node leg)
+
+Designed to run over a simulated-latency loopback in an unprivileged
+network namespace (no root needed):
+
+    unshare -rn sh -c '
+      ip link set lo up
+      tc qdisc add dev lo root netem delay 50ms limit 100000   # 100 ms RTT
+      python grpcbench.py server --bdp 0 >/dev/null 2>&1 &
+      sleep 2
+      python grpcbench.py client --only push
+    '
+
+Key knobs (each side independently):
+  --lookahead N   set grpc.http2.lookahead_bytes (HTTP/2 initial window)
+  --bdp 0         disable gRPC BDP probing, freezing windows at defaults —
+                  emulates a path where auto-tuning fails, which is the
+                  regime the WAN spike observed in the field.
+"""
+
+import argparse
+import time
+from concurrent import futures
+
+import grpc
+
+ADDR = "127.0.0.1:50551"
+MSG = 8 * 1024 * 1024  # 8 MB per message
+MAXLEN = 2_147_483_647
+
+
+def build_options(args):
+    opts = [
+        ("grpc.max_send_message_length", MAXLEN),
+        ("grpc.max_receive_message_length", MAXLEN),
+    ]
+    if args.lookahead:
+        opts.append(("grpc.http2.lookahead_bytes", args.lookahead))
+    if args.bdp is not None:
+        opts.append(("grpc.http2.bdp_probe", args.bdp))
+    return opts
+
+
+def ident(x):
+    return x
+
+
+def run_server(args):
+    def push(request, context):  # pylint: disable=unused-argument
+        return b"ok"
+
+    def pull(request, context):  # pylint: disable=unused-argument
+        return bytes(MSG)
+
+    handler = grpc.method_handlers_generic_handler(
+        "bench",
+        {
+            "Push": grpc.unary_unary_rpc_method_handler(
+                push, request_deserializer=ident, response_serializer=ident
+            ),
+            "Pull": grpc.unary_unary_rpc_method_handler(
+                pull, request_deserializer=ident, response_serializer=ident
+            ),
+        },
+    )
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=8), options=build_options(args)
+    )
+    server.add_generic_rpc_handlers((handler,))
+    server.add_insecure_port(ADDR)
+    server.start()
+    print("server ready", flush=True)
+    server.wait_for_termination()
+
+
+def run_client(args):
+    channel = grpc.insecure_channel(ADDR, options=build_options(args))
+    push = channel.unary_unary(
+        "/bench/Push", request_serializer=ident, response_deserializer=ident
+    )
+    pull = channel.unary_unary(
+        "/bench/Pull", request_serializer=ident, response_deserializer=ident
+    )
+    grpc.channel_ready_future(channel).result(timeout=10)
+    payload = bytes(MSG)
+
+    legs = [("push", push, payload), ("pull", pull, b"x")]
+    if args.only:
+        legs = [leg for leg in legs if leg[0] == args.only]
+    for name, fn, arg in legs:
+        rates = []
+        for _ in range(args.nmsg):
+            t0 = time.monotonic()
+            fn(arg, timeout=300)
+            rates.append(MSG * 8 / (time.monotonic() - t0) / 1e6)
+        print(
+            f"{name}: " + " ".join(f"{r:7.1f}" for r in rates)
+            + "  Mbit/s per 8MB msg",
+            flush=True,
+        )
+
+
+p = argparse.ArgumentParser()
+p.add_argument("role", choices=["server", "client"])
+p.add_argument("--lookahead", type=int, default=0)
+p.add_argument("--bdp", type=int, default=None)
+p.add_argument("--only", choices=["push", "pull"], default=None)
+p.add_argument("--nmsg", type=int, default=3)
+args = p.parse_args()
+(run_server if args.role == "server" else run_client)(args)

--- a/contrib/jneums-flower-wan-spike/patch_lookahead.py
+++ b/contrib/jneums-flower-wan-spike/patch_lookahead.py
@@ -17,10 +17,11 @@ Idempotent: skips if already patched.
 """
 
 import sys
+from pathlib import Path
 
 from flwr.supercore import grpc as _mod
 
-PATH = _mod.__file__
+PATH = Path(_mod.__file__)
 LOOKAHEAD = '        ("grpc.http2.lookahead_bytes", 16 * 1024 * 1024),\n'
 BANNER = (
     "\nfrom logging import INFO as _WAN_SPIKE_INFO\n"
@@ -28,7 +29,7 @@ BANNER = (
     '16 MB HTTP/2 windows (client channels + servers)")\n'
 )
 
-src = open(PATH).read()
+src = PATH.read_text(encoding="utf-8")
 if "lookahead_bytes" in src:
     print(f"already patched: {PATH}")
     sys.exit(0)
@@ -45,7 +46,8 @@ new_client = """    channel_options = [
         ("grpc.http2.lookahead_bytes", 16 * 1024 * 1024),
     ]
 """
-assert src.count(old_client) == 1, "client options block not found"
+if src.count(old_client) != 1:
+    raise RuntimeError("client options block not found")
 src = src.replace(old_client, new_client)
 
 # 2. Server options in generic_create_grpc_server
@@ -55,13 +57,16 @@ new_server = (
     + LOOKAHEAD
     + "    ]\n"
 )
-assert src.count(old_server) == 1, "server options block not found"
+if src.count(old_server) != 1:
+    raise RuntimeError("server options block not found")
 src = src.replace(old_server, new_server)
 
 # 3. Import-time banner so patched daemons are verifiable from their logs
 src += BANNER
 
-open(PATH, "w").write(src)
+PATH.write_text(src, encoding="utf-8")
 print(f"patched OK: {PATH}")
-print("restart the daemon and confirm its log shows "
-      "'wan-spike lookahead patch active'")
+print(
+    "restart the daemon and confirm its log shows "
+    "'wan-spike lookahead patch active'"
+)

--- a/contrib/jneums-flower-wan-spike/patch_lookahead.py
+++ b/contrib/jneums-flower-wan-spike/patch_lookahead.py
@@ -1,0 +1,43 @@
+"""Patch flwr/supercore/grpc.py: raise HTTP/2 per-stream lookahead to 16 MB.
+
+Applies to both the client channel (create_channel) and the server options.
+Idempotent: skips if already patched.
+"""
+
+import sys
+
+PATH = "/root/flenv/lib/python3.12/site-packages/flwr/supercore/grpc.py"
+LOOKAHEAD = '        ("grpc.http2.lookahead_bytes", 16 * 1024 * 1024),\n'
+
+src = open(PATH).read()
+if "lookahead_bytes" in src:
+    print("already patched")
+    sys.exit(0)
+
+# 1. Client channel options in create_channel
+old_client = """    channel_options = [
+        ("grpc.max_send_message_length", max_message_length),
+        ("grpc.max_receive_message_length", max_message_length),
+    ]
+"""
+new_client = """    channel_options = [
+        ("grpc.max_send_message_length", max_message_length),
+        ("grpc.max_receive_message_length", max_message_length),
+        ("grpc.http2.lookahead_bytes", 16 * 1024 * 1024),
+    ]
+"""
+assert src.count(old_client) == 1, "client options block not found"
+src = src.replace(old_client, new_client)
+
+# 2. Server options
+old_server = '        ("grpc.keepalive_permit_without_calls", 0),\n    ]\n'
+new_server = (
+    '        ("grpc.keepalive_permit_without_calls", 0),\n'
+    + LOOKAHEAD
+    + "    ]\n"
+)
+assert src.count(old_server) == 1, "server options block not found"
+src = src.replace(old_server, new_server)
+
+open(PATH, "w").write(src)
+print("patched OK")

--- a/contrib/jneums-flower-wan-spike/patch_lookahead.py
+++ b/contrib/jneums-flower-wan-spike/patch_lookahead.py
@@ -1,17 +1,36 @@
-"""Patch flwr/supercore/grpc.py: raise HTTP/2 per-stream lookahead to 16 MB.
+"""Patch flwr's supercore/grpc.py: raise HTTP/2 per-stream lookahead to 16 MB.
 
-Applies to both the client channel (create_channel) and the server options.
+Applies to both the client channel (create_channel) and the server options
+(generic_create_grpc_server) — the latter is what governs the node->SuperLink
+push leg, so the patch must be applied (and the daemon restarted) on BOTH the
+SuperNode and SuperLink hosts, in the environment their daemons actually run.
+
+Run it with the same interpreter that runs the daemon:
+
+    /path/to/venv/bin/python patch_lookahead.py
+
+Verification: the patch appends an import-time log line, so any process
+running the patched module prints "wan-spike lookahead patch active" at
+startup. If a daemon's log doesn't show it, that daemon is NOT patched.
+
 Idempotent: skips if already patched.
 """
 
 import sys
 
-PATH = "/root/flenv/lib/python3.12/site-packages/flwr/supercore/grpc.py"
+from flwr.supercore import grpc as _mod
+
+PATH = _mod.__file__
 LOOKAHEAD = '        ("grpc.http2.lookahead_bytes", 16 * 1024 * 1024),\n'
+BANNER = (
+    "\nfrom logging import INFO as _WAN_SPIKE_INFO\n"
+    'log(_WAN_SPIKE_INFO, "wan-spike lookahead patch active: '
+    '16 MB HTTP/2 windows (client channels + servers)")\n'
+)
 
 src = open(PATH).read()
 if "lookahead_bytes" in src:
-    print("already patched")
+    print(f"already patched: {PATH}")
     sys.exit(0)
 
 # 1. Client channel options in create_channel
@@ -29,7 +48,7 @@ new_client = """    channel_options = [
 assert src.count(old_client) == 1, "client options block not found"
 src = src.replace(old_client, new_client)
 
-# 2. Server options
+# 2. Server options in generic_create_grpc_server
 old_server = '        ("grpc.keepalive_permit_without_calls", 0),\n    ]\n'
 new_server = (
     '        ("grpc.keepalive_permit_without_calls", 0),\n'
@@ -39,5 +58,10 @@ new_server = (
 assert src.count(old_server) == 1, "server options block not found"
 src = src.replace(old_server, new_server)
 
+# 3. Import-time banner so patched daemons are verifiable from their logs
+src += BANNER
+
 open(PATH, "w").write(src)
-print("patched OK")
+print(f"patched OK: {PATH}")
+print("restart the daemon and confirm its log shows "
+      "'wan-spike lookahead patch active'")

--- a/contrib/jneums-flower-wan-spike/pyproject.toml
+++ b/contrib/jneums-flower-wan-spike/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "jneums-flower-wan-spike"
+version = "0.1.0"
+description = "Spike: round-trip a 2B-parameter weight payload through a Flower SuperLink over a real WAN (issue #70 de-risk)"
+license = { text = "Apache-2.0" }
+dependencies = [
+    "flwr>=1.32.0,<1.33.0",
+    "numpy>=1.26.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["wan_spike"]
+
+[tool.flwr.app]
+publisher = "jneums"
+
+[tool.flwr.app.components]
+serverapp = "wan_spike.server_app:app"
+clientapp = "wan_spike.client_app:app"
+
+[tool.flwr.app.config]
+# 2_000_000_000 params in float16 = ~4.0 GB payload each direction.
+payload-params = 2000000000
+# Params per tensor: 25M fp16 = 50 MB, i.e. ~80 tensors — keeps every message
+# object far below gRPC message-size limits, like a real model's layer tensors.
+tensor-params = 25000000
+num-server-rounds = 1

--- a/contrib/jneums-flower-wan-spike/tests/test_task.py
+++ b/contrib/jneums-flower-wan-spike/tests/test_task.py
@@ -1,0 +1,35 @@
+import importlib.util
+import unittest
+
+NUMPY_AVAILABLE = importlib.util.find_spec("numpy") is not None
+
+if NUMPY_AVAILABLE:
+    from wan_spike.task import make_ndarrays, total_bytes, validate_positive_int
+
+
+@unittest.skipUnless(NUMPY_AVAILABLE, "wan_spike task tests require numpy")
+class TaskTest(unittest.TestCase):
+    def test_make_ndarrays_chunks_payload_and_reports_bytes(self):
+        arrays = make_ndarrays(payload_params=7, tensor_params=3, seed=11)
+
+        self.assertEqual([array.shape for array in arrays], [(3,), (3,), (1,)])
+        self.assertTrue(all(array.dtype.name == "float16" for array in arrays))
+        self.assertEqual(total_bytes(arrays), 14)
+
+    def test_validate_positive_int_rejects_non_positive_values(self):
+        cases = [
+            ("payload_params", 0),
+            ("payload_params", -1),
+            ("tensor_params", 0),
+        ]
+
+        for name, value in cases:
+            with self.subTest(name=name, value=value):
+                with self.assertRaisesRegex(
+                    ValueError, f"{name} must be positive"
+                ):
+                    validate_positive_int(name, value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/jneums-flower-wan-spike/wan_spike/__init__.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/__init__.py
@@ -1,0 +1,1 @@
+"""Flower WAN weight-transfer spike for the issue #70 epic."""

--- a/contrib/jneums-flower-wan-spike/wan_spike/client_app.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/client_app.py
@@ -1,0 +1,36 @@
+"""ClientApp: receive the weight payload, echo it back, log timing legs."""
+
+import time
+
+from flwr.app import Context, Message, MetricRecord, RecordDict
+from flwr.clientapp import ClientApp
+
+app = ClientApp()
+
+
+@app.train()
+def train(msg: Message, context: Context) -> Message:
+    t0 = time.time()
+    arrays = msg.content["arrays"]
+    # Measure without deserializing to numpy: transport is what we're testing.
+    nbytes = sum(len(arr.data) for arr in arrays.values())
+    t1 = time.time()
+    print(
+        f"SPIKE client: received {nbytes / 1e9:.3f} GB "
+        f"(handler_start_unix={t0:.3f}, counted at {t1:.3f})",
+        flush=True,
+    )
+
+    content = RecordDict(
+        {
+            "arrays": arrays,  # echo the payload back unchanged
+            "metrics": MetricRecord(
+                {
+                    "num-examples": 1,
+                    "recv-gb": nbytes / 1e9,
+                    "handler-start-unix": t0,
+                }
+            ),
+        }
+    )
+    return Message(content=content, reply_to=msg)

--- a/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
@@ -6,16 +6,22 @@ from flwr.app import ArrayRecord, Context
 from flwr.serverapp import Grid, ServerApp
 from flwr.serverapp.strategy import FedAvg
 
-from wan_spike.task import make_ndarrays, total_bytes
+from wan_spike.task import make_ndarrays, total_bytes, validate_positive_int
 
 app = ServerApp()
 
 
 @app.main()
 def main(grid: Grid, context: Context) -> None:
-    payload_params: int = context.run_config["payload-params"]
-    tensor_params: int = context.run_config["tensor-params"]
-    num_rounds: int = context.run_config["num-server-rounds"]
+    payload_params = validate_positive_int(
+        "payload-params", int(context.run_config["payload-params"])
+    )
+    tensor_params = validate_positive_int(
+        "tensor-params", int(context.run_config["tensor-params"])
+    )
+    num_rounds = validate_positive_int(
+        "num-server-rounds", int(context.run_config["num-server-rounds"])
+    )
 
     t0 = time.time()
     ndarrays = make_ndarrays(payload_params, tensor_params)

--- a/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
@@ -1,0 +1,57 @@
+"""ServerApp: build a ~4 GB ArrayRecord, run FedAvg rounds, report timing."""
+
+import time
+
+from flwr.app import ArrayRecord, Context
+from flwr.serverapp import Grid, ServerApp
+from flwr.serverapp.strategy import FedAvg
+
+from wan_spike.task import make_ndarrays, total_bytes
+
+app = ServerApp()
+
+
+@app.main()
+def main(grid: Grid, context: Context) -> None:
+    payload_params: int = context.run_config["payload-params"]
+    tensor_params: int = context.run_config["tensor-params"]
+    num_rounds: int = context.run_config["num-server-rounds"]
+
+    t0 = time.time()
+    ndarrays = make_ndarrays(payload_params, tensor_params)
+    gb = total_bytes(ndarrays) / 1e9
+    arrays = ArrayRecord(numpy_ndarrays=ndarrays, keep_input=False)
+    del ndarrays
+    t1 = time.time()
+    print(
+        f"SPIKE server: payload built: {gb:.3f} GB in {len(arrays)} tensors "
+        f"({t1 - t0:.1f}s), unix={t1:.3f}",
+        flush=True,
+    )
+
+    # The spike runs a single node; FedAvg defaults require 2.
+    strategy = FedAvg(
+        fraction_train=1.0,
+        fraction_evaluate=0.0,
+        min_train_nodes=1,
+        min_evaluate_nodes=1,
+        min_available_nodes=1,
+    )
+    t2 = time.time()
+    result = strategy.start(
+        grid=grid,
+        initial_arrays=arrays,
+        num_rounds=num_rounds,
+    )
+    t3 = time.time()
+
+    per_round = (t3 - t2) / num_rounds
+    print(
+        f"SPIKE server: {num_rounds} round(s) in {t3 - t2:.1f}s "
+        f"(~{per_round:.1f}s/round for {gb:.3f} GB down + {gb:.3f} GB up); "
+        f"effective one-way throughput ~{2 * gb / per_round * 8:.2f} Gbit/s "
+        f"if legs were symmetric. start_unix={t2:.3f} end_unix={t3:.3f}",
+        flush=True,
+    )
+    # Keep the result object alive until after timing so nothing is GC'd early.
+    print(f"SPIKE server: final ArrayRecord holds {len(result.arrays)} tensors", flush=True)

--- a/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
@@ -13,12 +13,10 @@ app = ServerApp()
 
 @app.main()
 def main(grid: Grid, context: Context) -> None:
-    payload_params = validate_positive_int(
-        "payload-params", int(context.run_config["payload-params"])
-    )
-    tensor_params = validate_positive_int(
-        "tensor-params", int(context.run_config["tensor-params"])
-    )
+    # payload/tensor params are validated inside make_ndarrays; num_rounds is
+    # only used here, so it is validated at this call site.
+    payload_params = int(context.run_config["payload-params"])
+    tensor_params = int(context.run_config["tensor-params"])
     num_rounds = validate_positive_int(
         "num-server-rounds", int(context.run_config["num-server-rounds"])
     )

--- a/contrib/jneums-flower-wan-spike/wan_spike/task.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/task.py
@@ -1,0 +1,32 @@
+"""Payload construction for the WAN weight-transfer spike.
+
+NumPy-only on purpose: the spike measures transport, not training, and a
+torch-free app keeps remote node setup to `pip install flwr numpy`.
+
+float16 stands in for bfloat16 (NumPy has no native bf16); the wire payload
+is byte-identical in size.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def make_ndarrays(payload_params: int, tensor_params: int, seed: int = 7) -> list[np.ndarray]:
+    """Random fp16 tensors totalling ``payload_params`` parameters.
+
+    Random (not zeros) so any transparent compression on the path cannot
+    flatter the measurement.
+    """
+    rng = np.random.default_rng(seed)
+    out: list[np.ndarray] = []
+    remaining = payload_params
+    while remaining > 0:
+        n = min(tensor_params, remaining)
+        out.append(rng.standard_normal(n, dtype=np.float32).astype(np.float16))
+        remaining -= n
+    return out
+
+
+def total_bytes(arrays: list[np.ndarray]) -> int:
+    return sum(a.nbytes for a in arrays)

--- a/contrib/jneums-flower-wan-spike/wan_spike/task.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/task.py
@@ -12,12 +12,22 @@ from __future__ import annotations
 import numpy as np
 
 
+def validate_positive_int(name: str, value: int) -> int:
+    """Return ``value`` when positive, otherwise raise a clear config error."""
+    if value <= 0:
+        raise ValueError(f"{name} must be positive; got {value}")
+    return value
+
+
 def make_ndarrays(payload_params: int, tensor_params: int, seed: int = 7) -> list[np.ndarray]:
     """Random fp16 tensors totalling ``payload_params`` parameters.
 
     Random (not zeros) so any transparent compression on the path cannot
     flatter the measurement.
     """
+    validate_positive_int("payload_params", payload_params)
+    validate_positive_int("tensor_params", tensor_params)
+
     rng = np.random.default_rng(seed)
     out: list[np.ndarray] = []
     remaining = payload_params


### PR DESCRIPTION
## New Contribution Check List

- [x] I created a subdirectory named with the format `contrib/<my_github_user_name>-<feature_name>`: `contrib/jneums-flower-wan-spike/`
- [x] I included a short `README.md` that describes the contribution, its motivation and status, and how to try/evaluate it.
- [x] I added a `LICENSE` (repository defaults: Apache-2.0 code, CC-BY-4.0 docs).
- [x] (If contributing code) I put the code in a `wan_spike` subdirectory and unit tests in a `tests` subdirectory (payload chunking and config validation, contributed by @Rohithmatham12). The measurements themselves are validated by the protocol documented in the README (two-host WAN setup and a no-root local latency simulation).

## Description of Contribution

De-risk spike for the #70 epic: **can a ~2B-parameter model's weights round-trip through a Flower SuperLink over a real WAN, and what does a round cost?**

Answer, verified on two independent box pairs plus a local latency-simulation A/B:

- **Functionally proven**: 4 GB fp16 each way moves intact through a SuperLink over a real ~100 ms WAN; no message-size or memory failures.
- **Fast as shipped**: stock flwr 1.32 runs within ~15% of raw single-stream TCP in both directions — **~10 minutes per 2B exchange**, no tuning. Transport is not a performance concern for the epic.
- The contribution also includes an **optional hardening patch** (`patch_lookahead.py`, self-verifying from daemon logs) that pins throughput at the raw-TCP limit on paths where gRPC's flow-control auto-tuning misbehaves, plus the investigation record that motivated it.

This grounds the "Flower as connectivity layer" evaluation on #70 / #126 with measured numbers rather than assumptions.

## Related Issues

#70, #126

## If Code Is Included

### Code Description

- `wan_spike/` — minimal Flower app (NumPy-only): ServerApp builds a configurable random weight payload and runs single-node FedAvg rounds; ClientApp echoes the payload back; both log leg timings.
- `grpcbench.py` — standalone gRPC benchmark isolating the two transfer directions (big unary request vs big unary response) with per-side flow-control knobs; used with `unshare -rn` + `tc netem` for a no-root local WAN simulation.
- `patch_lookahead.py` — optional idempotent patch raising Flower's HTTP/2 windows to 16 MB on client channels and servers; appends an import-time log banner so a running daemon proves it loaded the patched module.
- Third-party: `flwr` 1.32, `numpy` only.

### Testing Performed

- Field: 2B-param (4 GB each way) and 0.5 GB rounds across vast.ai datacenter pairs (Quebec↔Sweden, two Quebec↔Norway pairs, ~100 ms RTT), with raw-TCP probes on the same paths as controls; per-leg timings reconstructed from app logs; TCP state sampled with `ss -ti` during transfers.
- Local: full stack (SuperLink + SuperNode + `flwr run`) in a network namespace under `tc netem` latency; A/B matrix over flow-control options with BDP probing enabled/disabled.
- Unit tests in `tests/` cover payload chunking and config validation (`python -m unittest discover -s tests` from the contrib dir, with numpy installed).
- All numbers and the reproduction protocol are in the README.

### Example Usage

```shell
# central node                      # sovereign node
flower-superlink --insecure        flower-supernode --insecure --superlink <central-host>:9092

# driver (0.5 GB payload)
flwr run . spike --run-config "payload-params=250000000" --stream
```

## Checklist

- [x] I have read and understood the CONTRIBUTING guide.
- [x] I have tested the code contributions in my local development environment.
- [x] I have added tests for all code contributions.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation (README in the contrib dir; findings summarized on #70 and #126).

