### PR TITLE
[Update] Changelog stamp workflow for main cuts (#143 follow-up)

### DIFF
--- a/.github/scripts/stamp_changelog.py
+++ b/.github/scripts/stamp_changelog.py
@@ -1,0 +1,55 @@
+"""Stamp the CHANGELOG's Unreleased section with a date when main is cut.
+
+Configured by ../workflows/changelog.yml (see issue #143). Idempotent:
+
+- If the ``## [Unreleased]`` section carries no entries, exit 0 without
+  touching the file (nothing to stamp; the workflow opens no PR).
+- Otherwise, rename the section to ``## [YYYY-MM-DD]`` and insert a fresh
+  empty ``## [Unreleased]`` above it, per keepachangelog conventions and
+  the flow documented at the top of CHANGELOG.md (entries accumulate on
+  ``develop``; the section gets stamped when ``main`` is cut).
+
+Exit codes: 0 = stamped (file modified), 78 = nothing to stamp (neutral),
+1 = CHANGELOG.md missing or has no Unreleased section.
+"""
+
+import datetime
+import pathlib
+import re
+import sys
+
+CHANGELOG = pathlib.Path("CHANGELOG.md")
+UNRELEASED_RE = re.compile(r"^## \[Unreleased\]\s*$", re.MULTILINE)
+SECTION_RE = re.compile(r"^## \[", re.MULTILINE)
+
+
+def main() -> int:
+    if not CHANGELOG.is_file():
+        print("CHANGELOG.md not found", file=sys.stderr)
+        return 1
+    text = CHANGELOG.read_text(encoding="utf-8")
+
+    match = UNRELEASED_RE.search(text)
+    if match is None:
+        print("no '## [Unreleased]' section found", file=sys.stderr)
+        return 1
+
+    # The Unreleased body runs from the end of its heading to the next
+    # "## [" heading (or EOF). Entries = any non-blank line in that span.
+    body_start = match.end()
+    next_section = SECTION_RE.search(text, body_start)
+    body_end = next_section.start() if next_section else len(text)
+    body = text[body_start:body_end]
+    if not any(line.strip() for line in body.splitlines()):
+        print("Unreleased is empty; nothing to stamp")
+        return 78
+
+    today = datetime.date.today().isoformat()
+    stamped = text[: match.start()] + f"## [Unreleased]\n\n## [{today}]" + text[match.end() :]
+    CHANGELOG.write_text(stamped, encoding="utf-8")
+    print(f"stamped Unreleased as [{today}]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,69 @@
+# Stamp CHANGELOG.md when main is cut (issue #143, second half).
+#
+# When a release lands on main, the accumulated "## [Unreleased]" entries
+# get stamped with the cut date and a fresh empty Unreleased section starts.
+# The stamp is proposed as a small PR against develop (the integration
+# branch) rather than pushed directly: it stays reviewable, and the next
+# main cut carries it. If Unreleased is empty, the workflow does nothing.
+#
+# Injection surface: none — no github.event.* text reaches a run: block;
+# the only dynamic value is a runner-computed UTC date.
+
+name: Changelog stamp
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  stamp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Stamp the Unreleased section
+        id: stamp
+        run: |
+          set -e
+          rc=0
+          python .github/scripts/stamp_changelog.py || rc=$?
+          if [ "$rc" = "78" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" = "0" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            exit "$rc"
+          fi
+
+      - name: Open the stamp PR
+        if: steps.stamp.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          date_today="$(date -u +%F)"
+          branch="chore/changelog-stamp-${date_today}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add CHANGELOG.md
+          git commit -s -m "Stamp CHANGELOG Unreleased section as ${date_today}"
+          git push origin "$branch"
+          gh pr create \
+            --base develop \
+            --head "$branch" \
+            --title "Stamp CHANGELOG Unreleased as ${date_today}" \
+            --body "Automated stamp: \`main\` was cut, so the accumulated Unreleased entries get their date and a fresh Unreleased section starts. See #143."


### PR DESCRIPTION
## Description of the PR

The second half of #143, which you invited in the #152 review — the GitHub Action, now that the #140 CI baseline is in.

**How it works:**

* On a push to `main` (a cut), the workflow checks out `develop`, runs `.github/scripts/stamp_changelog.py`, and if the `## [Unreleased]` section carries entries, stamps it as `## [YYYY-MM-DD]` and starts a fresh empty `## [Unreleased]`.
* The stamp is proposed as a **small PR against `develop`** rather than pushed directly: it stays reviewable, and the next `main` cut carries it. If you would rather have the stamp pushed straight to a branch cut from `main` (so the release itself carries the dated log), that is a two-line change — happy to flip it.
* Empty Unreleased → the workflow is a no-op (the script exits 78 and no PR opens).

**Design notes:**

* The stamping logic lives in `.github/scripts/stamp_changelog.py` next to the existing `collect_metrics.py` precedent — idempotent, stdlib-only, black/ruff clean.
* First-party actions only (`actions/checkout`, `actions/setup-python`), matching the #140 CI style; the PR opens via `gh` with the built-in `github.token`.
* No `github.event.*` text reaches any `run:` block, so there is no workflow-injection surface.
* One known GitHub quirk documented here for the record: PRs opened with the built-in token do not trigger other workflows — which is fine, since the CI from #140 only watches `src/**`, `contrib/**`, `examples/**` and the stamp only touches `CHANGELOG.md`.

## Related Issues

Closes #143 (with #152 having landed the file itself).

## Testing Performed

Both script paths exercised locally: entries present → stamps and exits 0 (verified against the repo's live CHANGELOG, then reverted); empty Unreleased → exits 78 and leaves the file untouched (synthetic fixture). `black --check` and `ruff check` pass on the script. The workflow itself can only be end-to-end tested on the first real `main` cut.

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
