### PR TITLE
Preserve contrib target failures

### DIFF
--- a/.common.mk
+++ b/.common.mk
@@ -185,8 +185,12 @@ contrib-%::
 	@for d in ${CONTRIB_DIRS}; \
 	do [ -d "$$d" ] || continue; \
 		echo "${INFO}In directory $$d:${_END}"; \
-		${MAKE} SRC_DIR=$$d --include-dir=$$d ${@:contrib-%=%} 2>&1 | \
-			egrep -v -e '(overriding|ignoring old) commands for target' || exit $$?; \
+		tmp=$$(mktemp); \
+		if ${MAKE} SRC_DIR=$$d --include-dir=$$d ${@:contrib-%=%} > "$$tmp" 2>&1; \
+		then status=0; else status=$$?; fi; \
+		egrep -v -e '(overriding|ignoring old) commands for target' "$$tmp" || true; \
+		rm -f "$$tmp"; \
+		[ $$status -eq 0 ] || exit $$status; \
 	done
 
 .PHONY: one-time-setup clean-setup

--- a/.website.mk
+++ b/.website.mk
@@ -17,7 +17,7 @@ make view-pages         # View the published GitHub pages in a browser.
 make view-local         # View the pages locally (requires Jekyll).
                         # Makes the targets 'setup-jekyll' and 'run-jekyll'
                         # Tip: "JEKYLL_PORT=8000 make view-local" uses port 8000 instead of 4000!
-make setup-jekyll       # Install Jekyll. Make sure Ruby is installed. 
+make setup-jekyll       # Install Jekyll. Make sure Ruby is installed.
                         # (Only needed for local viewing of the document.)
 make run-jekyll         # Used by "view-local"; assumes everything is already built.
                         # Tip: Build this target instead of 'view-local' to avoid repeating 'setup-jekyll'.
@@ -68,7 +68,7 @@ ruby-installed-check:
 
 bundle-command-check:
 	@command -v bundle > /dev/null || \
-		${MAKE} bundle-missing-error 
+		${MAKE} bundle-missing-error
 
 # NOTE: We call make to run these %-error targets, because if you try
 # some_command || $(error "didn't work"), the $(error ...) function is always
@@ -101,7 +101,7 @@ ERROR:   Bundler found conflicting requirements for the RubyGems version:
 ERROR:     In Gemfile:
 ERROR:       foo-bar (>= 3.0.0) was resolved to 3.0.0, which depends on
 ERROR:         RubyGems (>= 3.3.22)
-ERROR:   
+ERROR:
 ERROR:     Current RubyGems version:
 ERROR:       RubyGems (= 3.3.11)
 ERROR: In this case, try "brew upgrade ruby" to get a newer version.
@@ -112,7 +112,7 @@ define bundle-error-message
 
 ERROR: Did the bundle command fail with a message like this?
 ERROR: 	 "/usr/local/opt/ruby/bin/bundle:25:in `load': cannot load such file -- /usr/local/lib/ruby/gems/3.1.0/gems/bundler-X.Y.Z/exe/bundle (LoadError)"
-ERROR: Check that the /usr/local/lib/ruby/gems/3.1.0/gems/bundler-X.Y.Z directory actually exists. 
+ERROR: Check that the /usr/local/lib/ruby/gems/3.1.0/gems/bundler-X.Y.Z directory actually exists.
 ERROR: If not, try running the clean-jekyll command first:
 ERROR:   make clean-jekyll setup-jekyll
 ERROR: Answer "y" (yes) to the prompts and ignore any warnings that you can't uninstall a "default" gem.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -133,7 +133,7 @@ Two of the supported customization mechanisms are shown here.
 
 #### Help on Custom Targets You Define
 
