### PR TITLE
Standardize contribution and diagram conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_contrib_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_contrib_pr.md
@@ -25,10 +25,10 @@ Because having too many licenses can make managing the project difficult, please
 
 ## Description of Contribution
 
-Please provide a brief description of the contribution in this pull request:
+Lead in plain English with **Why** (problem/gap) then **What** (approach and result). Put detailed **How** after that; when a structural overview helps, start the how with one high-level Mermaid (see `AGENTS.md` § Pull request descriptions and `docs/architecture/diagrams/README.md`).
 
-* What is its purpose?
-* What problem does it solve or otherwise how does it improve Tapestry?
+* What problem does it solve or otherwise how does it improve Tapestry? (**Why**)
+* What is the approach, and what do reviewers/users get when this lands? (**What**)
 
 ## Related Issues
 

--- a/.github/PULL_REQUEST_TEMPLATE/update_docs_code_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update_docs_code_pr.md
@@ -4,10 +4,10 @@
 
 ## Description of the PR
 
-Please provide a brief description of the changes in this pull request:
+Lead in plain English with **Why** (problem/gap) then **What** (approach and result). Put detailed **How** after that; when a structural overview helps, start the how with one high-level Mermaid (see `AGENTS.md` § Pull request descriptions and `docs/architecture/diagrams/README.md`).
 
-* What is its purpose?
-* What problem does it solve or otherwise how does it improve Tapestry?
+* What problem does it solve or otherwise how does it improve Tapestry? (**Why**)
+* What is the approach, and what do reviewers/users get when this lands? (**What**)
 
 ## Related Issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,30 @@ Keep new code aligned with that split. Add tests under the matching `src/tests/t
 - Keep lint/type annotations compatible with `ruff`, `pylint`, and `ty`.
 - Preserve the docs site style in `website/`: Markdown pages, Jekyll front matter, and Just the Docs structure.
 - When editing documentation, keep the audience technical and contributor-focused rather than promotional.
+- When creating or editing Markdown under `docs/`, do not hard-wrap prose paragraphs; use soft wrap and break only for Markdown structure (see `docs/README.md` § Writing conventions).
+- For new inline Mermaid in architecture/reference docs, follow the conventions in `docs/architecture/diagrams/README.md` § Inline Mermaid style (TAP-009 for decision/sovereignty flows; `0-tva-methodology.md` for phased process/status diagrams).
 - Treat governance documents as load-bearing design constraints, not after-the-fact policy notes.
+
+## Pull request descriptions
+
+Write PR titles and bodies for human skimming first. Detail is welcome later; the opening must stand alone in plain English.
+
+**Title.** Outcome-oriented and specific enough to understand without opening the PR (e.g. `Add TAP-009: goal-derived base model selection`, not a file-list or implementation diary).
+
+**Opening (fixed order, plain English).** Put this at the top of the description — before file inventories, commit archaeology, or deep rationale:
+
+1. **Why** — the problem or gap this PR addresses.
+2. **What** — the proposed approach and what reviewers, users, or the project get when it lands (the result, not the mechanism).
+
+A reviewer who reads only the title and these two beats should understand the forest.
+
+**How (details after).** Implementation notes, files touched, edge cases, test evidence, and checklist items come next. Density is fine here.
+
+- When a structural overview helps, **precede the detailed how** with one high-level Mermaid diagram in the recommended style (`docs/architecture/diagrams/README.md` § Inline Mermaid style). Use it for flows, phase shifts, or decision structure — not for typo fixes or pure prose polish.
+- At most one diagram in that leading-how position; further diagrams belong deeper in the details if needed.
+- Prefer project language over repo archaeology in the opening (“propose a gate-then-score selection method” rather than “updated `classDef` in README”).
+
+Keep using the repo PR templates under `.github/PULL_REQUEST_TEMPLATE/` for checklists and contribution process; lead their description sections with Why → What as above.
 
 ## Practical Notes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ The directory index is [`architecture/README.md`](architecture/README.md). Main 
 | [`architecture/3-value-propositions.md`](architecture/3-value-propositions.md) | Phase 3 — what Tapestry offers that the status quo doesn't |
 | [`architecture/4-design-goals.md`](architecture/4-design-goals.md) | Phase 4 — constraints the architecture must satisfy |
 | [`architecture/5-architectural-options.md`](architecture/5-architectural-options.md) | Phase 5 — option space and decision analysis toward an architectural thesis |
