### PR TITLE
Add equal weighting to the consortium experiment

### DIFF
--- a/contrib/jneums-consortium-experiment/README.md
+++ b/contrib/jneums-consortium-experiment/README.md
@@ -30,5 +30,20 @@ The default run writes:
 - `runs/consortium_experiment/metrics.jsonl` with one JSON object per round;
 - `runs/consortium_experiment/summary.json` with aggregate metrics.
 
+To compare weighting options, run each policy with the same seed and separate
+output directories:
+
+```shell
+PYTHONPATH="$PWD/src:$PWD/contrib/jneums-consortium-experiment" \
+  uv run python contrib/jneums-consortium-experiment/run.py \
+  --weighting quality --seed 7 --out runs/consortium_experiment/quality
+
+PYTHONPATH="$PWD/src:$PWD/contrib/jneums-consortium-experiment" \
+  uv run python contrib/jneums-consortium-experiment/run.py \
+  --weighting equal --seed 7 --out runs/consortium_experiment/equal
+```
+
+Each run replaces `metrics.jsonl` and `summary.json` in its output directory.
+
 Recorded metrics include accepted/rejected nodes, contribution weights, maximum
 node influence, shared-base movement, sovereign artifact count, and node losses.

--- a/contrib/jneums-consortium-experiment/consortium_experiment/experiment.py
+++ b/contrib/jneums-consortium-experiment/consortium_experiment/experiment.py
@@ -10,13 +10,15 @@ from typing import Sequence
 
 import torch
 
-from .metrics import max_weight, state_delta_norm
 from tapestry.training.consortium import (
     ConsortiumCoordinator,
     ContributionPolicy,
+    ContributionWeighting,
     SovereignTrainingNode,
     TinyCausalModel,
 )
+
+from .metrics import max_weight, state_delta_norm
 
 
 @dataclass(frozen=True)
@@ -39,12 +41,14 @@ class PolicySpec:
     name: str = "quality_weighted"
     quality_floor: float = 0.0
     max_node_weight: float = 1.0
+    weighting: ContributionWeighting | str = ContributionWeighting.QUALITY
 
     def build(self) -> ContributionPolicy:
         """Build the contribution policy for this experiment."""
         return ContributionPolicy(
             quality_floor=self.quality_floor,
             max_node_weight=self.max_node_weight,
+            weighting=self.weighting,
         )
 
 
@@ -75,7 +79,7 @@ class RoundMetrics:  # pylint: disable=too-many-instance-attributes
 
 
 @dataclass(frozen=True)
-class ExperimentSummary:
+class ExperimentSummary:  # pylint: disable=too-many-instance-attributes
     """Summary metrics for a completed consortium-training PoC experiment."""
 
     seed: int
@@ -85,6 +89,7 @@ class ExperimentSummary:
     total_rejected_contributions: int
     max_observed_node_weight: float
     final_shared_base_delta_norm: float
+    weighting: str = ContributionWeighting.QUALITY.value
 
 
 @dataclass(frozen=True)
@@ -128,9 +133,10 @@ class ConsortiumExperimentRunner:  # pylint: disable=too-few-public-methods
             vocab_size=self.config.model_vocab_size,
             hidden_size=self.config.model_hidden_size,
         )
+        policy = self.config.policy.build()
         coordinator = ConsortiumCoordinator(
             base_model=base_model,
-            contribution_policy=self.config.policy.build(),
+            contribution_policy=policy,
         )
         nodes = [self._build_node(node_spec, base_model) for node_spec in self.config.nodes]
 
@@ -161,6 +167,7 @@ class ConsortiumExperimentRunner:  # pylint: disable=too-few-public-methods
             seed=self.config.seed,
             rounds=self.config.rounds,
             policy_name=self.config.policy.name,
+            weighting=policy.weighting.value,
             final_artifact_count=len(coordinator.sovereign_artifacts),
             total_rejected_contributions=sum(len(metrics.rejected_nodes) for metrics in round_metrics),
             max_observed_node_weight=max((metrics.max_node_weight for metrics in round_metrics), default=0.0),

--- a/contrib/jneums-consortium-experiment/run.py
+++ b/contrib/jneums-consortium-experiment/run.py
@@ -18,6 +18,7 @@ from consortium_experiment import (  # noqa: E402
     NodeSpec,
     PolicySpec,
 )
