### PR TITLE
Refinements to the output formatting used in the make recipes

### DIFF
--- a/.common.mk
+++ b/.common.mk
@@ -1,4 +1,9 @@
+  # .common.mk
 # See comment at the bottom of this file about "-include .custom.mk".
+
+# Definitions of RED, GREEN, etc., and INFO, ERROR, etc. for console output.
+# To see them in action, try "make show-colors".
+include .console-colors.mk
 
 SRC_DIR             ?= src
 CLEAN_DIRS          :=
@@ -21,60 +26,34 @@ ARCHITECTURE ?= $(shell uname -m)
 GIT_HASH     ?= $(shell git show --pretty="%H" --abbrev-commit |head -1)
 NOW          ?= $(shell date +"%Y%m%d-%H%M%S")
 
-# Colors used to make some messages stand out more than others...
-RED          := \033[31m
-BOLD_RED     := \033[1;31m
-GREEN        := \033[32m
-BOLD_GREEN   := \033[1;32m
-YELLOW       := \033[33m
-BOLD_YELLOW  := \033[1;33m
-BLUE         := \033[34m
-BOLD_BLUE    := \033[1;34m
-PURPLE       := \033[35m
-BOLD_PURPLE  := \033[1;35m
-CYAN         := \033[36m
-BOLD_CYAN    := \033[1;36m
-
-ERROR        := ${BOLD_RED}ERROR:
-WARN         := ${BOLD_YELLOW}WARNING:
-NOTE         := ${BOLD_PURPLE}NOTE:
-INFO         := ${BOLD_PURPLE}
-TIP          := ${BOLD_BLUE}TIP:
-HIGHLIGHT    := ${BOLD_GREEN}
-_END         := \033[0m
-
-
 define help_message
 Quick help for this make process.
 
-make all                # Makes the 'help' and 'print-info' targets (see below).
-make help               # Prints this output.
-make print-info         # Print the current values of some make env. variables.
+${CODE}make all${_END}                # Makes the 'help' and 'print-info' targets (see below).
+${CODE}make help${_END}               # Prints this output.
+${CODE}make print-info${_END}         # Print the current values of some make env. variables.
 
 Working with code:
 
-make tests              # Run the test suite.
-make clean              # Remove built artifacts, etc.
-make format             # Format the Python code with 'black'.
-make lint               # Lint the Python code by making the ruff and pylint targets.
-make ruff               # Lint the Python code with 'ruff'.
-make pylint             # Lint the Python code with 'pylint'.
-make type-check         # Type check the Python code with 'ty'.
-make type-check-watch   # Type check the Python code with 'ty' in "watch" mode,
+${CODE}make one-time-setup${_END}     # "One time setup" of dependencies. Requires MacOS or Linux.
+${CODE}make tests${_END}              # Run the test suite.
+${CODE}make clean${_END}              # Remove built artifacts, etc.
+${CODE}make format${_END}             # Format the Python code with ${CODE}black${_END}.
+${CODE}make lint${_END}               # Lint the Python code by making the ${CODE}ruff${_END} and ${CODE}pylint${_END} targets.
+${CODE}make ruff${_END}               # Lint the Python code with ${CODE}ruff${_END}.
+${CODE}make pylint${_END}             # Lint the Python code with ${CODE}pylint${_END}.
+${CODE}make type-check${_END}         # Type check the Python code with ${CODE}ty${_END}.
+${CODE}make type-check-watch${_END}   # Type check the Python code with ${CODE}ty${_END} in "watch" mode,
                         # so you can fix mistakes and keep it updating.
-make before-pr          # Make format, lint, type-check, and tests for "src" AND
+${CODE}make before-pr${_END}          # Make ${CODE}format${_END}, ${CODE}lint${_END}, ${CODE}type-check${_END}, and ${CODE}tests${_END} for "src" AND
                         # every "contrib" directory.
                         # DO THIS BEFORE SUBMITTING A PR!
 
-For contributed code in "contrib", any of the targets help, format, lint, ruff, pylint,
-type-check, type-check-watch, and before-pr, can be invoked by prefixing the targets
-name with "contrib-". This will run the corresponding target in all the contrib/* directories.
+For contributed code in "contrib", any of the targets ${CODE}help${_END}, ${CODE}format${_END}, ${CODE}lint${_END}, ${CODE}ruff${_END}, ${CODE}pylint${_END},
+${CODE}type-check${_END}, ${CODE}type-check-watch${_END}, and ${CODE}before-pr${_END}, can be invoked by prefixing the targets
+name with ${CODE}contrib-${_END}. This will run the corresponding target in all the contrib/* directories.
 
 ${help_top_level_message}
-endef
-
-define missing_shell_command_error_message
-is needed by ${PWD}/Makefile. Try 'make help' and look at the README.
 endef
 
 
@@ -94,7 +73,7 @@ help-%::
 	@true
 
 define help_targets_message
-  No custom targets defined.
+  ${NOTE}No custom targets defined.${_END}
 endef
 
 help-targets:: help-top-level-targets-prefix help-top-level-targets contrib-custom-program-help
@@ -118,14 +97,16 @@ clean::
 	rm -rf ${CLEAN_DIRS}
 
 print-info::
-	@echo "source               ${SRC_DIR}"
-	@echo "tests                ${SRC_DIR}/tests"
-	@echo "current dir:         ${PWD}"
-	@echo "MAKEFLAGS:           ${MAKEFLAGS}"
-	@echo "UNAME:               ${UNAME}"
-	@echo "ARCHITECTURE:        ${ARCHITECTURE}"
-	@echo "GIT_HASH:            ${GIT_HASH}"
-	@echo "NOW:                 ${NOW}"
+	@echo "${DARK_GREEN}MAKEFLAGS:${_END}          ${CODE}${MAKEFLAGS}${_END}"
+	@echo "${DARK_GREEN}UNAME:${_END}              ${CODE}${UNAME}${_END}"
+	@echo "${DARK_GREEN}ARCHITECTURE:${_END}       ${CODE}${ARCHITECTURE}${_END}"
+	@echo "${DARK_GREEN}GIT_HASH:${_END}           ${CODE}${GIT_HASH}${_END}"
+	@echo "${DARK_GREEN}NOW:${_END}                ${CODE}${NOW}${_END}"
+	@echo
+	@echo "${DARK_GREEN}Current Directory:${_END}  ${CODE}${PWD}${_END}"
+	@echo "${DARK_GREEN}Sources:${_END}            ${CODE}${SRC_DIR}${_END}"
+	@echo "${DARK_GREEN}Tests:${_END}              ${CODE}${SRC_DIR}/tests${_END}"
+	@echo "${DARK_GREEN}Contributions:${_END}      ${CODE}${CONTRIB_DIRS}${_END}"
 
 .PHONY: before-pr do-before-pr do-contrib-before-pr
 
@@ -185,6 +166,11 @@ type-check-watch-default:
 	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
 	uv run ty check --watch ${SRC_DIR}
 
+# Provide a concrete recipe for the contrib-help target, so the "contrib-%" target pattern below 
+# doesn't get used, because it does the wrong thing in this special case...
+contrib-help:: 
+	@${MAKE} help-targets
+
 # The next recipe contains logic to skip any item in ${CONTRIB_DIRS} that is not a directory,
 # although the construction of ${CONTRIB_DIRS} should prevent this from happening.
 # Also, the output is filtered with egrep to remove unhelpful warnings from make when
@@ -200,17 +186,19 @@ type-check-watch-default:
 contrib-%::
 	@for d in ${CONTRIB_DIRS}; \
 	do [ -d "$$d" ] || continue; \
-		echo "${INFO}In directory $$d:${_END}"; \
-			${MAKE} SRC_DIR=$$d --include-dir=$$d ${@:contrib-%=%} 2>&1 || exit $$?; \
-	done | egrep -v -e '(overriding|ignoring old) commands for target' 
+		echo "${INFO}For directory ${CODE}$$d${_END}:"; \
+			${MAKE} SRC_DIR=$$d --include-dir=$$d ${@:contrib-%=%} || exit $$?; \
+	done 2>&1 | egrep -v -e '(overriding|ignoring old) (commands|recipe) for target' 
 
-# This is really a test target for testing contrib-%, but it's reasonably useful
-# when you want to list all the contrib/* directories.
+# These are really test targets for testing contrib-%, but they are reasonably useful,
+# e.g., using "make contrib-list" to list all the contrib/* directories.
 # Try "make LIST_FILTER='*.md' contrib-list", for example.
 LIST_FILTER :=
-.PHONY: list
+.PHONY: list pwd
 list:
-	cd ${SRC_DIR} && ls -al ${LIST_FILTER}
+	@cd ${SRC_DIR} && ls -al ${LIST_FILTER}
+pwd:
+	@cd ${SRC_DIR} && echo "Currently in directory: ${CODE}$$(pwd)${_END}"
 
 .PHONY: one-time-setup clean-setup
 .PHONY: command-check-uv install-uv uv-venv install-dev-dependencies install-requirements-txt-dependencies
@@ -253,7 +241,7 @@ location and delete uv.
 endef
 
 define skip-contrib-target
-Skipping target \"${@:%-default=%}\" in ${SRC_DIR}! Overridden in ${SRC_DIR}/.custom.mk (see target \"$@\").
+${WARNING_LABEL}Skipping target ${CODE}${@:%-default=%}${_END} in ${CODE}${SRC_DIR}${_END}! Support target ${CODE}$@${_END} is overridden in ${CODE}${SRC_DIR}/.custom.mk${_END}.
 endef
 
 # Include a .custom.mk that _may or may not_ exist. The leading "-"

--- a/.common.mk
+++ b/.common.mk
@@ -229,15 +229,13 @@ help-command-uv help-command-uvx::
 	@echo
 
 define help-message-uv
-
-The Python environment management tool "uv" is required.
-See https://docs.astral.sh/uv/ for installation instructions.
-
-If you want to uninstall uv and you used HomeBrew to install it,
-use 'brew uninstall uv'. Otherwise, if you executed one of the
-installation commands on the website above, find the installation
-location and delete uv.
-
+${NOTE_LABEL}The Python environment management tool ${CODE}uv${_END} is required.
+${NOTE_LABEL}See ${CODE}https://docs.astral.sh/uv/${_END} for installation instructions.
+${NOTE_LABEL}
+${NOTE_LABEL}If you want to uninstall uv and you used HomeBrew to install it,
+${NOTE_LABEL}use ${CODE}brew uninstall uv${_END}. Otherwise, if you executed one of the
+${NOTE_LABEL}installation commands on the website above, find the installation
+${NOTE_LABEL}location and delete uv.
 endef
 
 define skip-contrib-target

--- a/.common.mk
+++ b/.common.mk
@@ -80,7 +80,7 @@ help-targets:: help-top-level-targets-prefix help-top-level-targets contrib-cust
 	@true  # for some reason, this needs to be here to avoid some undesirable, extra output
 
 help-top-level-targets-prefix:
-	@echo "${INFO}For the examples:${_END}"
+	@echo "${INFO_LABEL}For the ${CODE}examples${_END}:"
 
 help-top-level-targets:
 	$(info ${help_top_level_targets_message})
@@ -126,11 +126,11 @@ tests:: unit-tests
 unit-tests:: unit-tests-prerequisite unit-tests-default unit-tests-postrequisite
 unit-tests-prerequisite unit-tests-postrequisite::
 unit-tests-default:
-	@echo "${INFO}Running the unit tests (with coverage) in ${SRC_DIR}/tests:${_END}"
-	@if [ ! -d "${SRC_DIR}/tests" ]; then echo "${WARN} No test directory ${SRC_DIR}/tests found!${_END}"; \
+	@echo "${INFO_LABEL} $@: Running the unit tests (with coverage) in ${CODE}${SRC_DIR}/tests${_END}:"
+	@if [ ! -d "${SRC_DIR}/tests" ]; then echo "${WARN_LABEL} No test directory ${CODE}${SRC_DIR}/tests${_END} found!"; \
 	else \
 		cd ${SRC_DIR}; \
-		echo "Running: ${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}"; \
+		echo "${INFO_LABEL} Running: ${CODE}${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}${_END}"; \
 		${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}; \
 	fi
 
@@ -140,30 +140,30 @@ lint:: ruff pylint
 format:: format-prerequisite format-default format-postrequisite
 format-prerequisite format-postrequisite::
 format-default:
-	@echo "${INFO}$@: Running 'black' on the code in ${SRC_DIR}.${_END}"
+	@echo "${INFO_LABEL} $@: Running ${CODE}black${_END} on the code in ${CODE}${SRC_DIR}${_END}."
 	uv run black ${SRC_DIR}
 
 ruff:: ruff-prerequisite ruff-default ruff-postrequisite
 ruff-prerequisite ruff-postrequisite::
 ruff-default:
-	@echo "${INFO}$@: Running 'ruff' to lint the code in ${SRC_DIR}.${_END}"
+	@echo "${INFO_LABEL} $@: Running ${CODE}ruff${_END} to lint the code in ${CODE}${SRC_DIR}${_END}."
 	uv run ruff check --fix ${SRC_DIR}
 
 pylint:: pylint-prerequisite pylint-default pylint-postrequisite
 pylint-prerequisite pylint-postrequisite::
 pylint-default:
-	@echo "${INFO}$@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
+	@echo "${INFO_LABEL} $@: Running ${CODE}pylint${_END} on the code in ${CODE}${SRC_DIR}${_END} (configuration in ${CODE}pylintrc.toml${_END})"
 	uv run pylint ${PYLINT_IGNORE_ARGS} ${SRC_DIR}
 
 type-check:: type-check-prerequisite type-check-default type-check-postrequisite
 type-check-prerequisite type-check-postrequisite::
 type-check-default:
-	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR}.${_END}"
+	@echo "${INFO_LABEL} $@: Running ${CODE}ty${_END} to type check the code in ${CODE}${SRC_DIR}${_END}."
 	uv run ty check ${SRC_DIR}
 
 type-check-watch:: type-check-prerequisite type-check-watch-default type-check-postrequisite
 type-check-watch-default:
-	@echo "${INFO}$@: Running 'ty' to type check the code in ${SRC_DIR} using 'watch' mode.${_END}"
+	@echo "${INFO_LABEL} $@: Running ${CODE}ty${_END} to type check the code in ${CODE}${SRC_DIR}${_END} using 'watch' mode."
 	uv run ty check --watch ${SRC_DIR}
 
 # Provide a concrete recipe for the contrib-help target, so the "contrib-%" target pattern below 
@@ -186,7 +186,7 @@ contrib-help::
 contrib-%::
 	@for d in ${CONTRIB_DIRS}; \
 	do [ -d "$$d" ] || continue; \
-		echo "${INFO}For directory ${CODE}$$d${_END}:"; \
+		echo "${INFO_LABEL}For directory ${CODE}$$d${_END}:"; \
 			${MAKE} SRC_DIR=$$d --include-dir=$$d ${@:contrib-%=%} || exit $$?; \
 	done 2>&1 | egrep -v -e '(overriding|ignoring old) (commands|recipe) for target' 
 
@@ -207,11 +207,11 @@ setup one-time-setup:: install-uv uv-venv install-dev-dependencies
 
 install-%::
 	@cmd=${@:install-%=%} && command -v $$cmd > /dev/null && \
-		echo "${INFO}$$cmd is already installed${_END}" || ${MAKE} help-command-$$cmd
+		echo "${INFO_LABEL}command ${CODE}$$cmd${_END} is already installed." || ${MAKE} help-command-$$cmd
 
 uv-venv:: command-check-uv
-	@test -d .venv && echo "'.venv' already exists; not running 'uv venv'." || uv venv
-	@echo "run: 'source .venv/bin/activate' if subsequent commands fail!"
+	@test -d .venv && echo "${INFO_LABEL}directory ${CODE}.venv${_END} already exists; not running ${CODE}uv venv${_END}." || uv venv
+	@echo "${INFO_LABEL}run ${CODE}source .venv/bin/activate${_END} if subsequent commands fail!"
 
 install-dev-dependencies::
 	uv pip install -e ".[dev]"

--- a/.console-colors.mk
+++ b/.console-colors.mk
@@ -1,0 +1,86 @@
+# console-colors.mk
+
+# Color definitions for highlighting console output.
+# These definitions work on MacOS and Linux, zsh and bourne/dash shells.
+RED=$(shell tput setaf 1)
+GREEN=$(shell tput setaf 2)
+ORANGE=$(shell tput setaf 3)
+BLUE=$(shell tput setaf 4)
+PINK=$(shell tput setaf 5)
+DARK_GREEN=$(shell tput setaf 6)
+LIGHT_GREY=$(shell tput setaf 7)
+BLACK=$(shell tput setaf 8)
+# virtually identical to RED:
+RED2=$(shell tput setaf 9)
+BOLD=$(shell tput smso)
+OFFBOLD=$(shell tput rmso)
+_END=$(shell tput sgr0; tput rmso)
+
+# Note the definitions with labels, like "ERROR:" have a trailing space!!
+ERROR        = ${BOLD}${RED}ERROR: 
+WARN         = ${ORANGE}WARNING: 
+WARNING      = ${ORANGE}WARNING: 
+NOTE         = ${GREEN}NOTE: 
+INFO         = ${DARK_GREEN}INFO: 
+TIP          = ${BOLD}${DARK_GREEN}TIP: 
+HIGHLIGHT    = ${BOLD}${BLUE}
+
+# "Labels" for when you just want to, e.g., "ERROR:" colored, but the rest of the line should be "normal".
+ERROR_LABEL     = ${BOLD}${RED}ERROR:${_END} 
+WARN_LABEL      = ${ORANGE}WARNING:${_END} 
+WARNING_LABEL   = ${ORANGE}WARNING:${_END} 
+NOTE_LABEL      = ${GREEN}NOTE:${_END} 
+INFO_LABEL      = ${DARK_GREEN}INFO:${_END} 
+TIP_LABEL       = ${BOLD}${DARK_GREEN}TIP:${_END} 
+
+# For "special" strings in output:
+CODE          = ${PINK}
+
+.PHONY: show-colors show-colors-info show-colors-echo
+
+# Use this target to see the colors defined above.
+show-colors:: show-colors-info show-colors-echo
+
+show-colors-info::
+	$(info This is how the color and message definition look using $$(info ...) and related output functions:)
+	$(info This is <${RED}RED${_END}>)
+	$(info This is <${RED2}RED2${_END}>)
+	$(info This is <${GREEN}GREEN${_END}>)
+	$(info This is <${ORANGE}ORANGE${_END}>)
+	$(info This is <${BLUE}BLUE${_END}>)
+	$(info This is <${PINK}PINK${_END}>)
+	$(info This is <${DARK_GREEN}DARK_GREEN${_END}>)
+	$(info This is <${LIGHT_GREY}LIGHT_GREY${_END}>)
+	$(info This is <${BLACK}BLACK${_END}>)
+	$(info This is <${BOLD}${BLACK}BOLD and BLACK${_END}>)
+	$(info )
+	$(info This is an ERROR:     ${ERROR} Oooops! ${_END})
+	$(info This is a  WARN:      ${WARN} Careful! ${_END})
+	$(info This is a  WARNING:   ${WARNING} Careful! ${_END})
+	$(info This is a  NOTE:      ${NOTE} Of note... ${_END})
+	$(info This is an INFO:      ${INFO} It's useful to know ${_END})
+	$(info This is a  TIP:       ${TIP} This can help... ${_END})
+	$(info This is a  HIGHLIGHT: ${HIGHLIGHT}/foo/bar/baz ${_END})
+	$(info )
+
+show-colors-echo::
+	$(info This is how the color and message definition look using echo:)
+	@echo "This is <${RED}RED${_END}>"
+	@echo "This is <${RED2}RED2${_END}>"
+	@echo "This is <${GREEN}GREEN${_END}>"
+	@echo "This is <${ORANGE}ORANGE${_END}>"
+	@echo "This is <${BLUE}BLUE${_END}>"
+	@echo "This is <${PINK}PINK${_END}>"
+	@echo "This is <${DARK_GREEN}DARK_GREEN${_END}>"
+	@echo "This is <${LIGHT_GREY}LIGHT_GREY${_END}>"
+	@echo "This is <${BLACK}BLACK${_END}>"
+	@echo "This is <${BOLD}${BLACK}BOLD and BLACK${_END}>"
+	@echo
+	@echo "This is an ERROR:     ${ERROR} Oooops! ${_END}"
+	@echo "This is a  WARN:      ${WARN} Careful! ${_END}"
+	@echo "This is a  WARNING:   ${WARNING} Careful! ${_END}"
+	@echo "This is a  NOTE:      ${NOTE} Of note... ${_END}"
+	@echo "This is an INFO:      ${INFO} It's useful to know ${_END}"
+	@echo "This is a  TIP:       ${TIP} This can help... ${_END}"
+	@echo "This is a  HIGHLIGHT: ${HIGHLIGHT}/foo/bar/baz ${_END}"
+	@echo

--- a/.console-colors.mk
+++ b/.console-colors.mk
@@ -26,6 +26,7 @@ TIP          = ${BOLD}${DARK_GREEN}TIP:
 HIGHLIGHT    = ${BOLD}${BLUE}
 
 # "Labels" for when you just want to, e.g., "ERROR:" colored, but the rest of the line should be "normal".
+# No "${_END}" has to be provided when these labels are used.
 ERROR_LABEL     = ${BOLD}${RED}ERROR:${_END} 
 WARN_LABEL      = ${BOLD}${ORANGE}WARNING:${_END} 
 WARNING_LABEL   = ${BOLD}${ORANGE}WARNING:${_END} 

--- a/.console-colors.mk
+++ b/.console-colors.mk
@@ -27,10 +27,10 @@ HIGHLIGHT    = ${BOLD}${BLUE}
 
 # "Labels" for when you just want to, e.g., "ERROR:" colored, but the rest of the line should be "normal".
 ERROR_LABEL     = ${BOLD}${RED}ERROR:${_END} 
-WARN_LABEL      = ${ORANGE}WARNING:${_END} 
-WARNING_LABEL   = ${ORANGE}WARNING:${_END} 
-NOTE_LABEL      = ${GREEN}NOTE:${_END} 
-INFO_LABEL      = ${DARK_GREEN}INFO:${_END} 
+WARN_LABEL      = ${BOLD}${ORANGE}WARNING:${_END} 
+WARNING_LABEL   = ${BOLD}${ORANGE}WARNING:${_END} 
+NOTE_LABEL      = ${BOLD}${GREEN}NOTE:${_END} 
+INFO_LABEL      = ${BOLD}${DARK_GREEN}INFO:${_END} 
 TIP_LABEL       = ${BOLD}${DARK_GREEN}TIP:${_END} 
 
 # For "special" strings in output:

--- a/.website.mk
+++ b/.website.mk
@@ -7,43 +7,44 @@ CLEAN_DIRS   += ${SITE_DIR} ${WEBSITE_DIR}/.sass-cache
 JEKYLL_PORT  ?= 4000
 
 ifndef WEBSITE_DIR
-$(error ERROR: There is no ${WEBSITE_DIR} directory!)
+$(error ${ERROR}There is no ${WEBSITE_DIR} directory!${_END})
 endif
 
 define help_website_message
-Help for the documentation website:
+${HIGHLIGHT}Help for the documentation website targets:${_END}
 
-make view-pages         # View the published GitHub pages in a browser.
-make view-local         # View the pages locally (requires Jekyll).
-                        # Makes the targets 'setup-jekyll' and 'run-jekyll'
-                        # Tip: "JEKYLL_PORT=8000 make view-local" uses port 8000 instead of 4000!
-make setup-jekyll       # Install Jekyll. Make sure Ruby is installed.
+${CODE}make view-pages${_END}         # View the published GitHub pages in a browser.
+${CODE}make view-local${_END}         # View the pages locally (requires Jekyll).
+                        # Makes the targets ${CODE}setup-jekyll${_END} and ${CODE}run-jekyll${_END}.
+                        # Tip: ${CODE}make JEKYLL_PORT=8000 view-local${_END} uses port 8000 instead of 4000!
+${CODE}make setup-jekyll${_END}       # Install Jekyll. Make sure Ruby is installed.
                         # (Only needed for local viewing of the document.)
-make run-jekyll         # Used by "view-local"; assumes everything is already built.
-                        # Tip: Build this target instead of 'view-local' to avoid repeating 'setup-jekyll'.
-                        # Tip: "JEKYLL_PORT=8000 make run-jekyll" uses port 8000 instead of 4000!
+${CODE}make run-jekyll${_END}         # Used by ${CODE}view-local${_END}; assumes ${CODE}setup-jekyll${_END} is already "built".
+                        # Tip: Build this target instead of ${CODE}view-local${_END} to avoid repeating ${CODE}setup-jekyll${_END}.
+                        # Tip: ${CODE}make JEKYLL_PORT=8000 run-jekyll${_END} uses port 8000 instead of 4000!
 endef
 
 print-info::
 	@echo
-	@echo "GitHub Pages URL:    ${PAGES_URL}"
-	@echo "Website files:       ${WEBSITE_DIR}"
-	@echo "JEKYLL_PORT:         ${JEKYLL_PORT} (when viewing locally: http://localhost:${JEKYLL_PORT})"
+	@echo "${DARK_GREEN}GitHub Pages URL:${_END}   ${CODE}${PAGES_URL}${_END}"
+	@echo "${DARK_GREEN}Website files:${_END}      ${CODE}${WEBSITE_DIR}${_END}"
+	@echo "${DARK_GREEN}JEKYLL_PORT:${_END}        ${CODE}${JEKYLL_PORT}${_END} (when viewing locally: ${CODE}http://localhost:${JEKYLL_PORT}${_END})"
 
 .PHONY: view-pages view-local
 .PHONY: setup-jekyll run-jekyll
 
 view-pages::
 	@python -m webbrowser "${PAGES_URL}" || \
-		$(error "ERROR: I could not open the GitHub Pages URL. Try ⌘-click or ^-click on this URL instead: ${PAGES_URL}")
+		$(error "${ERROR}I could not open the GitHub Pages URL.${_END} Try ⌘-click or ^-click on this URL instead: ${CODE}${PAGES_URL}${_END}")
 
 view-local:: setup-jekyll run-jekyll
 
 # Passing --baseurl '' allows us to use `localhost:4000` rather than require
 # `localhost:4000/The-AI-Alliance/tapestry` when running locally.
+
 run-jekyll: clean
 	@echo
-	@echo "Once you see the http://127.0.0.1:${JEKYLL_PORT}/ URL printed, open it with command+click..."
+	@echo "Once you see the ${CODE}http://127.0.0.1:${JEKYLL_PORT}/${_END} URL printed, open it with command+click..."
 	@echo
 	cd ${WEBSITE_DIR} && \
 		bundle exec jekyll serve --port ${JEKYLL_PORT} --baseurl '' --incremental || \
@@ -55,7 +56,7 @@ setup-jekyll:: ruby-installed-check ruby-gem-installation bundle-command-check b
 .PHONY: jekyll-error ruby-missing-error gem-missing-error gem-error bundle-error bundle-missing-error
 
 ruby-gem-installation::
-	@echo "Updating Ruby gems required for local viewing of the ${WEBSITE_DIR}, including jekyll."
+	@echo "${NOTE}Updating Ruby gems required for local viewing of the website in the '${WEBSITE_DIR}' directory...${_END}"
 	gem install jekyll bundler jemoji || ${MAKE} gem-error
 
 bundle-installation::
@@ -75,36 +76,35 @@ bundle-command-check:
 # invoked, independent of the shell script logic. Hence, the only way to make
 # this invocation conditional is to use a make target invocation, as shown above.
 jekyll-error:
-	$(error "ERROR: Failed to run Jekyll. Try running 'make setup-jekyll'.")
+	$(error "${ERROR}Failed to run Jekyll.${_END} Try running 'make setup-jekyll'.")
 ruby-missing-error:
-	$(error "ERROR: 'ruby' is required. ${ruby_installation_message}")
+	$(error "${ERROR}'ruby' is required.${_END} ${ruby_installation_message}")
 gem-missing-error:
-	$(error "ERROR: Ruby's 'gem' is required. ${ruby_installation_message}")
+	$(error "${ERROR}Ruby's 'gem' is required.${_END} ${ruby_installation_message}")
 gem-error:
 	$(error ${gem-error-message})
 bundle-error:
 	$(error ${bundle-error-message})
 bundle-missing-error:
-	$(error "ERROR: Ruby gem command 'bundle' is required. I tried 'gem install bundle', but it apparently didn't work!")
-
+	$(error "${ERROR}Ruby gem command 'bundle' is required.${_END} I tried ${CODE}gem install bundle${_END}, but it apparently didn't work!")
 
 define gem-error-message
 
-ERROR: Did the gem command fail with a message like this?
-ERROR: 	 "You don't have write permissions for the /Library/Ruby/Gems/2.6.0 directory."
-ERROR: To run the "gem install ..." command for the MacOS default ruby installation requires "sudo".
-ERROR: Instead, use Homebrew (https://brew.sh) to install ruby and make sure "/usr/local/.../bin/gem"
-ERROR: is on your PATH before "user/bin/gem".
-ERROR:
-ERROR: Or did the gem command fail with a message like this?
-ERROR:   Bundler found conflicting requirements for the RubyGems version:
-ERROR:     In Gemfile:
-ERROR:       foo-bar (>= 3.0.0) was resolved to 3.0.0, which depends on
-ERROR:         RubyGems (>= 3.3.22)
-ERROR:
-ERROR:     Current RubyGems version:
-ERROR:       RubyGems (= 3.3.11)
-ERROR: In this case, try "brew upgrade ruby" to get a newer version.
+${ERROR_LABEL}Did the gem command fail with a message like this?
+${ERROR_LABEL}	 "You don't have write permissions for the /Library/Ruby/Gems/2.6.0 directory."
+${ERROR_LABEL}To run the "gem install ..." command for the MacOS default ruby installation requires "sudo".
+${ERROR_LABEL}Instead, use Homebrew (https://brew.sh) to install ruby and make sure "/usr/local/.../bin/gem"
+${ERROR_LABEL}is on your PATH before "user/bin/gem".
+${ERROR_LABEL}
+${ERROR_LABEL}Or did the gem command fail with a message like this?
+${ERROR_LABEL}  Bundler found conflicting requirements for the RubyGems version:
+${ERROR_LABEL}    In Gemfile:
+${ERROR_LABEL}      foo-bar (>= 3.0.0) was resolved to 3.0.0, which depends on
+${ERROR_LABEL}        RubyGems (>= 3.3.22)
+${ERROR_LABEL}
+${ERROR_LABEL}    Current RubyGems version:
+${ERROR_LABEL}      RubyGems (= 3.3.11)
+${ERROR_LABEL}In this case, try "brew upgrade ruby" to get a newer version.
 
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endef
 .PHONY: consortium-demo
 
 consortium-demo::
-	@echo "${INFO}Running the consortium-training demo...${_END}"
+	@echo "${INFO_LABEL}Running the consortium-training demo: ${CODE}examples/consortium_training_demo.py${_END}"
 	uv run python examples/consortium_training_demo.py
 
 # This construct uses the list of .targets.mk files in $(CONTRIB_TARGETS_MKS) and

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,16 @@ include .website.mk
 define help_top_level_message
 For additional help:
 
-make help-targets       # Print help on custom targets, e.g., demonstration commands, etc. (including "contribs").
-make help-website       # Print help for the documentation website.
+${CODE}make help-targets${_END}       # Print help on custom targets, e.g., demonstration commands, etc. (including "contribs").
+${CODE}make help-website${_END}       # Print help for the documentation website.
 endef
 
 define help_top_level_targets_message
 
-For the consortium-training prototype:
-make consortium-demo    # Run the N+1 consortium-training proof-of-concept demo.
-endef
+${HIGHLIGHT}Help for the consortium-training prototype targets:${_END}
 
-print-info::
+${CODE}make consortium-demo${_END}           # Run the N+1 consortium-training proof-of-concept demo.
+endef
 
 .PHONY: consortium-demo
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,16 @@ We use [pytest](https://docs.pytest.org/) for testing. The easiest way to run th
 make unit-tests   # tests is also defined as an alias for unit-tests.
 ```
 
-This runs the following commands:
+This runs `pytest` with coverage reporting, using the following commands:
 
 ```shell
 cd src
-uv run python -m pytest tests -q
+uv run --active coverage run -m pytest -q -v -s
+uv run --active coverage report -m
 ```
+
+> [!NOTE]
+> The `--active` flag is needed for recursive invocation in `contrib/*`, where some of the contributions define their own local `uv/venv` environments.
 
 ## Code Refinement
 
@@ -169,14 +173,19 @@ make type-check-watch
 uv run ty --watch src
 ```
 
-## _Where_ to Create Your Contribution
+## Making Contributions
+
+> [!NOTE]
+> Make sure to read the general guidance in [**Getting Involved**](#getting-involved-anchor) below before submitting a PR.
+
+### _Where_ to Create Your Contribution
 
 If you are enhancing existing code, make the changes under `src`, and when appropriate, the top-level `Makefile` and `.common.mk`.
 
 However, for everything else, including proofs of concept (PoCs), experiments, proposed additions, etc., create them under [`contrib`](contrib/README.md), the staging area for new contributions. The `contrib` [`README`](contrib/README.md) describes the requirements you must follow for new contributions, including how
-the master `make` process works and customizations you might need to make to it.
+the master `make` process works and the customizations you might need to "global" _quality check_ targets, like `tests`, `lint`, etc. For example, there is an easy way to disable some of these checks for PoC code that isn't considered production ready.
 
-## Before You Submit a PR...
+### Before You Submit a PR...
 
 Before submitting a PR, please make these "quality" targets: `format`, `lint` (which makes `ruff` and `pylint`), `type-check`, and `tests`. This needs to be done in both the _production_ `src` tree and all the `contrib` contributions. Use the convenient make target `before-pr`, which handles all of them for you:
 
@@ -191,12 +200,11 @@ However, note that there is a mechanism each `contrib` contribution may use to s
 You can run a specific quality target on one or more contributions as follows. Let's use `contrib/foo` and target `format` as an example:
 
 ```shell
-make SRC_DIR=contrib/foo format  # Make "format" just for "contrib/foo"
-make contrib-format              # Make "format" for ALL "contrib/*"
+# Make "format" just for "contrib/foo"
+make SRC_DIR=contrib/foo --include-dir=contrib/foo format  
+# Make "format" for ALL "contrib/*"
+make contrib-format
 ```
-
-> [!NOTE]
-> Make sure to read the general guidance in [**Getting Involved**](#getting-involved-anchor) below before submitting a PR.
 
 ## Project Code Structure
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -91,7 +91,6 @@ make contrib-pylint        # run just `pylint` for all contrib/*
 ```
 
 (Substitute `pylint` with any of the other quality checks mentioned above, as desired.)
-
 To run checks for your contribution only, let's assume it is named `contrib/johndoe-foo`, then use the following command in the top-level directory to run all the quality targets:
 
 ```shell
@@ -117,19 +116,21 @@ You can find examples in most of the `contrib/*` directories. Customization is d
 override define help_targets_message
 For the consortium-training prototype:
 
-make consortium-experiment
+${CODE}make consortium-experiment${_END}
                         # Run deterministic PoC metrics for consortium-training rounds.
-make consortium-tests   # Run only the consortium-training prototype tests.
+${CODE}make consortium-tests${_END}   # Run only the consortium-training prototype tests.
 endef
 
 # This definition effectively skips the "pylint" and "type-check" targets defined
 # in the top-level Makefile.
 pylint-default type-check-default:
-  @echo "${WARN} ${skip-contrib-target}${_END}"
+  @echo "${skip-contrib-target}"
   @true
 ```
 
 Two of the supported customization mechanisms are shown here.
+
+But first, note the `${CODE}` and `${_END}` `make` variables used in the help message. They provide color highlighting of the output. `${CODE}` starts a string of highlighting and `${_END}` stops it (returning to normal console output). They make messages more readable, but you can omit them in your help messages. See `../.console-colors.mk` for more details about these and other highlighting definitions. See other message definitions in `../.common.mk` for more examples, as well as the examples below that use `${INFO}`, which behaves similarly to `${CODE}` (it takes affect until `${_END}` is seen) and `${INFO_LABEL}`, which shows a highlighted leading "label", `INFO:`, and immediately resets to the normal output, so `${_END}` isn't necessary.
 
 #### Help on Custom Targets You Define
 
@@ -144,7 +145,7 @@ Try `make help-targets` in the top-level directory to see all the help messages 
 
 #### Disable Some Quality Checks
 
-The second customization mechanism is shown for `pylint` and `type-check`. In this contribution, they don't currently pass (and don't really need to pass at this time). Hence, they are _disabled_ by _overriding_ the definitions of the `pylint-default` and `type-check-default` targets to print a warning message (as a reminder to the user), but not actually invoke `pylint` and `type-check`, respectively.
+The second customization mechanism is shown for `pylint` and `type-check` in the example contribution. These quality targets don't currently pass (and don't really need to pass at this time). Hence, they are _disabled_ by _overriding_ the definitions of the `pylint-default` and `type-check-default` targets to print a warning message (as a reminder to the user), but not actually invoke `pylint` and `type-check`, respectively.
 
 In the top level `.common.mk`, the `pylint` target is defined as follows (the other quality targets like `type-check` are similar):
 
@@ -152,32 +153,34 @@ In the top level `.common.mk`, the `pylint` target is defined as follows (the ot
 pylint:: pylint-prerequisite pylint-default pylint-postrequisite
 pylint-prerequisite pylint-postrequisite::
 pylint-default:
-  @echo "${INFO}$@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
+  @echo "${INFO} $@: Running 'pylint' on the code in ${SRC_DIR}.${_END} (configuration in pylintrc.toml)"
   uv run pylint ${SRC_DIR}
 ```
 
 So, if you don't override the definition of `pylint-default` in your `.custom.mk`, the definition in the top level `.common.mk` will be used to run `pylint` on your code.
 
 > [!NOTE]
-> Anytime you disable a quality check by overriding the definition of `x-default`, please use the commands shown in the example above for `contrib/jneums-consortium-experiment/.custom.mk`, so the warning message is issued for the user's benefit!
+> Anytime you disable a quality check by overriding the definition of `x-default`, please use the commands shown in the example above, so the warning message is issued for the user's benefit!
 
-The third and fourth customization mechanisms can be seen in the snippet from the top level `.common.mk` above. The `pylint-prerequisite` target does nothing by default, but if you need to do something _before_ `pylint` is invoked, you can add a definition for this target in your `.custom.mk` file. Similarly, `pylint-postrequisite` does nothing by default, but it can be defined to do work after `pylint` finishes, for example, cleaning up temporary files.
+The third and fourth customization mechanisms can be "suggested" in the snippet from the top level `.common.mk` above. The `pylint-prerequisite` target does nothing by default, but if you need to do something _before_ `pylint` is invoked, you can add a definition for this target in your `.custom.mk` file. Similarly, `pylint-postrequisite` does nothing by default, but it can be defined to do work after `pylint` finishes, for example, cleaning up temporary files.
 
-Let's look at how the prerequisite hook is used before tests are run to set up a custom environment in a different contribution, `contrib/nguyennm1024-sociocultural-alignment/`. In that directory's `.custom.mk` you will find this definition:
+Let's look at how a prerequisite hook can be used before tests are run to set up a custom environment in a different contribution, adapted from `contrib/nguyennm1024-sociocultural-alignment/`:
 
 ```makefile
 unit-tests-prerequisite::
   @cd ${SRC_DIR}; \
     if [ -d .venv ]; \
-    then echo "'.venv' already exists; not running 'uv venv'."; \
+    then echo "${INFO_LABEL}'.venv' already exists; not running 'uv venv'."; \
     else \
       uv venv; \
-      echo "running: uv pip install --requirements requirements.txt"; \
+      echo "${INFO_LABEL}running: uv pip install --requirements requirements.txt"; \
       uv pip install --requirements requirements.txt; \
     fi
 ```
 
-(Recall from above that `SRC_DIR` will be defined to `contrib/nguyennm1024-sociocultural-alignment` by the top level `.common.mk` before this target is built.) Here, `uv` installs some additional dependencies in `contrib/nguyennm1024-sociocultural-alignment/.venv`, used just for this contribution, _before_ any tests are executed by building the `tests-default` target.
+Recall from above that `SRC_DIR` will be defined to `contrib/nguyennm1024-sociocultural-alignment` by the top level `.common.mk` before this target is built. The `${INFO_LABEL}` renders as a bright green `INFO:` prefix, so the messages stand out. 
+
+In this recipe, `uv` installs some additional dependencies in `contrib/nguyennm1024-sociocultural-alignment/.venv`, used just for this contribution, _before_ any tests are executed by building the `tests-default` target.
 
 > [!WARNING]
 >

--- a/contrib/jneums-consortium-experiment/.custom.mk
+++ b/contrib/jneums-consortium-experiment/.custom.mk
@@ -1,16 +1,14 @@
 
 override define help_targets_message
-For the consortium-training prototype:
+${HIGHLIGHT}Help for the consortium-training prototype targets:${_END}
 
-make consortium-experiment-all  # Make all the following targets.
-
-make consortium-experiment
-                        # Run deterministic PoC metrics for consortium-training rounds.
-make consortium-tests   # Run only the consortium-training prototype tests.
+${CODE}make consortium-experiment-all${_END} # Make all the following targets.
+${CODE}make consortium-experiment${_END}     # Run deterministic PoC metrics for consortium-training rounds.
+${CODE}make consortium-tests${_END}          # Run only the consortium-training prototype tests.
 endef
 
 # This definition effectively skips the "pylint" and "type-check" targets defined
 # in the top-level Makefile.
 pylint-default type-check-default:
-	@echo "${WARN} ${skip-contrib-target}${_END}"
+	@echo "${skip-contrib-target}"
 	@true

--- a/contrib/jneums-cultural-cpt-validation/.custom.mk
+++ b/contrib/jneums-cultural-cpt-validation/.custom.mk
@@ -1,16 +1,16 @@
 
 override define help_targets_message
-For the EXP-001 cultural-CPT validation harness (contrib):
+${HIGHLIGHT}Help for the EXP-001 cultural-CPT validation harness (contrib) targets:${_END}
 
-make cultural-cpt-all          # Make all the following targets.
+${CODE}make cultural-cpt-all${_END}          # Make all the following targets.
 
-make cultural-cpt-validation   # Run the arms experiment, single seed (smoke mode).
-make cultural-cpt-aggregation  # Run the FedAvg aggregation-survival experiment.
-make cultural-cpt-stats        # Run the multi-seed go/no-go decision (smoke mode).
-make cultural-cpt-tests        # Run the cultural-CPT harness tests.
+${CODE}make cultural-cpt-validation${_END}   # Run the arms experiment, single seed (smoke mode).
+${CODE}make cultural-cpt-aggregation${_END}  # Run the FedAvg aggregation-survival experiment.
+${CODE}make cultural-cpt-stats${_END}        # Run the multi-seed go/no-go decision (smoke mode).
+${CODE}make cultural-cpt-tests${_END}        # Run the cultural-CPT harness tests.
 
-make cultural-cpt-fetch-seed   # Fetch the real EXP-001 demonstration seed corpus (needs network).
-make cultural-cpt-validate-corpus
+${CODE}make cultural-cpt-fetch-seed${_END}   # Fetch the real EXP-001 demonstration seed corpus (needs network).
+${CODE}make cultural-cpt-validate-corpus${_END}
                                # Validate the corpus against the EXP-001 controls.
 
 endef
@@ -18,5 +18,5 @@ endef
 # This definition effectively skips the "pylint" and "type-check" targets defined
 # in the top-level Makefile.
 pylint-default type-check-default:
-	@echo "${WARN} ${skip-contrib-target}${_END}"
+	@echo "${skip-contrib-target}"
 	@true

--- a/contrib/jneums-flower-wan-spike/.custom.mk
+++ b/contrib/jneums-flower-wan-spike/.custom.mk
@@ -1,5 +1,5 @@
 # This definition effectively skips the "pylint" and "type-check" targets defined
 # in the top-level Makefile.
 pylint-default type-check-default:
-	@echo "${WARN} ${skip-contrib-target}${_END}"
+	@echo "${skip-contrib-target}"
 	@true

--- a/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
+++ b/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
@@ -4,12 +4,12 @@
 
 # unit-tests-prerequisite::
 # 	@cd ${SRC_DIR}; \
-# 	echo "Building $@ in $$(pwd)."; \
+# 	echo "${INFO_LABEL}Building $@ in $$(pwd)."; \
 # 	if [ -d .venv ]; \
-# 	then echo "${WARN}'.venv' already exists; not running 'uv venv'.${_END}"; \
+# 	then echo "${WARNING_LABEL}'.venv' already exists; not running 'uv venv'."; \
 # 	else \
 # 		uv venv; \
-# 		echo "running: uv pip install --requirements requirements.txt"; \
+# 		echo "${INFO_LABEL}running: uv pip install --requirements requirements.txt"; \
 # 		uv pip install --requirements requirements.txt; \
 # 	fi
 
@@ -19,12 +19,12 @@
 # directory, because a separate environment is setup here.
 # unit-tests-default:
 # 	@cd ${SRC_DIR}; \
-# 	echo "${INFO}Building $@ in $$(pwd).${_END}"; \
-# 	echo "running: which source"; \
+# 	echo "${INFO_LABEL}Building $@ in $$(pwd)."; \
+# 	echo "${INFO_LABEL}running: which source"; \
 # 	which source; \
-# 	echo "running: source $$(pwd)/.venv/bin/activate"; \
+# 	echo "${INFO_LABEL}running: source $$(pwd)/.venv/bin/activate"; \
 # 	source $$(pwd)/.venv/bin/activate; \
-# 	echo "running: ${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}"; \
+# 	echo "${INFO_LABEL}running: ${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}"; \
 # 	${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}
 
 # This definition effectively skips the, "ruff", "pylint", "type-check",

--- a/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
+++ b/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
@@ -30,5 +30,5 @@
 # This definition effectively skips the, "ruff", "pylint", "type-check",
 # and "unit-tests" targets defined in the top-level Makefile.
 ruff-default pylint-default type-check-default unit-tests-default:
-	@echo "${WARN} ${skip-contrib-target}${_END}"
+	@echo "${skip-contrib-target}"
 	@true


### PR DESCRIPTION
# [Update] Refinements to the output formatting used in the make recipes

## Description of the PR

The make files define shell escapes for color coding output, but the ones in current use only work with `echo` commands, not make's built in `info`, `warning`, and `error` functions. This PR uses a different scheme that works universally. The PR also adds the use of color coding in strings that are passed to those make functions, now that the colors can be used. It also refines many messages and even simplifies the default "boilerplate" recipes contributions are asked to use when they disable "global" commands, like `tests`, `lint`, etc.

## Related Issues

Related issues or PRs (#number, ...): N/A

## If Code Changes Are Included

### Description of Code Changes

Primarily in `.common.mk`, and new include file, `.console-colors.mk`, and the make files that use them, `Makefile`, and other `*.mk` files.

### Testing Performed

Manually tested on MacOS using `zsh` and on Linux using `bash` and `/bin/sh`, the `dash` shell that is equivalent to the Bourne shell, which is used by `make` by default.

### Example Usage

Include an example of how to use the changed function or feature:

* `make help`
* `make contrib-help`
* `make contrib-list`
* ...

## Checklist

Confirm that the following have been completed.

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

Ignore (or delete) any of the following check list sections or items that aren't applicable, like the code-related check list items when this is a documentation-only PR:

For code changes:

- [x] I have tested the code changes in my local development environment.
- [ ] I have added or modified tests for all code changes.
- [x] I have followed the existing code styles and conventions.
- [ ] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation.

For documentation changes, including `docs`:

- [x] I have followed the existing documentation styles and conventions.
- [ ] I have included helpful diagrams, screenshots, tables, etc.