-| [`architecture/diagrams/README.md`](architecture/diagrams/README.md) | Architecture figures (SVG in Markdown) and embedding conventions |
+| [`architecture/diagrams/README.md`](architecture/diagrams/README.md) | Architecture figures (SVG in Markdown), embedding conventions, and preferred inline Mermaid style |
 | [`architecture/decisions/`](architecture/decisions/README.md) | Architecture Decision Records (ADRs) |
 
 ## Reference documents
@@ -35,3 +35,9 @@ The [`reference/`](reference/README.md) directory holds material outside the TVA
 | [`reference/training-approaches.md`](reference/training-approaches.md) | Centralized vs. federated vs. consortium training |
 
 Repository root [**`README.md`**](../README.md) and [**`AGENTS.md`**](../AGENTS.md) summarize how `docs/` fits with `website/`, `src/`, and contributor workflows.
+
+## Writing conventions
+
+When creating or editing Markdown under `docs/`:
+
+- **Do not hard-wrap prose.** Write each paragraph as a single logical line (or continuous soft-wrapped text in the editor). Avoid manual line breaks inside a paragraph for visual column width; let the viewer soft-wrap. Use a blank line between paragraphs, and hard breaks only where Markdown structure requires them (lists, headings, code fences, tables, etc.).

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -53,3 +53,4 @@ Avoid consecutive plain Markdown lines like `**Status:** ...` / `**Date:** ...`;
 | [TAP-005](adr-005-sovereign-pipeline.md) | The Sovereign Build | proposed | 4/5 |
 | [TAP-006](adr-006-phased-base-model.md) | Phased base model strategy | proposed | 4/5 |
 | [TAP-007](adr-007-architecture-comparison.md) | Training architecture comparison | proposed | 4/5 |
+| [TAP-008](adr-008-data-sovereignty.md) | Data sovereignty | proposed | 5/5 |

--- a/docs/architecture/diagrams/README.md
+++ b/docs/architecture/diagrams/README.md
@@ -71,3 +71,70 @@ The GitHub Pages site under [`website/`](../../../website/) does not automatical
 ## Naming
 
 Use **kebab-case**, short topic-first names. One **`basename.svg`** per figure.