+from tapestry.training.consortium import ContributionWeighting  # noqa: E402
 
 DOMAIN_CORPORA: dict[str, list[str]] = {
     "vietnam": [
@@ -43,20 +44,31 @@ QUALITY_SCORES = {
     "india": 0.88,
 }
 
+POLICY_NAMES = {
+    ContributionWeighting.QUALITY: "quality_floor_capped",
+    ContributionWeighting.EQUAL: "equal_after_quality_floor",
+}
+
 
 def _encode(texts: list[str]) -> list[list[int]]:
     """Byte-encode text into the tiny model's vocabulary range."""
     return [[token % 128 for token in text.encode("utf-8")] for text in texts]
 
 
-def _default_config(rounds: int, seed: int) -> ExperimentConfig:
+def _default_config(
+    rounds: int,
+    seed: int,
+    weighting: ContributionWeighting | str = ContributionWeighting.QUALITY,
+) -> ExperimentConfig:
+    weighting = ContributionWeighting(weighting)
     return ExperimentConfig(
         seed=seed,
         rounds=rounds,
         policy=PolicySpec(
-            name="quality_floor_capped",
+            name=POLICY_NAMES[weighting],
             quality_floor=0.75,
             max_node_weight=0.5,
+            weighting=weighting,
         ),
         nodes=[
             NodeSpec(
@@ -80,15 +92,24 @@ def main() -> None:
     )
     parser.add_argument("--rounds", type=int, default=3, help="number of consortium-training rounds")
     parser.add_argument("--seed", type=int, default=7, help="random seed for deterministic runs")
+    parser.add_argument(
+        "--weighting",
+        choices=tuple(weighting.value for weighting in POLICY_NAMES),
+        default=ContributionWeighting.QUALITY.value,
+        help="contribution weighting policy to run",
+    )
     args = parser.parse_args()
 
-    result = ConsortiumExperimentRunner(_default_config(rounds=args.rounds, seed=args.seed)).run()
+    result = ConsortiumExperimentRunner(
+        _default_config(rounds=args.rounds, seed=args.seed, weighting=args.weighting)
+    ).run()
     result.write_json(args.out)
 
     print("Tapestry consortium-training PoC metrics")
     print(f"  output dir                 : {args.out}")
     print(f"  rounds                     : {result.summary.rounds}")
     print(f"  policy                     : {result.summary.policy_name}")
+    print(f"  weighting                  : {result.summary.weighting}")
     print(f"  final artifact count       : {result.summary.final_artifact_count}")
     print(f"  rejected contributions     : {result.summary.total_rejected_contributions}")
     print(f"  max observed node weight   : {result.summary.max_observed_node_weight:.3f}")

--- a/contrib/jneums-consortium-experiment/tests/test_experiment.py
+++ b/contrib/jneums-consortium-experiment/tests/test_experiment.py
@@ -98,6 +98,23 @@ def test_experiment_records_anti_capture_cap() -> None:
     assert sum(round_metrics.contribution_weights.values()) == pytest.approx(1.0)
 
 
+def test_experiment_supports_equal_contribution_weighting() -> None:
+    """Equal weighting should give every accepted node the same influence."""
+    config = _config(
+        PolicySpec(name="equal_after_quality_floor", quality_floor=0.75, weighting="equal"),
+        rounds=1,
+    )
+
+    result = ConsortiumExperimentRunner(config).run()
+
+    assert result.rounds[0].contribution_weights == {
+        "vietnam": pytest.approx(0.5),
+        "swiss": pytest.approx(0.5),
+    }
+    assert result.rounds[0].rejected_nodes == ["india"]
+    assert result.summary.weighting == "equal"
+
+
 def test_experiment_records_n_plus_one_artifacts_and_shared_base_change() -> None:
     """The metrics should preserve N sovereign artifacts and show base movement."""
     config = _config(PolicySpec(name="quality_weighted", quality_floor=0.1), rounds=1)
@@ -132,6 +149,7 @@ def test_experiment_writes_json_metrics_and_summary(tmp_path) -> None:
     assert metric_lines[1]["round_num"] == 2
     assert summary["rounds"] == 2
     assert summary["policy_name"] == "quality_weighted"
+    assert summary["weighting"] == "quality"
 
 
 def test_state_delta_norm_rejects_mismatched_model_states() -> None:


### PR DESCRIPTION
## Description of the PR

Adds the equal option from #91 to the experiment from #47, so it can save results for either weighting option. It also records which option was used, adds a test, and shows how to run both with the same seed.

## Related Issues

Closes #68.

### Testing Performed

- `make consortium-tests`
- Ran both options locally and confirmed repeated runs with the same seed matched.

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.
- [x] I have tested the code changes in my local development environment.
- [x] I have added or modified tests for all code changes.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation.
