### PR TITLE
[#70] Flower WAN spike: black-format + pytest dev group (follow-up to #130)

### DIFF
--- a/contrib/jneums-flower-wan-spike/grpcbench.py
+++ b/contrib/jneums-flower-wan-spike/grpcbench.py
@@ -59,17 +59,11 @@ def run_server(args):
     handler = grpc.method_handlers_generic_handler(
         "bench",
         {
-            "Push": grpc.unary_unary_rpc_method_handler(
-                push, request_deserializer=ident, response_serializer=ident
-            ),
-            "Pull": grpc.unary_unary_rpc_method_handler(
-                pull, request_deserializer=ident, response_serializer=ident
-            ),
+            "Push": grpc.unary_unary_rpc_method_handler(push, request_deserializer=ident, response_serializer=ident),
+            "Pull": grpc.unary_unary_rpc_method_handler(pull, request_deserializer=ident, response_serializer=ident),
         },
     )
-    server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=8), options=build_options(args)
-    )
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=8), options=build_options(args))
     server.add_generic_rpc_handlers((handler,))
     server.add_insecure_port(ADDR)
     server.start()
@@ -79,12 +73,8 @@ def run_server(args):
 
 def run_client(args):
     channel = grpc.insecure_channel(ADDR, options=build_options(args))
-    push = channel.unary_unary(
-        "/bench/Push", request_serializer=ident, response_deserializer=ident
-    )
-    pull = channel.unary_unary(
-        "/bench/Pull", request_serializer=ident, response_deserializer=ident
-    )
+    push = channel.unary_unary("/bench/Push", request_serializer=ident, response_deserializer=ident)
+    pull = channel.unary_unary("/bench/Pull", request_serializer=ident, response_deserializer=ident)
     grpc.channel_ready_future(channel).result(timeout=10)
     payload = bytes(MSG)
 
@@ -98,8 +88,7 @@ def run_client(args):
             fn(arg, timeout=300)
             rates.append(MSG * 8 / (time.monotonic() - t0) / 1e6)
         print(
-            f"{name}: " + " ".join(f"{r:7.1f}" for r in rates)
-            + "  Mbit/s per 8MB msg",
+            f"{name}: " + " ".join(f"{r:7.1f}" for r in rates) + "  Mbit/s per 8MB msg",
             flush=True,
         )
 

--- a/contrib/jneums-flower-wan-spike/patch_lookahead.py
+++ b/contrib/jneums-flower-wan-spike/patch_lookahead.py
@@ -52,11 +52,7 @@ src = src.replace(old_client, new_client)
 
 # 2. Server options in generic_create_grpc_server
 old_server = '        ("grpc.keepalive_permit_without_calls", 0),\n    ]\n'
-new_server = (
-    '        ("grpc.keepalive_permit_without_calls", 0),\n'
-    + LOOKAHEAD
-    + "    ]\n"
-)
+new_server = '        ("grpc.keepalive_permit_without_calls", 0),\n' + LOOKAHEAD + "    ]\n"
 if src.count(old_server) != 1:
     raise RuntimeError("server options block not found")
 src = src.replace(old_server, new_server)
@@ -66,7 +62,4 @@ src += BANNER
 
 PATH.write_text(src, encoding="utf-8")
 print(f"patched OK: {PATH}")
-print(
-    "restart the daemon and confirm its log shows "
-    "'wan-spike lookahead patch active'"
-)
+print("restart the daemon and confirm its log shows " "'wan-spike lookahead patch active'")

--- a/contrib/jneums-flower-wan-spike/pyproject.toml
+++ b/contrib/jneums-flower-wan-spike/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
     "numpy>=1.26.0",
 ]
 
+[dependency-groups]
+# Installed by default by `uv run`, so the top-level `make contrib-tests`
+# (which runs pytest with this contribution's own uv project environment)
+# finds pytest here.
+dev = ["pytest>=8.0"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["wan_spike"]
 

--- a/contrib/jneums-flower-wan-spike/tests/test_task.py
+++ b/contrib/jneums-flower-wan-spike/tests/test_task.py
@@ -25,9 +25,7 @@ class TaskTest(unittest.TestCase):
 
         for name, value in cases:
             with self.subTest(name=name, value=value):
-                with self.assertRaisesRegex(
-                    ValueError, f"{name} must be positive"
-                ):
+                with self.assertRaisesRegex(ValueError, f"{name} must be positive"):
                     validate_positive_int(name, value)
 
 

--- a/contrib/jneums-flower-wan-spike/wan_spike/client_app.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/client_app.py
@@ -16,8 +16,7 @@ def train(msg: Message, context: Context) -> Message:
     nbytes = sum(len(arr.data) for arr in arrays.values())
     t1 = time.time()
     print(
-        f"SPIKE client: received {nbytes / 1e9:.3f} GB "
-        f"(handler_start_unix={t0:.3f}, counted at {t1:.3f})",
+        f"SPIKE client: received {nbytes / 1e9:.3f} GB " f"(handler_start_unix={t0:.3f}, counted at {t1:.3f})",
         flush=True,
     )
 

--- a/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
+++ b/contrib/jneums-flower-wan-spike/wan_spike/server_app.py
@@ -17,9 +17,7 @@ def main(grid: Grid, context: Context) -> None:
     # only used here, so it is validated at this call site.
     payload_params = int(context.run_config["payload-params"])
     tensor_params = int(context.run_config["tensor-params"])
-    num_rounds = validate_positive_int(
-        "num-server-rounds", int(context.run_config["num-server-rounds"])
-    )
+    num_rounds = validate_positive_int("num-server-rounds", int(context.run_config["num-server-rounds"]))
 
     t0 = time.time()
     ndarrays = make_ndarrays(payload_params, tensor_params)
@@ -28,8 +26,7 @@ def main(grid: Grid, context: Context) -> None:
     del ndarrays
     t1 = time.time()
     print(
-        f"SPIKE server: payload built: {gb:.3f} GB in {len(arrays)} tensors "
-        f"({t1 - t0:.1f}s), unix={t1:.3f}",
+        f"SPIKE server: payload built: {gb:.3f} GB in {len(arrays)} tensors " f"({t1 - t0:.1f}s), unix={t1:.3f}",
         flush=True,
     )
 


### PR DESCRIPTION
## Description of the PR

Tiny follow-up to #130 — one commit that was pushed to the PR branch minutes after the merge, so it missed the train:

- `black`-format the contribution (formatting only, no behavior change).
- Add a `pytest` dev dependency group to the contribution's `pyproject.toml`, so the top-level `make contrib-tests` (which runs pytest inside the contribution's own uv project environment) finds pytest and passes.

Both also prepare this contribution for the quality gates introduced by #132.

## Related Issues

#130, #132, #70

## Testing Performed

`cd contrib/jneums-flower-wan-spike && uv run python -m pytest tests -q` — 2 passed. `uv run ruff check` and `uv run black --check` clean.