+
+## Inline Mermaid style (preferred)
+
+New inline Mermaid in architecture/reference docs should follow one of two reference patterns, chosen by diagram job:
+
+| Job | Reference | Use for |
+| :--- | :-------- | :------ |
+| **Decision / purpose flow** | [TAP-009](../decisions/adr-009-goal-derived-base-model-selection.md), also [`training-approaches.md`](../../reference/training-approaches.md) | Sovereignty views, gates, evidence → outcome, consortium phases as purpose layers |
+| **Phased process / status** | [`0-tva-methodology.md`](../0-tva-methodology.md) | Methodology or lifecycle stages, complete/next/pending status, forward flow with revision loops |
+
+Do not invent a parallel palette for the same roles. Older diagrams need not be rewritten unless you are already editing them.
+
+### Mechanics
+
+- Prefer **`classDef` + `class`** over repeated per-node `style` statements (TVA’s older `style P1 …` form is fine when few nodes share a status).
+- Set **`stroke-width:2px`** on class defs when using the TAP-009-style palettes.
+- Put **dark text on light fills** and **white text on saturated fills** (`color:#fff` or a dark near-black).
+- Use **`<br/>`** or `\n` for multi-line node labels; keep labels short enough to read in GitHub’s renderer.
+- Keep high-level diagrams compact enough to scan without excessive horizontal or vertical scrolling. Prefer a balanced aspect ratio, short labels, and grouped concepts; if a diagram remains overwide or overtall, split supporting detail into a second diagram.
+- Choose **shapes by role**, not decoration — for example in TAP-009: hexagon for the top concept, stadiums for sovereignty views, diamond for a non-compensable gate, parallelogram for seeded evidence, double-border rectangle for score-table outputs.
+
+### Edges and structure
+
+From both references:
+
+- **Solid arrows** (`-->`) for the primary forward path.
+- **Dashed labeled arrows** (`-.->|"label"|`) for feedback, revision, or “ripples back” links — never draw revision as if it were the main sequence.
+- **Subgraphs** for named movements or groupings (e.g. Requirements vs Architecture in TVA), with a clear subgraph title.
+
+### Phased process / status palette
+
+Reuse when nodes are stages whose color means progress (as in [`0-tva-methodology.md`](../0-tva-methodology.md)):
+
+| Role | `classDef` name | Fill | Stroke | Text |
+| :--- | :-------------- | :--- | :----- | :--- |
+| Complete / done | `complete` | `#2e7d32` | `#1b5e20` | `#fff` |
+| Next / active | `next` | `#1565c0` | `#0d47a1` | `#fff` |
+| Pending | (default / omit class) | — | — | — |
+
+Follow the diagram with a short **legend** when status colors are used (e.g. Complete · Next · Pending).
+
+### Sovereignty palette
+
+Reuse these when a diagram distinguishes frontier / national / socio-cultural / industrial purposes:
+
+| Role | `classDef` name | Fill | Stroke | Text |
+| :--- | :-------------- | :--- | :----- | :--- |
+| Frontier / collective framing | `frontier` / `collective` | `#1b4965` | `#13365a` (or lighter accent `#62b6cb`) | `#fff` |
+| National | `national` / `base` | `#2c7da0` | `#236a8c` | `#fff` |
+| Socio-cultural | `sociocultural` / `sovereign` | `#5e548e` | `#4a4170` | `#fff` |
+| Industrial | `industrial` | `#bc6c25` | `#9a5619` | `#fff` |
+
+### Decision / evaluation palette
+
+Use when a flowchart moves through scope → gates → evidence → outcome (as in TAP-009):
+
+| Role | `classDef` name | Fill | Stroke | Text |
+| :--- | :-------------- | :--- | :----- | :--- |
+| Scope / iteration bound | `scope` | `#287271` | `#1e5a59` | `#fff` |
+| Non-compensable gate (blocking) | `gate` | `#b23a48` | `#8e2e39` | `#fff` |
+| Neutral evaluation dimensions | `dimensions` | `#fff` | `#546e7a` | `#263238` |
+| Derived weights / positive path | `weights` | `#d8f3dc` | `#2d6a4f` | `#1b4332` |
+| Seeded / provisional evidence | `evidence` | `#fff2cc` | `#d6b656` | `#5d4b00` |
+| Verify / reconcile | `verify` | `#ede7f6` | `#7b1fa2` | `#4a148c` |
+| Accepted / output artifact | `output` | `#2d6a4f` | `#1b4332` | `#fff` |
+
+Copy only the classes a diagram needs.


### PR DESCRIPTION
## Why

Tapestry's contributor guidance did not define a consistent, skimmable opening for pull requests or a shared standard for inline architecture diagrams. That leaves reviewers to reconstruct intent from implementation detail and allows diagrams to become inconsistent or difficult to scan. The ADR index also omitted the existing TAP-008 record.

## What

This adds a shared authoring standard for contributor-facing Markdown: PR descriptions lead with Why, then What, then detailed How; prose uses soft-flow paragraphs; and inline Mermaid diagrams use consistent roles, palettes, shapes, edges, and compact proportions. Both PR templates now point contributors to the same guidance, and the ADR index includes TAP-008.

## How

- Document the PR title and Why → What → How convention in `AGENTS.md`.
- Align both repository PR templates with that opening structure.
- Record the soft-flow Markdown rule in `docs/README.md`.
- Add reusable inline Mermaid guidance for decision flows and phased processes, including a rule against overwide or overtall high-level diagrams.
- Add the missing TAP-008 entry to the ADR index.

## Related Issues

Related PR: #158

## Validation

- `make lint` — Ruff and Pylint passed; Pylint rated the code 10.00/10.
- `git diff --check origin/develop...HEAD` — passed.
- Verified referenced existing local documents and the TAP-008 ADR are present.

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.
- [x] I have followed the existing documentation styles and conventions.
- [x] I have included diagram guidance and examples appropriate to this documentation-only change.