-We will see below, that you can define targets that can be executed to demonstrate your contribution using the `.targets.mk` file. You provide a brief description of all these commands in `.custom.mk`, where you you _override_ the definition of `help_targets_message` as shown here.
+We will see below, that you can define targets that can be executed to demonstrate your contribution using the `.targets.mk` file. You provide a brief description of all these commands in `.custom.mk`, where you _override_ the definition of `help_targets_message` as shown here.
 
 This message will be printed whenever the user runs `make help-targets` (a target defined in the top level `.common.mk`), along with similar messages for all the other contributions. In this example, there are two program targets defined, `consortium-experiment` and `consortium-tests`.
 
@@ -149,8 +149,8 @@ The second customization mechanism is shown for `pylint` and `type-check`. In th
 In the top level `.common.mk`, the `pylint` target is defined as follows (the other quality targets like `type-check` are similar):
 
 ```makefile
-pylint:: pylint-prerequsite pylint-default pylint-postrequisite
-pylint-prerequsite pylint-postrequisite::
+pylint:: pylint-prerequisite pylint-default pylint-postrequisite
+pylint-prerequisite pylint-postrequisite::
 pylint-default:
   @echo "${INFO}$@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
   uv run pylint ${SRC_DIR}
@@ -181,7 +181,7 @@ unit-tests-prerequisite::
 
 > [!WARN] One or Two Trailing Colons??
 >
-> Did you notice that the top level `.common.mk` has `pylint-prerequsite::` (two trailing colons) and `pylint-default:` (one trailing colon)?? This is deliberate and reflects how we exploit the different behaviors in `make` for our purposes.
+> Did you notice that the top level `.common.mk` has `pylint-prerequisite::` (two trailing colons) and `pylint-default:` (one trailing colon)?? This is deliberate and reflects how we exploit the different behaviors in `make` for our purposes.
 >
 > When a target has two trailing colons, `make` allows _more than one_ definition of that target. This is a tool for adding additional dependencies to a target or additional commands to execute. consider this contrived example,
 >
@@ -206,7 +206,7 @@ unit-tests-prerequisite::
 > b
 > finished!
 > ```
-> We exploit this feature to have a "no-op" default behavior for `pylint-prerequsite` and allow contributions to define any additional prerequisite behavior they want.
+> We exploit this feature to have a "no-op" default behavior for `pylint-prerequisite` and allow contributions to define any additional prerequisite behavior they want.
 >
 > In contrast, `pylint-default:` has one trailing colon; _the last definition overrides all previous definitions seen._ We only want a _single_ definition of this target to be used. For example,
 > ```makefile
@@ -227,7 +227,7 @@ unit-tests-prerequisite::
 
 ### How to Add Custom Targets
 
-The optional `.targets.mk` allows you to define custom targets that will be visible to the top-level `make` process. For example, you should consider adding targets to run demonstrations of your contribution. _Also had help messages for them, as mentioned above, using `.custom.mk`._
+The optional `.targets.mk` allows you to define custom targets that will be visible to the top-level `make` process. For example, you should consider adding targets to run demonstrations of your contribution. _Also add help messages for them, as mentioned above, using `.custom.mk`._
 
 Here is an example from `contrib/jneums-consortium-experiment/.targets.mk`:
 


### PR DESCRIPTION
## Summary

- preserve the recursive `make` exit status in `contrib-%` while still filtering duplicate-target warnings
- clean trailing whitespace that made `git diff --check` fail
- fix `.common.mk` hook names and small wording typos in the contrib protocol docs

## Why

`contrib-%` currently pipes the recursive `make` output through `egrep`. On POSIX shells, the pipeline status is the final command, so a failing contribution target can return success if `egrep` emits any output.

Concrete reproduction before this patch:

```shell
make contrib-pylint
```

The inner `uv run pylint contrib/oli-sovereign-eval-evidence` fails locally because `uv` is not installed, but the top-level command exits `0`.

After this patch, the same command exits non-zero while preserving the filtered output.

## Testing

- `git diff --check`
- `make help-targets`
- `make -n consortium-experiment-all`
- `make contrib-pylint` now exits non-zero when the inner contribution target fails locally because `uv` is not installed.
