### PR TITLE
[Update] Contribution index, status badges, and promotion path (contrib process)

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -4,6 +4,21 @@ This directory is a staging area for **contributed ideas, techniques, and experi
 
 Think of `contrib/` as the front porch. Promising contributions may later be promoted into `src/`, `docs/`, or `examples/` after discussion and review. Material here is **not** part of the supported codebase and carries no stability guarantees.
 
+## Current Contributions
+
+| Contribution | Contributor(s) | Status | What it is |
+| :----------- | :------------- | :----- | :--------- |
+| [`jneums-consortium-experiment`](jneums-consortium-experiment/README.md) | jneums | Speculative | Deterministic measurement layer around the consortium-training proof of concept |
+| [`jneums-cultural-cpt-validation`](jneums-cultural-cpt-validation/README.md) | jneums | Speculative | Runnable harness for EXP-001: does culturally grounded continued pretraining shift alignment beyond language exposure? |
+| [`jneums-flower-wan-spike`](jneums-flower-wan-spike/README.md) | jneums | Speculative | De-risk spike for #70: 2B-parameter weight round-trip through a Flower SuperLink over a real WAN |
+| [`nguyennm1024-sociocultural-alignment`](nguyennm1024-sociocultural-alignment/README.md) | nguyennm1024 | Speculative | LoRA + consortium learning + Inglehart–Welzel evaluation for sovereign cultural alignment (Vietnamese case study) |
+| [`oli-sovereign-eval-evidence`](oli-sovereign-eval-evidence/README.md) | oli | Speculative | Evidence layer connecting cultural-alignment evaluation, data sovereignty, and certification claims |
+
+Statuses are `Speculative`, `Candidate`, or `Promoted` — see
+[State the Readiness Level](#state-the-readiness-level) and
+[Promotion to Production](#promotion-to-production) below. The table is
+maintained by hand for now: when you add a contribution, add your row.
+
 ## How to Contribute
 
 We follow normal _GitOps_ practices (see the top-level [`CONTRIBUTING.md`](../CONTRIBUTING.md)). To add a contribution:
@@ -301,6 +316,21 @@ For code that might be adopted later, reduce integration friction:
   helpful descriptions for every argument.
 - Include automated tests for behavior that Tapestry would rely on.
 - Use type annotations for (almost) everything and make sure the `type-check` target passes, as well as the other quality checks discussed above.
+
+## Promotion to Production
+
+The exact promotion process is **TBD**, but the skeleton is what you would
+expect:
+
+- **Who decides:** the maintainers, after discussion on an issue or the
+  contribution's PR.
+- **What must be true:** the "candidate for adoption" criteria above — the
+  full quality gates pass without skips (`format`, `lint`, `type-check`,
+  `tests`), the package/test shape matches `src/`, and the contribution has
+  demonstrated value worth supporting.
+- **How it happens:** a normal PR that moves the code under `src/` (or the
+  material under `docs/` / `examples/`), with its tests, and updates the
+  contribution's status to `Promoted` in the index above.
 
 ## Contribution Policy
 

--- a/contrib/jneums-consortium-experiment/README.md
+++ b/contrib/jneums-consortium-experiment/README.md
@@ -5,7 +5,7 @@ Tapestry consortium-training proof of concept. It is staged under `contrib/`
 so the core training-loop package can remain focused on the minimal PoC
 protocol while experiment ideas are reviewed and iterated.
 
-Status: prototype / measurement scaffold.
+**Status: Speculative** (prototype / measurement scaffold).
 
 It intentionally does not replace Flower, NIID-Bench, OpenDiLoCo,
 lm-evaluation-harness, Unitxt, or other larger evaluation and federated

--- a/contrib/jneums-cultural-cpt-validation/README.md
+++ b/contrib/jneums-cultural-cpt-validation/README.md
@@ -7,7 +7,7 @@ model's cultural alignment, beyond mere language exposure?
 
 Staged under `contrib/` (like `jneums-consortium-experiment`) while it iterates.
 
-> **Status: executed; result is bounded.** Run for real on Qwen3-4B base/instruct,
+> **Status: Speculative** (executed; result is bounded). Run for real on Qwen3-4B base/instruct,
 > real Arabic-Wikipedia corpora, plus a 3-culture FedAvg aggregation and a behavioral
 > probe. The honest finding is **real but shallow**: grounded CPT shifts a **base**
 > model's **survey-measured** values toward the target culture **more than a

--- a/contrib/jneums-flower-wan-spike/README.md
+++ b/contrib/jneums-flower-wan-spike/README.md
@@ -1,5 +1,7 @@
 # Flower WAN Weight-Transfer Spike
 
+**Status: Speculative**
+
 De-risk spike for the [issue #70](https://github.com/The-AI-Alliance/tapestry/issues/70)
 epic: **can a ~2B-parameter model's weights round-trip through a Flower SuperLink over a
 real WAN, and how long does a round take?** This measures transport only — the "training"

--- a/contrib/nguyennm1024-sociocultural-alignment/README.md
+++ b/contrib/nguyennm1024-sociocultural-alignment/README.md
@@ -6,7 +6,7 @@ The parts are meant to be reusable beyond this case: a data-synthesis methodolog
 training pipeline, a **consortium-learning** step that fuses specialized members, and a
 cultural-alignment **evaluation** harness.
 
-> Status: preliminary / experimental. Staging-area work, not a supported package.
+> **Status: Speculative** (preliminary / experimental). Staging-area work, not a supported package.
 
 ## Why (mission fit)
 

--- a/contrib/oli-sovereign-eval-evidence/README.md
+++ b/contrib/oli-sovereign-eval-evidence/README.md
@@ -1,6 +1,6 @@
 # Sovereign Evaluation Evidence Layer
 
-Status: proposal / evaluation design scaffold.
+**Status: Speculative** (proposal / evaluation design scaffold).
 
 This contribution proposes a small evidence layer for Tapestry's Evaluation &
 Certification work. It connects cultural-alignment evaluation, data-sovereignty


### PR DESCRIPTION
## Description of the PR

The three improvements from #142, in two surgical commits:

**Commit 1 — index + promotion path** (`contrib/README.md`):
* A **Current Contributions** table near the top: contribution (link) · contributor(s) · status · one-line description, seeded with the five current entries. Maintained by hand for now ("add your row" note included), automatable later.
* A **Promotion to Production** section that states the process is **TBD** while sketching the obvious skeleton: maintainer decision · the existing candidate-readiness criteria · a normal PR moving code under `src/` with its tests, flipping the status to `Promoted`.

**Commit 2 — status badges** (the five `contrib/*/README.md`):
* Every contribution README now carries the bold badge near the top (`**Status: Speculative**`), mapped to the readiness levels defined in `contrib/README.md`. Four entries already had an informal status line in varying shapes; each keeps its author's descriptor **verbatim** in parentheses after the standardized badge (e.g. `**Status: Speculative** (executed; result is bounded)`), so no nuance is lost. The Flower WAN spike gains the badge line it did not have.

Kept as two commits on purpose: if you would rather have each author stamp their own status (the scoping question in the issue thread), drop the second commit and the index/promotion piece still stands alone.

Bold badge rather than YAML front-matter for now: it renders everywhere, and front-matter can come later if an Actions script wants to parse it.

## Related Issues

Closes #142

## Testing Performed

Docs-only change. `make before-pr` quality gates replayed locally on `src` (ruff, pylint, ty, 6/6 pytest green); the `contrib` legs are unaffected (README-only edits).

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For documentation changes:

- [x] I have followed the existing documentation styles and conventions.
