### PR TITLE
Add Flower WAN make protocol hooks

### DIFF
--- a/contrib/jneums-flower-wan-spike/.custom.mk
+++ b/contrib/jneums-flower-wan-spike/.custom.mk
@@ -1,0 +1,15 @@
+override define help_targets_message
+For the Flower WAN weight-transfer spike:
+
+make flower-wan-spike-all  # Make all the following targets.
+
+make flower-wan-spike-tests
+                           # Run the Flower WAN spike unit tests.
+endef
+
+# This contribution depends on Flower runtime packages that are resolved from
+# its own pyproject.toml. The root lint/type-check environment cannot resolve
+# those imports yet, so keep these checks opt-in for the provisional spike.
+pylint-default type-check-default:
+	@echo "${WARN} ${skip-contrib-target}${_END}"
+	@true

--- a/contrib/jneums-flower-wan-spike/.targets.mk
+++ b/contrib/jneums-flower-wan-spike/.targets.mk
@@ -1,0 +1,11 @@
+# This file is included in the top-level Makefile
+
+FLOWER_WAN_SPIKE_DIR := contrib/jneums-flower-wan-spike
+
+.PHONY: flower-wan-spike-all flower-wan-spike-tests
+
+flower-wan-spike-all:: flower-wan-spike-tests
+
+flower-wan-spike-tests::
+	@echo "${INFO}Running the Flower WAN spike unit tests...${_END}"
+	cd ${FLOWER_WAN_SPIKE_DIR}; uv run python -m unittest discover -s tests


### PR DESCRIPTION
Summary
- add `.custom.mk` for `contrib/jneums-flower-wan-spike`
- expose `flower-wan-spike-all` and `flower-wan-spike-tests` through the top-level make protocol
- skip root `pylint` and `type-check` for this provisional Flower contribution because its Flower imports are resolved from the contribution package environment

Why
- follows Dean's request on #130 to try the #132 contribution make protocol with the Flower WAN spike
- gives #132 a concrete test case for a newly merged contribution

Testing
- `git diff --check`
- `make help-targets`
- `make SRC_DIR=contrib/jneums-flower-wan-spike --include-dir=contrib/jneums-flower-wan-spike pylint type-check`
- `make -n flower-wan-spike-all`
- `PYTHONPATH=contrib/jneums-flower-wan-spike python3 -m unittest discover -s contrib/jneums-flower-wan-spike/tests` (skips locally because numpy is not installed)
- `python3 -m py_compile contrib/jneums-flower-wan-spike/grpcbench.py contrib/jneums-flower-wan-spike/patch_lookahead.py contrib/jneums-flower-wan-spike/wan_spike/client_app.py contrib/jneums-flower-wan-spike/wan_spike/server_app.py contrib/jneums-flower-wan-spike/wan_spike/task.py contrib/jneums-flower-wan-spike/tests/test_task.py`
