### PR TITLE
[New Contribution] Logically-grounded DPO/PPO explanation training pipeline

### DIFF
--- a/contrib/14H034160212-logically-grounded-dpo/.custom.mk
+++ b/contrib/14H034160212-logically-grounded-dpo/.custom.mk
@@ -1,0 +1,8 @@
+# This contribution is an excerpted, as-published reference implementation (see
+# README.md); its dependencies (transformers, peft, trl, pandas, ...) are not part
+# of the project's own dependency set, so pylint/type-check are not meaningful here.
+# This effectively skips the "pylint" and "type-check" targets defined in the
+# top-level Makefile.
+pylint-default type-check-default:
+	@echo "${skip-contrib-target}"
+	@true

--- a/contrib/14H034160212-logically-grounded-dpo/LICENSE
+++ b/contrib/14H034160212-logically-grounded-dpo/LICENSE
@@ -1,0 +1,8 @@
+This contribution follows the repository default licenses:
+
+- Code: Apache License, Version 2.0. See [LICENSES/LICENSE.Apache-2.0](../../LICENSES/LICENSE.Apache-2.0).
+- Documentation: Creative Commons Attribution 4.0 International. See [LICENSES/LICENSE.CC-BY-4.0](../../LICENSES/LICENSE.CC-BY-4.0).
+
+Copyright (c) 2025-2026 Qiming Bao. Released here under Apache-2.0 for this
+excerpted training-code contribution. No data is included (see the "Data
+clearance" section of the accompanying README.md).

--- a/contrib/14H034160212-logically-grounded-dpo/README.md
+++ b/contrib/14H034160212-logically-grounded-dpo/README.md
@@ -1,0 +1,97 @@
+# Logically-Grounded DPO: Answer-Grounded Preference Optimization for Explanation Generation
+
+**Status: Validated (published).** Method and results below are from a
+peer-reviewed arXiv paper; this directory contributes the core reference
+implementation for Tapestry's consideration, not a finished integration. **No
+data is included** — see [Data clearance](#data-clearance) below.
+
+## Motivation
+
+A model can be fluent and still fail to *justify the correct answer* — high
+surface-similarity scores (BLEU, BERTScore against a reference explanation)
+don't tell you whether a generated explanation actually implies the correct
+answer. This is a general risk for any consortium base model asked to explain
+its reasoning (tutoring, decision support, code review, etc.), not specific to
+one domain: a fluent, plausible-sounding justification can still be logically
+disconnected from the answer it's supposedly justifying.
+
+We built and evaluated a fix for this in the educational-explanation domain
+(justifying answers to multiple-choice exam questions), but the technique
+itself — an automated, verifier-based preference-pair construction plus an
+NLI-grounded reward — is domain-agnostic.
+
+## What this contributes
+
+Reference implementation of a training pipeline (SFT → verifier-based
+preference-pair construction → DPO/PPO with an NLI-grounded reward) that
+replaces standard reference-text similarity metrics with a reward tied to
+whether the generated explanation *logically entails* the correct answer:
+
+- **`logically-grounded-dpo/rl_train_sft.py`** — LoRA SFT baseline (stage 1).
+- **`logically-grounded-dpo/rl_build_preference_data.py`** — automatically
+  constructs DPO preference pairs by sampling N candidate explanations per
+  question and scoring them with a domain-trained verifier model, instead of
+  relying on expensive human annotation or a fixed external teacher model.
+- **`logically-grounded-dpo/rl_generate_synthetic_data.py`** — augments
+  preference pairs with GPT-4o/Claude chain-of-thought synthetic positives and
+  model-generated hard negatives, to counter reward hacking.
+- **`logically-grounded-dpo/rl_train_dpo.py`** — offline preference
+  optimisation (DPO) over the constructed pairs.
+- **`logically-grounded-dpo/rl_train_ppo_nli.py`** — online alternative (PPO)
+  using a live NLI-entailment reward instead of an offline preference dataset.
+- **`logically-grounded-dpo/rl_evaluation.py`** — the evaluation framework
+  itself: a three-tier answer-grounded metric suite (BERTScore-vs-answer,
+  Answer Coverage Rate, and NLI entailment against the correct option, rather
+  than against student reference text). The NLI metric is the most
+  discriminative signal in our experiments — the SFT baseline scores ~0.05
+  while RL-trained models score 0.22–0.30 (4–5x gap) — precisely because it
+  captures logical entailment rather than surface similarity.
+
+All scripts are LoRA fine-tuning / RL training code (PEFT + `transformers`
+`Trainer`, TRL for DPO/PPO) evaluated across LLaMA-2-13B, LLaMA-3-8B, Qwen3-8B,
+and Gemma-3-4B backbones.
+
+## How to try / evaluate
+
+The full project (additional model variants, evaluation logs, and the paper
+sources) is public:
+
+- Code: https://github.com/14H034160212/Explanation-Generation
+- Paper: https://arxiv.org/abs/2605.04539 — *"RLearner-LLM: Balancing Logical
+  Grounding and Fluency in Large Language Models via Hybrid Direct Preference
+  Optimization"* (Bao, Leinonen, Denny, Witbrock)
+
+The scripts here are excerpted as-is to make the core method (verifier-based
+preference construction + NLI-grounded reward) reviewable without pulling in
+the full set of per-model/per-domain training variants in the source
+repository. See each script's module docstring and `--help` for the expected
+input schema and CLI usage.
+
+## Data clearance
+
+This contribution is **code only**. The underlying training/evaluation data
+(PeerWise multiple-choice exam questions and per-student answer submissions
+from partner institutions) is student-generated educational-assessment data
+subject to institutional data-use agreements, and is explicitly excluded from
+the public source repository (`.gitignore`'d) and from this contribution. None
+of it is included, referenced by value, or reproduced here — only the training
+code, which operates on data in a documented schema (see script docstrings)
+that a Tapestry partner would supply from their own cleared source.
+
+## Relevance to Tapestry
+
+The verifier-based automatic preference construction and NLI-grounded reward
+are reusable as a general post-training technique for any Tapestry-derived
+model expected to produce explanations, justifications, or reasoning traces
+that must be *checked against*, not just *fluent around*, a ground-truth
+answer.
+
+## License
+
+This contribution follows the repository default licenses:
+
+- Code: Apache License, Version 2.0. See [LICENSES/LICENSE.Apache-2.0](../../LICENSES/LICENSE.Apache-2.0).
+- Documentation: Creative Commons Attribution 4.0 International. See [LICENSES/LICENSE.CC-BY-4.0](../../LICENSES/LICENSE.CC-BY-4.0).
+
+Copyright (c) 2025-2026 Qiming Bao. Released here under Apache-2.0 for this
+excerpted training-code contribution.

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_build_preference_data.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_build_preference_data.py
@@ -1,0 +1,397 @@
+"""
+RLearner-LLM Step 2: Build DPO Preference Dataset
+
+For each question in the PeerWise dataset:
+  1. Use the SFT generator to sample N explanations at varying temperatures.
+  2. Score each explanation with the trained Verifier model.
+  3. Pair the highest-scoring explanation (chosen) against the lowest-scoring (rejected).
+  4. Optionally inject synthetic hard negatives (reversed logic, high-score gibberish).
+
+Output format (compatible with rl_train_dpo.py):
+  [{"prompt": "...", "chosen": "...", "rejected": "...", "chosen_score": x, "rejected_score": y}, ...]
+
+Usage:
+    python rl_build_preference_data.py \
+        --generator_path ./rl_sft_qwen3_14b_generator \
+        --verifier_path ./llama_2_13B_merged_all_evaluator \
+        --data_path ./Paul_new_data/Merged_Sydney_Cardiff_Law_Medical_Y1_Y2/generator_merged_avg_3_lenexp_10.json \
+        --output_path ./rl_preference_data/preference_pairs.json \
+        --num_samples 6 \
+        --min_score_gap 0.5
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import random
+from typing import List, Optional
+
+import torch
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = (
+    "You are an expert educator specializing in generating high-quality explanations "
+    "for exam questions. Your explanations should be clear, accurate, educational, "
+    "and written in a style similar to how knowledgeable students explain answers."
+)
+
+VERIFIER_INSTRUCTION = (
+    "As a question rating verifier expert, can you generate the question rating score "
+    "for the given input?"
+)
+
+# Hard negative templates for synthetic data augmentation
+HARD_NEGATIVE_TEMPLATES = [
+    # Reversed logic: attribute cause to wrong option
+    "The incorrect option is actually correct because {wrong_reason}. Therefore the answer must be wrong.",
+    # Gibberish high-confidence
+    "This question is straightforward. The answer is undeniably correct based on fundamental principles, "
+    "which clearly demonstrate the inherent validity of the chosen response in all applicable contexts.",
+    # Off-topic
+    "While this is an interesting topic, it's worth noting that many related concepts exist in this field. "
+    "Various factors contribute to understanding this area of study comprehensively.",
+]
+
+
+class VerifierScorer:
+    """Wrapper around the trained LLaMA-2 Verifier to extract numerical scores."""
+
+    def __init__(self, model_path: str, device: str = "cuda", cache_dir: str = "cache"):
+        logger.info(f"Loading verifier from {model_path} ...")
+        # use_fast=False avoids LlamaTokenizerFast infinite recursion on older
+        # model configs that have a circular bos_token_id → unk_token_id lookup.
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_path, cache_dir=cache_dir, trust_remote_code=True, use_fast=False
+        )
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            torch_dtype=torch.float16,
+            low_cpu_mem_usage=True,
+            cache_dir=cache_dir,
+            trust_remote_code=True,
+        ).to(device)
+        self.model.eval()
+        self.device = device
+        logger.info("Verifier loaded.")
+
+    @torch.no_grad()
+    def score(self, question_input: str, explanation: str) -> float:
+        """
+        Score an explanation given the question context.
+        Returns a float in [0, 5]. Returns -1.0 if parsing fails.
+        """
+        merged = f"{question_input} Explanation: {explanation}"
+        fulltext = (
+            f"Instruction: {VERIFIER_INSTRUCTION}\n\n"
+            f"Input: {merged}\n\n"
+            f"Output: "
+        )
+        tokens = self.tokenizer(fulltext, return_tensors="pt").input_ids.to(self.device)
+        generated = self.model.generate(
+            tokens,
+            max_new_tokens=32,
+            use_cache=True,
+            pad_token_id=self.tokenizer.eos_token_id,
+            do_sample=False,
+            temperature=1.0,
+        )
+        generated_text = self.tokenizer.decode(generated[0], skip_special_tokens=True)
+
+        # Extract score from "Output: X.X" pattern
+        match = re.search(r"Output:\s*(\d+(?:\.\d+)?)", generated_text)
+        if match:
+            return float(match.group(1))
+        # Fallback: look for any float in the generated part after "Output:"
+        after_output = generated_text.split("Output:")[-1]
+        match = re.search(r"(\d+(?:\.\d+)?)", after_output)
+        if match:
+            return float(match.group(1))
+        logger.warning(f"Could not parse score from: {generated_text[:100]}")
+        return -1.0
+
+
+class ExplanationGenerator:
+    """Wraps the SFT generator (with optional LoRA adapter) for multi-sample generation."""
+
+    def __init__(
+        self,
+        model_path: str,
+        lora_adapter_path: Optional[str] = None,
+        device: str = "cuda",
+        cache_dir: str = "cache",
+    ):
+        logger.info(f"Loading generator from {model_path} ...")
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_path, cache_dir=cache_dir, trust_remote_code=True
+        )
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            cache_dir=cache_dir,
+            trust_remote_code=True,
+        ).to(device)
+
+        if lora_adapter_path and os.path.isdir(lora_adapter_path):
+            logger.info(f"Loading LoRA adapter from {lora_adapter_path} ...")
+            self.model = PeftModel.from_pretrained(self.model, lora_adapter_path)
+            self.model = self.model.merge_and_unload()  # Merge for faster inference
+
+        self.model.eval()
+        self.device = device
+        logger.info("Generator loaded.")
+
+    def _build_prompt(self, instruction: str, input_text: str) -> str:
+        """Build Alpaca-format inference prompt (no response text, ends with ### Response:)."""
+        return build_prompt_for_dpo(instruction, input_text)
+
+    @torch.no_grad()
+    def generate_samples(
+        self,
+        instruction: str,
+        input_text: str,
+        num_samples: int = 6,
+        temperatures: Optional[List[float]] = None,
+        max_new_tokens: int = 512,
+    ) -> List[str]:
+        """
+        Generate `num_samples` diverse explanations by cycling through different temperatures.
+        Returns list of generated explanation strings.
+        """
+        if temperatures is None:
+            # Spread across conservative to exploratory temperatures
+            temperatures = [0.3, 0.5, 0.7, 0.9, 1.1, 1.3]
+
+        prompt = self._build_prompt(instruction, input_text)
+        tokens = self.tokenizer(prompt, return_tensors="pt").input_ids.to(self.device)
+
+        samples = []
+        for i in range(num_samples):
+            temp = temperatures[i % len(temperatures)]
+            output_ids = self.model.generate(
+                tokens,
+                max_new_tokens=max_new_tokens,
+                do_sample=True,
+                temperature=temp,
+                top_p=0.95,
+                top_k=50,
+                repetition_penalty=1.1,
+                pad_token_id=self.tokenizer.eos_token_id,
+                use_cache=True,
+            )
+            full_text = self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
+            # Strip the prompt from the output
+            if full_text.startswith(prompt):
+                response = full_text[len(prompt):].strip()
+            else:
+                # For chat-template models, extract after last assistant turn
+                parts = full_text.split("assistant")
+                response = parts[-1].strip() if len(parts) > 1 else full_text.strip()
+
+            if response:
+                samples.append(response)
+
+        return samples
+
+
+def build_prompt_for_dpo(instruction: str, input_text: str) -> str:
+    """
+    Build Alpaca-format prompt for DPO dataset.
+
+    Ends with '### Response:\\n' so TRL 0.7.1 DPOTrainer can identify the
+    boundary between prompt tokens and response tokens.
+    Must match the ALPACA_TEMPLATE used in rl_train_sft.py (without the output).
+    """
+    return (
+        "Below is an instruction that describes a task, paired with an input that "
+        "provides further context. Write a response that appropriately completes the request.\n\n"
+        f"### Instruction:\n{instruction}\n\n"
+        f"### Input:\n{input_text}\n\n"
+        "### Response:\n"
+    )
+
+
+def add_synthetic_hard_negatives(
+    preference_pairs: List[dict],
+    hard_negative_ratio: float = 0.2,
+) -> List[dict]:
+    """
+    Augment the dataset with synthetic hard negatives.
+    Selects ~hard_negative_ratio of the pairs and replaces the rejected
+    explanation with a template-based hard negative (confusing, off-topic, etc.).
+    """
+    augmented = list(preference_pairs)
+    num_to_augment = int(len(preference_pairs) * hard_negative_ratio)
+    indices = random.sample(range(len(preference_pairs)), min(num_to_augment, len(preference_pairs)))
+
+    for idx in indices:
+        template = random.choice(HARD_NEGATIVE_TEMPLATES)
+        hard_neg = template.format(wrong_reason="the logic is inverted in this context")
+        new_pair = dict(preference_pairs[idx])
+        new_pair["rejected"] = hard_neg
+        new_pair["rejected_score"] = 0.0
+        new_pair["is_synthetic"] = True
+        augmented.append(new_pair)
+
+    logger.info(f"Added {len(indices)} synthetic hard negatives. Total pairs: {len(augmented)}")
+    return augmented
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build DPO preference dataset for RLearner-LLM.")
+    parser.add_argument("--generator_path", required=True,
+                        help="Path to the SFT generator model (local dir or HF model ID).")
+    parser.add_argument("--lora_adapter_path", default=None,
+                        help="Optional LoRA adapter path to load on top of the generator.")
+    parser.add_argument("--verifier_path", required=True,
+                        help="Path to the trained verifier model (e.g., llama_2_13B_merged_all_evaluator).")
+    parser.add_argument("--data_path", required=True,
+                        help="Input PeerWise JSON file (fields: instruction, input, output).")
+    parser.add_argument("--output_path", required=True,
+                        help="Output path for preference JSON dataset.")
+    parser.add_argument("--num_samples", type=int, default=6,
+                        help="Number of explanations to generate per question.")
+    parser.add_argument("--max_new_tokens", type=int, default=512,
+                        help="Max tokens for each generated explanation.")
+    parser.add_argument("--min_score_gap", type=float, default=0.3,
+                        help="Minimum score gap between chosen and rejected. Pairs below this are skipped.")
+    parser.add_argument("--add_hard_negatives", action="store_true",
+                        help="Add synthetic hard negative examples to the dataset.")
+    parser.add_argument("--hard_negative_ratio", type=float, default=0.2,
+                        help="Fraction of pairs to augment with hard negatives.")
+    parser.add_argument("--generator_device", default="cuda:0",
+                        help="Device for generator model.")
+    parser.add_argument("--verifier_device", default="cuda:1",
+                        help="Device for verifier model (separate GPU recommended).")
+    parser.add_argument("--cache_dir", default="cache",
+                        help="Model cache directory.")
+    parser.add_argument("--max_questions", type=int, default=None,
+                        help="Limit processing to N questions (for testing).")
+    args = parser.parse_args()
+
+    os.makedirs(os.path.dirname(args.output_path) or ".", exist_ok=True)
+
+    # Load models
+    generator = ExplanationGenerator(
+        model_path=args.generator_path,
+        lora_adapter_path=args.lora_adapter_path,
+        device=args.generator_device,
+        cache_dir=args.cache_dir,
+    )
+    verifier = VerifierScorer(
+        model_path=args.verifier_path,
+        device=args.verifier_device,
+        cache_dir=args.cache_dir,
+    )
+
+    # Load data
+    with open(args.data_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+
+    if args.max_questions:
+        raw_data = raw_data[: args.max_questions]
+        logger.info(f"Processing {len(raw_data)} questions (limited by --max_questions).")
+    else:
+        logger.info(f"Processing {len(raw_data)} questions.")
+
+    preference_pairs = []
+    skipped_no_gap = 0
+    skipped_empty = 0
+
+    for item in tqdm(raw_data, desc="Building preference pairs"):
+        instruction = item.get("instruction", "").replace("</s>", "").strip()
+        input_text = item.get("input", "").replace("</s>", "").strip()
+        ground_truth = item.get("output", item.get("Explanation", "")).replace("</s>", "").strip()
+
+        if not input_text:
+            skipped_empty += 1
+            continue
+
+        # Generate N candidate explanations
+        candidates = generator.generate_samples(
+            instruction=instruction,
+            input_text=input_text,
+            num_samples=args.num_samples,
+            max_new_tokens=args.max_new_tokens,
+        )
+
+        # If we have the ground truth and it's non-empty, include it as a candidate
+        if ground_truth:
+            candidates.append(ground_truth)
+
+        if len(candidates) < 2:
+            skipped_empty += 1
+            continue
+
+        # Score all candidates
+        scored = []
+        for cand in candidates:
+            if cand.strip():
+                s = verifier.score(input_text, cand)
+                if s >= 0:  # -1 means parsing failed
+                    scored.append((cand, s))
+
+        if len(scored) < 2:
+            skipped_empty += 1
+            continue
+
+        # Sort by score descending
+        scored.sort(key=lambda x: x[1], reverse=True)
+        best_explanation, best_score = scored[0]
+        worst_explanation, worst_score = scored[-1]
+
+        score_gap = best_score - worst_score
+        if score_gap < args.min_score_gap:
+            skipped_no_gap += 1
+            continue
+
+        prompt_text = build_prompt_for_dpo(instruction, input_text)
+        preference_pairs.append({
+            "prompt": prompt_text,
+            "chosen": best_explanation,
+            "rejected": worst_explanation,
+            "chosen_score": best_score,
+            "rejected_score": worst_score,
+            "score_gap": score_gap,
+            "is_synthetic": False,
+        })
+
+    logger.info(
+        f"Built {len(preference_pairs)} preference pairs. "
+        f"Skipped: {skipped_no_gap} (score gap too small), {skipped_empty} (empty/parse error)."
+    )
+
+    # Optionally inject synthetic hard negatives
+    if args.add_hard_negatives and preference_pairs:
+        preference_pairs = add_synthetic_hard_negatives(
+            preference_pairs, hard_negative_ratio=args.hard_negative_ratio
+        )
+
+    # Save
+    with open(args.output_path, "w", encoding="utf-8") as f:
+        json.dump(preference_pairs, f, ensure_ascii=False, indent=2)
+    logger.info(f"Preference dataset saved to {args.output_path}")
+
+    # Print statistics
+    if preference_pairs:
+        scores_gap = [p["score_gap"] for p in preference_pairs if not p.get("is_synthetic")]
+        avg_gap = sum(scores_gap) / len(scores_gap) if scores_gap else 0
+        logger.info(f"Average score gap: {avg_gap:.3f}")
+        logger.info(f"Score gap range: [{min(scores_gap):.2f}, {max(scores_gap):.2f}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_build_preference_data.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_build_preference_data.py
@@ -46,8 +46,7 @@ SYSTEM_PROMPT = (
 )
 
 VERIFIER_INSTRUCTION = (
-    "As a question rating verifier expert, can you generate the question rating score "
-    "for the given input?"
+    "As a question rating verifier expert, can you generate the question rating score " "for the given input?"
 )
 
 # Hard negative templates for synthetic data augmentation
@@ -91,11 +90,7 @@ class VerifierScorer:
         Returns a float in [0, 5]. Returns -1.0 if parsing fails.
         """
         merged = f"{question_input} Explanation: {explanation}"
-        fulltext = (
-            f"Instruction: {VERIFIER_INSTRUCTION}\n\n"
-            f"Input: {merged}\n\n"
-            f"Output: "
-        )
+        fulltext = f"Instruction: {VERIFIER_INSTRUCTION}\n\n" f"Input: {merged}\n\n" f"Output: "
         tokens = self.tokenizer(fulltext, return_tensors="pt").input_ids.to(self.device)
         generated = self.model.generate(
             tokens,
@@ -131,9 +126,7 @@ class ExplanationGenerator:
         cache_dir: str = "cache",
     ):
         logger.info(f"Loading generator from {model_path} ...")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_path, cache_dir=cache_dir, trust_remote_code=True
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path, cache_dir=cache_dir, trust_remote_code=True)
         if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
 
@@ -195,7 +188,7 @@ class ExplanationGenerator:
             full_text = self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
             # Strip the prompt from the output
             if full_text.startswith(prompt):
-                response = full_text[len(prompt):].strip()
+                response = full_text[len(prompt) :].strip()
             else:
                 # For chat-template models, extract after last assistant turn
                 parts = full_text.split("assistant")
@@ -252,34 +245,43 @@ def add_synthetic_hard_negatives(
 
 def main():
     parser = argparse.ArgumentParser(description="Build DPO preference dataset for RLearner-LLM.")
-    parser.add_argument("--generator_path", required=True,
-                        help="Path to the SFT generator model (local dir or HF model ID).")
-    parser.add_argument("--lora_adapter_path", default=None,
-                        help="Optional LoRA adapter path to load on top of the generator.")
-    parser.add_argument("--verifier_path", required=True,
-                        help="Path to the trained verifier model (e.g., llama_2_13B_merged_all_evaluator).")
-    parser.add_argument("--data_path", required=True,
-                        help="Input PeerWise JSON file (fields: instruction, input, output).")
-    parser.add_argument("--output_path", required=True,
-                        help="Output path for preference JSON dataset.")
-    parser.add_argument("--num_samples", type=int, default=6,
-                        help="Number of explanations to generate per question.")
-    parser.add_argument("--max_new_tokens", type=int, default=512,
-                        help="Max tokens for each generated explanation.")
-    parser.add_argument("--min_score_gap", type=float, default=0.3,
-                        help="Minimum score gap between chosen and rejected. Pairs below this are skipped.")
-    parser.add_argument("--add_hard_negatives", action="store_true",
-                        help="Add synthetic hard negative examples to the dataset.")
-    parser.add_argument("--hard_negative_ratio", type=float, default=0.2,
-                        help="Fraction of pairs to augment with hard negatives.")
-    parser.add_argument("--generator_device", default="cuda:0",
-                        help="Device for generator model.")
-    parser.add_argument("--verifier_device", default="cuda:1",
-                        help="Device for verifier model (separate GPU recommended).")
-    parser.add_argument("--cache_dir", default="cache",
-                        help="Model cache directory.")
-    parser.add_argument("--max_questions", type=int, default=None,
-                        help="Limit processing to N questions (for testing).")
+    parser.add_argument(
+        "--generator_path", required=True, help="Path to the SFT generator model (local dir or HF model ID)."
+    )
+    parser.add_argument(
+        "--lora_adapter_path", default=None, help="Optional LoRA adapter path to load on top of the generator."
+    )
+    parser.add_argument(
+        "--verifier_path",
+        required=True,
+        help="Path to the trained verifier model (e.g., llama_2_13B_merged_all_evaluator).",
+    )
+    parser.add_argument(
+        "--data_path", required=True, help="Input PeerWise JSON file (fields: instruction, input, output)."
+    )
+    parser.add_argument("--output_path", required=True, help="Output path for preference JSON dataset.")
+    parser.add_argument("--num_samples", type=int, default=6, help="Number of explanations to generate per question.")
+    parser.add_argument("--max_new_tokens", type=int, default=512, help="Max tokens for each generated explanation.")
+    parser.add_argument(
+        "--min_score_gap",
+        type=float,
+        default=0.3,
+        help="Minimum score gap between chosen and rejected. Pairs below this are skipped.",
+    )
+    parser.add_argument(
+        "--add_hard_negatives", action="store_true", help="Add synthetic hard negative examples to the dataset."
+    )
+    parser.add_argument(
+        "--hard_negative_ratio", type=float, default=0.2, help="Fraction of pairs to augment with hard negatives."
+    )
+    parser.add_argument("--generator_device", default="cuda:0", help="Device for generator model.")
+    parser.add_argument(
+        "--verifier_device", default="cuda:1", help="Device for verifier model (separate GPU recommended)."
+    )
+    parser.add_argument("--cache_dir", default="cache", help="Model cache directory.")
+    parser.add_argument(
+        "--max_questions", type=int, default=None, help="Limit processing to N questions (for testing)."
+    )
     args = parser.parse_args()
 
     os.makedirs(os.path.dirname(args.output_path) or ".", exist_ok=True)
@@ -359,15 +361,17 @@ def main():
             continue
 
         prompt_text = build_prompt_for_dpo(instruction, input_text)
-        preference_pairs.append({
-            "prompt": prompt_text,
-            "chosen": best_explanation,
-            "rejected": worst_explanation,
-            "chosen_score": best_score,
-            "rejected_score": worst_score,
-            "score_gap": score_gap,
-            "is_synthetic": False,
-        })
+        preference_pairs.append(
+            {
+                "prompt": prompt_text,
+                "chosen": best_explanation,
+                "rejected": worst_explanation,
+                "chosen_score": best_score,
+                "rejected_score": worst_score,
+                "score_gap": score_gap,
+                "is_synthetic": False,
+            }
+        )
 
     logger.info(
         f"Built {len(preference_pairs)} preference pairs. "
@@ -376,9 +380,7 @@ def main():
 
     # Optionally inject synthetic hard negatives
     if args.add_hard_negatives and preference_pairs:
-        preference_pairs = add_synthetic_hard_negatives(
-            preference_pairs, hard_negative_ratio=args.hard_negative_ratio
-        )
+        preference_pairs = add_synthetic_hard_negatives(preference_pairs, hard_negative_ratio=args.hard_negative_ratio)
 
     # Save
     with open(args.output_path, "w", encoding="utf-8") as f:

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_evaluation.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_evaluation.py
@@ -33,11 +33,10 @@ import logging
 import os
 import re
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import torch
-from bert_score import score as bert_score_fn
 from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
 from peft import PeftModel
 from tqdm import tqdm
@@ -56,18 +55,16 @@ SYSTEM_PROMPT = (
 )
 
 VERIFIER_INSTRUCTION = (
-    "As a question rating verifier expert, can you generate the question rating score "
-    "for the given input?"
+    "As a question rating verifier expert, can you generate the question rating score " "for the given input?"
 )
 
-GENERATOR_INSTRUCTION = (
-    "As an explanation generation expert, can you generate the explanation for the given input?"
-)
+GENERATOR_INSTRUCTION = "As an explanation generation expert, can you generate the explanation for the given input?"
 
 
 # ---------------------------------------------------------------------------
 # Answer-grounded evaluation helpers
 # ---------------------------------------------------------------------------
+
 
 def extract_correct_option_text(input_text: str):
     """
@@ -113,22 +110,23 @@ def answer_coverage_rate(explanation: str, correct_option_text: str) -> float:
 @dataclass
 class ModelConfig:
     """Configuration for a single model to evaluate."""
+
     name: str
     model_path: str
     lora_adapter_path: Optional[str] = None
     is_legacy_llama: bool = False  # True for existing LLaMA-2 SFT models
-    use_kround: bool = False       # True to simulate ILearner K-round iterative refinement
-    k_rounds: int = 5              # Number of refinement rounds (if use_kround=True)
+    use_kround: bool = False  # True to simulate ILearner K-round iterative refinement
+    k_rounds: int = 5  # Number of refinement rounds (if use_kround=True)
 
 
 @dataclass
 class EvalResult:
     model_name: str
     bleu_scores: List[float]
-    bert_scores: List[float]           # vs student explanation (traditional)
-    bert_scores_answer: List[float]    # vs correct option text (answer-anchored, new)
-    acr_scores: List[float]            # Answer Coverage Rate (lexical, new)
-    nli_scores: List[float]            # NLI entailment score (explanation → correct option)
+    bert_scores: List[float]  # vs student explanation (traditional)
+    bert_scores_answer: List[float]  # vs correct option text (answer-anchored, new)
+    acr_scores: List[float]  # Answer Coverage Rate (lexical, new)
+    nli_scores: List[float]  # NLI entailment score (explanation → correct option)
     verifier_scores: List[float]
     inference_times: List[float]
     generated_explanations: List[str]  # saved for qualitative analysis
@@ -185,15 +183,11 @@ def load_nli_model(model_name: str, device: str = "cpu", cache_dir: str = "cache
     logger.info(f"Loading NLI model: {model_name} ...")
     # use_fast=False: older tokenizers lib (0.13.x) can't parse DeBERTa-v3 fast tokenizer
     nli_tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir, use_fast=False)
-    nli_model = AutoModelForSequenceClassification.from_pretrained(
-        model_name, cache_dir=cache_dir
-    ).to(device)
+    nli_model = AutoModelForSequenceClassification.from_pretrained(model_name, cache_dir=cache_dir).to(device)
     nli_model.eval()
     # Determine entailment label index from id2label
     id2label = nli_model.config.id2label or {}
-    entailment_idx = next(
-        (k for k, v in id2label.items() if "entail" in v.lower()), 1
-    )
+    entailment_idx = next((k for k, v in id2label.items() if "entail" in v.lower()), 1)
     logger.info(f"  NLI model loaded. id2label={id2label}, entailment_idx={entailment_idx}")
     return nli_model, nli_tokenizer, entailment_idx
 
@@ -215,16 +209,19 @@ def compute_nli_scores(
     """
     scores = []
     for i in range(0, len(explanations), batch_size):
-        batch_exp = explanations[i:i + batch_size]
-        batch_hyp = hypotheses[i:i + batch_size]
+        batch_exp = explanations[i : i + batch_size]
+        batch_hyp = hypotheses[i : i + batch_size]
         enc = nli_tokenizer(
-            batch_exp, batch_hyp,
-            padding=True, truncation=True, max_length=512,
+            batch_exp,
+            batch_hyp,
+            padding=True,
+            truncation=True,
+            max_length=512,
             return_tensors="pt",
         )
         enc = {k: v.to(device) for k, v in enc.items()}
-        logits = nli_model(**enc).logits          # (B, num_labels)
-        probs = torch.softmax(logits, dim=-1)     # (B, num_labels)
+        logits = nli_model(**enc).logits  # (B, num_labels)
+        probs = torch.softmax(logits, dim=-1)  # (B, num_labels)
         entail_probs = probs[:, entailment_idx].cpu().tolist()
         scores.extend(entail_probs)
     return scores
@@ -281,9 +278,7 @@ def build_generator_prompt(
                 f"As a explanation generation expert, can you generate a better explanation "
                 f"for the given input? \n\n{input_text}\n\n Output: "
             )
-        return (
-            f"Instruction: {GENERATOR_INSTRUCTION}\n\nInput: {input_text}\n\n Output: "
-        )
+        return f"Instruction: {GENERATOR_INSTRUCTION}\n\nInput: {input_text}\n\n Output: "
 
     # Modern chat-template format (Qwen3/Llama-3)
     user_content = f"{instruction}\n\n{input_text}" if instruction else input_text
@@ -299,9 +294,7 @@ def build_generator_prompt(
     ]
     if hasattr(tokenizer, "apply_chat_template"):
         try:
-            return tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
+            return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         except Exception:
             pass
     return f"Instruction: {instruction}\n\nInput: {input_text}\n\nOutput: "
@@ -332,7 +325,7 @@ def generate_explanation(
     full_text = tokenizer.decode(out[0], skip_special_tokens=True)
     # Strip the prompt from the decoded text
     if full_text.startswith(prompt):
-        response = full_text[len(prompt):].strip()
+        response = full_text[len(prompt) :].strip()
     else:
         # For chat-template models
         parts = full_text.split("assistant")
@@ -352,11 +345,7 @@ def get_verifier_score(
 ) -> float:
     """Extract numerical score from the Verifier model."""
     merged = f"{question_input} Explanation: {explanation}"
-    fulltext = (
-        f"Instruction: {VERIFIER_INSTRUCTION}\n\n"
-        f"Input: {merged}\n\n"
-        f"Output: "
-    )
+    fulltext = f"Instruction: {VERIFIER_INSTRUCTION}\n\n" f"Input: {merged}\n\n" f"Output: "
     tokens = verifier_tokenizer(fulltext, return_tensors="pt", truncation=True, max_length=1024)
     verifier_device = next(verifier_model.parameters()).device
     tokens = tokens.input_ids.to(verifier_device)
@@ -406,7 +395,7 @@ def evaluate_model(
     smoother = SmoothingFunction().method1
     generated_explanations = []
     ground_truths_for_bert = []
-    correct_option_texts = []   # for answer-anchored BERTScore
+    correct_option_texts = []  # for answer-anchored BERTScore
 
     for item in tqdm(test_data, desc=f"Evaluating {config.name}"):
         instruction = item.get("instruction", GENERATOR_INSTRUCTION).replace("</s>", "").strip()
@@ -427,7 +416,9 @@ def evaluate_model(
             score = 0.0
             for k in range(config.k_rounds):
                 prompt = build_generator_prompt(
-                    instruction, input_text, tokenizer,
+                    instruction,
+                    input_text,
+                    tokenizer,
                     is_legacy=config.is_legacy_llama,
                     prev_score=score if k > 0 else None,
                     prev_explanation=explanation if k > 0 else None,
@@ -438,18 +429,16 @@ def evaluate_model(
                 if not explanation:
                     break
                 # Score this round's explanation to use in next round's prompt
-                score = get_verifier_score(
-                    verifier_model, verifier_tokenizer, input_text, explanation, device=device
-                )
+                score = get_verifier_score(verifier_model, verifier_tokenizer, input_text, explanation, device=device)
         else:
             # 1-shot generation (RL-trained or plain SFT)
             prompt = build_generator_prompt(
-                instruction, input_text, tokenizer,
+                instruction,
+                input_text,
+                tokenizer,
                 is_legacy=config.is_legacy_llama,
             )
-            explanation = generate_explanation(
-                model, tokenizer, prompt, device=device, max_new_tokens=max_new_tokens
-            )
+            explanation = generate_explanation(model, tokenizer, prompt, device=device, max_new_tokens=max_new_tokens)
 
         elapsed = time.time() - start_time
 
@@ -471,9 +460,7 @@ def evaluate_model(
         acr = answer_coverage_rate(explanation, correct_opt_text)
 
         # Compute Verifier Score (final 1-shot score for RL models)
-        v_score = get_verifier_score(
-            verifier_model, verifier_tokenizer, input_text, explanation, device=device
-        )
+        v_score = get_verifier_score(verifier_model, verifier_tokenizer, input_text, explanation, device=device)
 
         result.bleu_scores.append(bleu)
         result.acr_scores.append(acr)
@@ -487,10 +474,7 @@ def evaluate_model(
 
         # Traditional: generated vs student explanation
         logger.info(f"  Computing BERTScore (vs student) for {config.name} ...")
-        _, _, F1 = bert_score_fn(
-            generated_explanations, ground_truths_for_bert,
-            lang="en", verbose=False
-        )
+        _, _, F1 = bert_score_fn(generated_explanations, ground_truths_for_bert, lang="en", verbose=False)
         result.bert_scores = F1.tolist()
 
         # New: generated vs correct option text (answer-anchored, reference-free)
@@ -498,10 +482,7 @@ def evaluate_model(
         if valid_pairs:
             logger.info(f"  Computing BERTScore (vs correct answer) for {config.name} ...")
             gen_valid, ans_valid = zip(*valid_pairs)
-            _, _, F1_ans = bert_score_fn(
-                list(gen_valid), list(ans_valid),
-                lang="en", verbose=False
-            )
+            _, _, F1_ans = bert_score_fn(list(gen_valid), list(ans_valid), lang="en", verbose=False)
             # Fill scores back (use 0.0 for examples without extractable option text)
             idx = 0
             for c in correct_option_texts:
@@ -520,8 +501,10 @@ def evaluate_model(
                 logger.info(f"  Computing NLI entailment scores for {config.name} ...")
                 gen_nli, hyp_nli = zip(*valid_nli)
                 nli_vals = compute_nli_scores(
-                    nli_model, nli_tokenizer,
-                    list(gen_nli), list(hyp_nli),
+                    nli_model,
+                    nli_tokenizer,
+                    list(gen_nli),
+                    list(hyp_nli),
                     entailment_idx=nli_entailment_idx,
                     device=nli_device,
                 )
@@ -544,46 +527,43 @@ def evaluate_model(
 
 def main():
     parser = argparse.ArgumentParser(description="Evaluate RLearner-LLM models.")
-    parser.add_argument("--test_data_path", required=True,
-                        help="Test set JSON file (fields: instruction, input, output/Explanation).")
-    parser.add_argument("--verifier_path", required=True,
-                        help="Path to trained Verifier model.")
-    parser.add_argument("--output_path", default="./rl_eval_results/comparison.json",
-                        help="Output path for evaluation results.")
+    parser.add_argument(
+        "--test_data_path", required=True, help="Test set JSON file (fields: instruction, input, output/Explanation)."
+    )
+    parser.add_argument("--verifier_path", required=True, help="Path to trained Verifier model.")
+    parser.add_argument(
+        "--output_path", default="./rl_eval_results/comparison.json", help="Output path for evaluation results."
+    )
     parser.add_argument("--device", default="cuda:0", help="Device for generator models.")
     parser.add_argument("--verifier_device", default="cuda:1", help="Device for verifier model.")
     parser.add_argument("--cache_dir", default="cache")
     parser.add_argument("--max_new_tokens", type=int, default=512)
-    parser.add_argument("--nli_model", default="cross-encoder/nli-deberta-v3-small",
-                        help="NLI model for entailment scoring (default: cross-encoder/nli-deberta-v3-small).")
-    parser.add_argument("--nli_device", default="cpu",
-                        help="Device for NLI model (cpu or cuda:N). Defaults to cpu.")
-    parser.add_argument("--skip_nli", action="store_true",
-                        help="Skip NLI entailment metric (faster, no download needed).")
+    parser.add_argument(
+        "--nli_model",
+        default="cross-encoder/nli-deberta-v3-small",
+        help="NLI model for entailment scoring (default: cross-encoder/nli-deberta-v3-small).",
+    )
+    parser.add_argument("--nli_device", default="cpu", help="Device for NLI model (cpu or cuda:N). Defaults to cpu.")
+    parser.add_argument(
+        "--skip_nli", action="store_true", help="Skip NLI entailment metric (faster, no download needed)."
+    )
 
     # Model specification arguments
-    parser.add_argument("--sft_model_path", default=None,
-                        help="Path to baseline SFT model (K=1, no RL).")
-    parser.add_argument("--sft_lora_path", default=None,
-                        help="LoRA adapter for SFT baseline (if applicable).")
-    parser.add_argument("--dpo_model_path", default=None,
-                        help="Base model path for DPO-trained model.")
-    parser.add_argument("--dpo_lora_path", default=None,
-                        help="LoRA adapter path from DPO training.")
-    parser.add_argument("--dpo_v2_model_path", default=None,
-                        help="Base model path for DPO-v2 model (improved preference data).")
-    parser.add_argument("--dpo_v2_lora_path", default=None,
-                        help="LoRA adapter path from DPO-v2 training.")
-    parser.add_argument("--ppo_model_path", default=None,
-                        help="Base model path for PPO-trained model.")
-    parser.add_argument("--ppo_lora_path", default=None,
-                        help="LoRA adapter path from PPO training.")
-    parser.add_argument("--ilearner_model_path", default=None,
-                        help="Path to ILearner-LLM model for K-round baseline.")
-    parser.add_argument("--ilearner_k", type=int, default=5,
-                        help="Number of refinement rounds for ILearner baseline.")
-    parser.add_argument("--ilearner_is_legacy", action="store_true",
-                        help="Use legacy alpaca-style prompt for ILearner model.")
+    parser.add_argument("--sft_model_path", default=None, help="Path to baseline SFT model (K=1, no RL).")
+    parser.add_argument("--sft_lora_path", default=None, help="LoRA adapter for SFT baseline (if applicable).")
+    parser.add_argument("--dpo_model_path", default=None, help="Base model path for DPO-trained model.")
+    parser.add_argument("--dpo_lora_path", default=None, help="LoRA adapter path from DPO training.")
+    parser.add_argument(
+        "--dpo_v2_model_path", default=None, help="Base model path for DPO-v2 model (improved preference data)."
+    )
+    parser.add_argument("--dpo_v2_lora_path", default=None, help="LoRA adapter path from DPO-v2 training.")
+    parser.add_argument("--ppo_model_path", default=None, help="Base model path for PPO-trained model.")
+    parser.add_argument("--ppo_lora_path", default=None, help="LoRA adapter path from PPO training.")
+    parser.add_argument("--ilearner_model_path", default=None, help="Path to ILearner-LLM model for K-round baseline.")
+    parser.add_argument("--ilearner_k", type=int, default=5, help="Number of refinement rounds for ILearner baseline.")
+    parser.add_argument(
+        "--ilearner_is_legacy", action="store_true", help="Use legacy alpaca-style prompt for ILearner model."
+    )
     args = parser.parse_args()
 
     os.makedirs(os.path.dirname(args.output_path) or ".", exist_ok=True)
@@ -617,46 +597,56 @@ def main():
     model_configs = []
 
     if args.sft_model_path:
-        model_configs.append(ModelConfig(
-            name="Baseline-SFT (K=1)",
-            model_path=args.sft_model_path,
-            lora_adapter_path=args.sft_lora_path,
-            is_legacy_llama=False,
-            use_kround=False,
-        ))
+        model_configs.append(
+            ModelConfig(
+                name="Baseline-SFT (K=1)",
+                model_path=args.sft_model_path,
+                lora_adapter_path=args.sft_lora_path,
+                is_legacy_llama=False,
+                use_kround=False,
+            )
+        )
 
     if args.dpo_model_path and args.dpo_lora_path:
-        model_configs.append(ModelConfig(
-            name="RL-DPO (K=1)",
-            model_path=args.dpo_model_path,
-            lora_adapter_path=args.dpo_lora_path,
-            use_kround=False,
-        ))
+        model_configs.append(
+            ModelConfig(
+                name="RL-DPO (K=1)",
+                model_path=args.dpo_model_path,
+                lora_adapter_path=args.dpo_lora_path,
+                use_kround=False,
+            )
+        )
 
     if args.dpo_v2_model_path and args.dpo_v2_lora_path:
-        model_configs.append(ModelConfig(
-            name="RL-DPO-v2 (K=1)",
-            model_path=args.dpo_v2_model_path,
-            lora_adapter_path=args.dpo_v2_lora_path,
-            use_kround=False,
-        ))
+        model_configs.append(
+            ModelConfig(
+                name="RL-DPO-v2 (K=1)",
+                model_path=args.dpo_v2_model_path,
+                lora_adapter_path=args.dpo_v2_lora_path,
+                use_kround=False,
+            )
+        )
 
     if args.ppo_model_path and args.ppo_lora_path:
-        model_configs.append(ModelConfig(
-            name="RL-PPO (K=1)",
-            model_path=args.ppo_model_path,
-            lora_adapter_path=args.ppo_lora_path,
-            use_kround=False,
-        ))
+        model_configs.append(
+            ModelConfig(
+                name="RL-PPO (K=1)",
+                model_path=args.ppo_model_path,
+                lora_adapter_path=args.ppo_lora_path,
+                use_kround=False,
+            )
+        )
 
     if args.ilearner_model_path:
-        model_configs.append(ModelConfig(
-            name=f"ILearner-LLM (K={args.ilearner_k})",
-            model_path=args.ilearner_model_path,
-            is_legacy_llama=args.ilearner_is_legacy,
-            use_kround=True,
-            k_rounds=args.ilearner_k,
-        ))
+        model_configs.append(
+            ModelConfig(
+                name=f"ILearner-LLM (K={args.ilearner_k})",
+                model_path=args.ilearner_model_path,
+                is_legacy_llama=args.ilearner_is_legacy,
+                use_kround=True,
+                k_rounds=args.ilearner_k,
+            )
+        )
 
     if not model_configs:
         logger.error("No models specified. Use --sft_model_path, --dpo_model_path, etc.")
@@ -700,9 +690,9 @@ def main():
             logger.info(f"  {k}: {v}")
 
     # ---------- Summary Table ----------
-    logger.info("\n" + "="*100)
+    logger.info("\n" + "=" * 100)
     logger.info("FINAL COMPARISON TABLE")
-    logger.info("="*100)
+    logger.info("=" * 100)
     header = (
         f"{'Model':<28} {'BLEU':>8} {'BERT(Stu)':>10} {'BERT(Ans)':>10} "
         f"{'ACR':>8} {'NLI':>8} {'Verifier':>10} {'Time(s)':>9}"

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_evaluation.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_evaluation.py
@@ -1,0 +1,754 @@
+"""
+RLearner-LLM Evaluation: Compare RL vs Baseline Models
+
+Evaluates all models on the test set and produces a comparison table:
+  - Baseline SFT (K=1, no RL): Original LLaMA-2 / Qwen3 fine-tuned
+  - RL-DPO (K=1): DPO-trained model with LoRA
+  - RL-PPO (K=1): PPO-trained model with LoRA
+  - ILearner-LLM (K=5): Original K-round iterative refinement baseline
+
+Metrics:
+  - BLEU Score: n-gram overlap with ground-truth student explanations
+  - BERTScore F1 (vs Student): Semantic similarity to student ground-truth explanation
+  - BERTScore F1 (vs Answer): Answer-anchored — semantic similarity to the correct option
+    text extracted from the question. Reference-free w.r.t. student explanations;
+    measures whether the generated explanation covers the correct answer concept.
+  - Answer Coverage Rate (ACR): Fraction of key terms in the correct option text that
+    appear in the generated explanation. Fast lexical proxy for answer correctness.
+  - Verifier Score: Quality rating from the trained Verifier model
+  - Avg. Inference Time: Latency per explanation (1-shot vs K-round)
+
+Usage:
+    python rl_evaluation.py \
+        --test_data_path ./Paul_new_data/Cardiff/Cardiff_vicuna_13b_finetuned_random_100.json \
+        --verifier_path ./qiming_alpaca_7B_Cardiff_Sydney_merged_verifier_way_2 \
+        --output_path ./rl_eval_results/comparison.json \
+        --sft_model_path /data/shared/llama2/llama-2-13b-hf \
+        --sft_lora_path ./rl_sft_llama2_13b_generator
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional
+
+import torch
+from bert_score import score as bert_score_fn
+from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
+from peft import PeftModel
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = (
+    "You are an expert educator specializing in generating high-quality explanations "
+    "for exam questions. Your explanations should be clear, accurate, educational, "
+    "and written in a style similar to how knowledgeable students explain answers."
+)
+
+VERIFIER_INSTRUCTION = (
+    "As a question rating verifier expert, can you generate the question rating score "
+    "for the given input?"
+)
+
+GENERATOR_INSTRUCTION = (
+    "As an explanation generation expert, can you generate the explanation for the given input?"
+)
+
+
+# ---------------------------------------------------------------------------
+# Answer-grounded evaluation helpers
+# ---------------------------------------------------------------------------
+
+def extract_correct_option_text(input_text: str):
+    """
+    Parse the correct answer letter and option text from the question input.
+
+    The input format contains:
+        "Option A: <text> Option B: <text> ... The correct answer is Option X."
+
+    Returns:
+        (correct_letter, option_text) — e.g. ("C", "Long head of triceps brachii")
+        Returns (None, None) if parsing fails.
+    """
+    m = re.search(r"The correct answer is Option ([A-Z])", input_text)
+    if not m:
+        return None, None
+    letter = m.group(1)
+    opt_pat = rf"Option {letter}:\s*(.+?)(?:\s+Option [A-Z]:|The correct answer|$)"
+    opt_m = re.search(opt_pat, input_text, re.DOTALL)
+    opt_text = opt_m.group(1).strip() if opt_m else None
+    return letter, opt_text
+
+
+def answer_coverage_rate(explanation: str, correct_option_text: str) -> float:
+    """
+    Answer Coverage Rate (ACR): lexical measure of whether the generated
+    explanation mentions the key terms in the correct answer option.
+
+    Computed as: |matched key terms| / |total key terms|
+    where key terms are words of ≥4 characters in the correct option text.
+
+    Returns 0.0 if inputs are missing or no key terms found.
+    """
+    if not explanation or not correct_option_text:
+        return 0.0
+    exp_lower = explanation.lower()
+    key_terms = re.findall(r"\b\w{4,}\b", correct_option_text.lower())
+    if not key_terms:
+        return 0.0
+    matched = sum(1 for t in key_terms if t in exp_lower)
+    return matched / len(key_terms)
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a single model to evaluate."""
+    name: str
+    model_path: str
+    lora_adapter_path: Optional[str] = None
+    is_legacy_llama: bool = False  # True for existing LLaMA-2 SFT models
+    use_kround: bool = False       # True to simulate ILearner K-round iterative refinement
+    k_rounds: int = 5              # Number of refinement rounds (if use_kround=True)
+
+
+@dataclass
+class EvalResult:
+    model_name: str
+    bleu_scores: List[float]
+    bert_scores: List[float]           # vs student explanation (traditional)
+    bert_scores_answer: List[float]    # vs correct option text (answer-anchored, new)
+    acr_scores: List[float]            # Answer Coverage Rate (lexical, new)
+    nli_scores: List[float]            # NLI entailment score (explanation → correct option)
+    verifier_scores: List[float]
+    inference_times: List[float]
+    generated_explanations: List[str]  # saved for qualitative analysis
+
+    @property
+    def avg_bleu(self) -> float:
+        return sum(self.bleu_scores) / len(self.bleu_scores) if self.bleu_scores else 0
+
+    @property
+    def avg_bert(self) -> float:
+        return sum(self.bert_scores) / len(self.bert_scores) if self.bert_scores else 0
+
+    @property
+    def avg_bert_answer(self) -> float:
+        return sum(self.bert_scores_answer) / len(self.bert_scores_answer) if self.bert_scores_answer else 0
+
+    @property
+    def avg_acr(self) -> float:
+        return sum(self.acr_scores) / len(self.acr_scores) if self.acr_scores else 0
+
+    @property
+    def avg_nli(self) -> float:
+        return sum(self.nli_scores) / len(self.nli_scores) if self.nli_scores else 0
+
+    @property
+    def avg_verifier(self) -> float:
+        return sum(self.verifier_scores) / len(self.verifier_scores) if self.verifier_scores else 0
+
+    @property
+    def avg_time(self) -> float:
+        return sum(self.inference_times) / len(self.inference_times) if self.inference_times else 0
+
+    def summary(self) -> Dict:
+        return {
+            "model": self.model_name,
+            "avg_bleu": round(self.avg_bleu, 4),
+            "avg_bert_score_f1": round(self.avg_bert, 4),
+            "avg_bert_score_f1_answer_anchored": round(self.avg_bert_answer, 4),
+            "avg_answer_coverage_rate": round(self.avg_acr, 4),
+            "avg_nli_entailment": round(self.avg_nli, 4),
+            "avg_verifier_score": round(self.avg_verifier, 4),
+            "avg_inference_time_s": round(self.avg_time, 3),
+        }
+
+
+def load_nli_model(model_name: str, device: str = "cpu", cache_dir: str = "cache"):
+    """
+    Load a DeBERTa-based NLI model for entailment scoring.
+    Default: cross-encoder/nli-deberta-v3-small (lightweight, ~90 MB).
+
+    Returns (model, tokenizer, entailment_idx) where entailment_idx is the
+    index of the ENTAILMENT class in the model's label space.
+    """
+    logger.info(f"Loading NLI model: {model_name} ...")
+    # use_fast=False: older tokenizers lib (0.13.x) can't parse DeBERTa-v3 fast tokenizer
+    nli_tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir, use_fast=False)
+    nli_model = AutoModelForSequenceClassification.from_pretrained(
+        model_name, cache_dir=cache_dir
+    ).to(device)
+    nli_model.eval()
+    # Determine entailment label index from id2label
+    id2label = nli_model.config.id2label or {}
+    entailment_idx = next(
+        (k for k, v in id2label.items() if "entail" in v.lower()), 1
+    )
+    logger.info(f"  NLI model loaded. id2label={id2label}, entailment_idx={entailment_idx}")
+    return nli_model, nli_tokenizer, entailment_idx
+
+
+@torch.no_grad()
+def compute_nli_scores(
+    nli_model,
+    nli_tokenizer,
+    explanations: List[str],
+    hypotheses: List[str],
+    entailment_idx: int,
+    device: str = "cpu",
+    batch_size: int = 16,
+) -> List[float]:
+    """
+    Compute NLI entailment probability for each (explanation, hypothesis) pair.
+    Premise = generated explanation; Hypothesis = correct option text.
+    Returns list of entailment probabilities in [0, 1].
+    """
+    scores = []
+    for i in range(0, len(explanations), batch_size):
+        batch_exp = explanations[i:i + batch_size]
+        batch_hyp = hypotheses[i:i + batch_size]
+        enc = nli_tokenizer(
+            batch_exp, batch_hyp,
+            padding=True, truncation=True, max_length=512,
+            return_tensors="pt",
+        )
+        enc = {k: v.to(device) for k, v in enc.items()}
+        logits = nli_model(**enc).logits          # (B, num_labels)
+        probs = torch.softmax(logits, dim=-1)     # (B, num_labels)
+        entail_probs = probs[:, entailment_idx].cpu().tolist()
+        scores.extend(entail_probs)
+    return scores
+
+
+def load_model_and_tokenizer(config: ModelConfig, device: str = "cuda", cache_dir: str = "cache"):
+    """Load model + tokenizer. Handles both legacy LLaMA-2 and modern chat models."""
+    logger.info(f"Loading model: {config.name} from {config.model_path}")
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        config.model_path,
+        cache_dir=cache_dir,
+        trust_remote_code=True,
+        padding_side="left",
+        use_fast=False,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(
+        config.model_path,
+        torch_dtype=torch.float16,
+        low_cpu_mem_usage=True,
+        cache_dir=cache_dir,
+        trust_remote_code=True,
+    )
+
+    if config.lora_adapter_path and os.path.isdir(config.lora_adapter_path):
+        logger.info(f"  Loading LoRA adapter from {config.lora_adapter_path}")
+        model = PeftModel.from_pretrained(model, config.lora_adapter_path)
+        model = model.merge_and_unload()
+
+    model = model.to(device)
+    model.eval()
+    logger.info(f"  Model loaded on {device}.")
+    return model, tokenizer
+
+
+def build_generator_prompt(
+    instruction: str,
+    input_text: str,
+    tokenizer,
+    is_legacy: bool = False,
+    prev_score: Optional[float] = None,
+    prev_explanation: Optional[str] = None,
+) -> str:
+    """Build the generation prompt. Handles both legacy and chat-template formats."""
+    if is_legacy:
+        # Original ILearner-LLM format for legacy LLaMA-2 models
+        if prev_score is not None and prev_explanation:
+            return (
+                f"Instruction: Your last time verifier rating score for your explanation generation is "
+                f"{prev_score} and the explanation you generated was {prev_explanation} "
+                f"As a explanation generation expert, can you generate a better explanation "
+                f"for the given input? \n\n{input_text}\n\n Output: "
+            )
+        return (
+            f"Instruction: {GENERATOR_INSTRUCTION}\n\nInput: {input_text}\n\n Output: "
+        )
+
+    # Modern chat-template format (Qwen3/Llama-3)
+    user_content = f"{instruction}\n\n{input_text}" if instruction else input_text
+    if prev_score is not None and prev_explanation:
+        user_content = (
+            f"Your previous explanation scored {prev_score:.1f}/5.0 from the verifier. "
+            f"Previous explanation: {prev_explanation}\n\n"
+            f"Please generate a better explanation:\n\n{user_content}"
+        )
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+    if hasattr(tokenizer, "apply_chat_template"):
+        try:
+            return tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        except Exception:
+            pass
+    return f"Instruction: {instruction}\n\nInput: {input_text}\n\nOutput: "
+
+
+@torch.no_grad()
+def generate_explanation(
+    model,
+    tokenizer,
+    prompt: str,
+    device: str = "cuda",
+    max_new_tokens: int = 512,
+) -> str:
+    """Generate a single explanation from the given prompt."""
+    tokens = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=1024).input_ids
+    tokens = tokens.to(device)
+    out = model.generate(
+        tokens,
+        max_new_tokens=max_new_tokens,
+        do_sample=True,
+        temperature=0.5,
+        top_k=50,
+        top_p=1.0,
+        repetition_penalty=1.1,
+        pad_token_id=tokenizer.eos_token_id,
+        use_cache=True,
+    )
+    full_text = tokenizer.decode(out[0], skip_special_tokens=True)
+    # Strip the prompt from the decoded text
+    if full_text.startswith(prompt):
+        response = full_text[len(prompt):].strip()
+    else:
+        # For chat-template models
+        parts = full_text.split("assistant")
+        response = parts[-1].strip() if len(parts) > 1 else full_text.strip()
+        # Further clean up any remaining tags
+        response = re.sub(r"<\|.*?\|>", "", response).strip()
+    return response
+
+
+@torch.no_grad()
+def get_verifier_score(
+    verifier_model,
+    verifier_tokenizer,
+    question_input: str,
+    explanation: str,
+    device: str = "cuda",
+) -> float:
+    """Extract numerical score from the Verifier model."""
+    merged = f"{question_input} Explanation: {explanation}"
+    fulltext = (
+        f"Instruction: {VERIFIER_INSTRUCTION}\n\n"
+        f"Input: {merged}\n\n"
+        f"Output: "
+    )
+    tokens = verifier_tokenizer(fulltext, return_tensors="pt", truncation=True, max_length=1024)
+    verifier_device = next(verifier_model.parameters()).device
+    tokens = tokens.input_ids.to(verifier_device)
+    out = verifier_model.generate(
+        tokens,
+        max_new_tokens=16,
+        do_sample=False,
+        pad_token_id=verifier_tokenizer.eos_token_id,
+    )
+    text = verifier_tokenizer.decode(out[0], skip_special_tokens=True)
+    match = re.search(r"Output:\s*(\d+(?:\.\d+)?)", text)
+    if match:
+        return min(float(match.group(1)), 5.0)
+    match2 = re.search(r"(\d+(?:\.\d+)?)", text.split("Output:")[-1])
+    if match2:
+        return min(float(match2.group(1)), 5.0)
+    return 0.0
+
+
+def evaluate_model(
+    config: ModelConfig,
+    test_data: List[dict],
+    verifier_model,
+    verifier_tokenizer,
+    device: str = "cuda",
+    cache_dir: str = "cache",
+    max_new_tokens: int = 512,
+    nli_model=None,
+    nli_tokenizer=None,
+    nli_entailment_idx: int = 1,
+    nli_device: str = "cpu",
+) -> EvalResult:
+    """Run full evaluation for one model on the test set."""
+    model, tokenizer = load_model_and_tokenizer(config, device=device, cache_dir=cache_dir)
+    result = EvalResult(
+        model_name=config.name,
+        bleu_scores=[],
+        bert_scores=[],
+        bert_scores_answer=[],
+        acr_scores=[],
+        nli_scores=[],
+        verifier_scores=[],
+        inference_times=[],
+        generated_explanations=[],
+    )
+
+    smoother = SmoothingFunction().method1
+    generated_explanations = []
+    ground_truths_for_bert = []
+    correct_option_texts = []   # for answer-anchored BERTScore
+
+    for item in tqdm(test_data, desc=f"Evaluating {config.name}"):
+        instruction = item.get("instruction", GENERATOR_INSTRUCTION).replace("</s>", "").strip()
+        input_text = item.get("input", "").replace("</s>", "").strip()
+        ground_truth = item.get("output", item.get("Explanation", "")).replace("</s>", "").strip()
+
+        if not input_text or not ground_truth:
+            continue
+
+        # Extract correct answer option text for answer-grounded metrics
+        _, correct_opt_text = extract_correct_option_text(input_text)
+
+        start_time = time.time()
+
+        if config.use_kround:
+            # Simulate ILearner K-round iterative refinement (original paper baseline)
+            explanation = ""
+            score = 0.0
+            for k in range(config.k_rounds):
+                prompt = build_generator_prompt(
+                    instruction, input_text, tokenizer,
+                    is_legacy=config.is_legacy_llama,
+                    prev_score=score if k > 0 else None,
+                    prev_explanation=explanation if k > 0 else None,
+                )
+                explanation = generate_explanation(
+                    model, tokenizer, prompt, device=device, max_new_tokens=max_new_tokens
+                )
+                if not explanation:
+                    break
+                # Score this round's explanation to use in next round's prompt
+                score = get_verifier_score(
+                    verifier_model, verifier_tokenizer, input_text, explanation, device=device
+                )
+        else:
+            # 1-shot generation (RL-trained or plain SFT)
+            prompt = build_generator_prompt(
+                instruction, input_text, tokenizer,
+                is_legacy=config.is_legacy_llama,
+            )
+            explanation = generate_explanation(
+                model, tokenizer, prompt, device=device, max_new_tokens=max_new_tokens
+            )
+
+        elapsed = time.time() - start_time
+
+        if not explanation:
+            continue
+
+        generated_explanations.append(explanation)
+        ground_truths_for_bert.append(ground_truth)
+        correct_option_texts.append(correct_opt_text or "")
+
+        # Compute BLEU (vs student explanation — traditional)
+        bleu = sentence_bleu(
+            [ground_truth.split()],
+            explanation.split(),
+            smoothing_function=smoother,
+        )
+
+        # Compute Answer Coverage Rate (ACR) — lexical, reference-free
+        acr = answer_coverage_rate(explanation, correct_opt_text)
+
+        # Compute Verifier Score (final 1-shot score for RL models)
+        v_score = get_verifier_score(
+            verifier_model, verifier_tokenizer, input_text, explanation, device=device
+        )
+
+        result.bleu_scores.append(bleu)
+        result.acr_scores.append(acr)
+        result.verifier_scores.append(v_score)
+        result.inference_times.append(elapsed)
+        result.generated_explanations.append(explanation)
+
+    # Compute BERTScore in batch for all predictions
+    if generated_explanations:
+        from bert_score import score as bert_score_fn
+
+        # Traditional: generated vs student explanation
+        logger.info(f"  Computing BERTScore (vs student) for {config.name} ...")
+        _, _, F1 = bert_score_fn(
+            generated_explanations, ground_truths_for_bert,
+            lang="en", verbose=False
+        )
+        result.bert_scores = F1.tolist()
+
+        # New: generated vs correct option text (answer-anchored, reference-free)
+        valid_pairs = [(g, c) for g, c in zip(generated_explanations, correct_option_texts) if c]
+        if valid_pairs:
+            logger.info(f"  Computing BERTScore (vs correct answer) for {config.name} ...")
+            gen_valid, ans_valid = zip(*valid_pairs)
+            _, _, F1_ans = bert_score_fn(
+                list(gen_valid), list(ans_valid),
+                lang="en", verbose=False
+            )
+            # Fill scores back (use 0.0 for examples without extractable option text)
+            idx = 0
+            for c in correct_option_texts:
+                if c:
+                    result.bert_scores_answer.append(F1_ans[idx].item())
+                    idx += 1
+                else:
+                    result.bert_scores_answer.append(0.0)
+        else:
+            result.bert_scores_answer = [0.0] * len(generated_explanations)
+
+        # NLI entailment: explanation → correct option text (answer-anchored)
+        if nli_model is not None:
+            valid_nli = [(g, c) for g, c in zip(generated_explanations, correct_option_texts) if c]
+            if valid_nli:
+                logger.info(f"  Computing NLI entailment scores for {config.name} ...")
+                gen_nli, hyp_nli = zip(*valid_nli)
+                nli_vals = compute_nli_scores(
+                    nli_model, nli_tokenizer,
+                    list(gen_nli), list(hyp_nli),
+                    entailment_idx=nli_entailment_idx,
+                    device=nli_device,
+                )
+                idx = 0
+                for c in correct_option_texts:
+                    if c:
+                        result.nli_scores.append(nli_vals[idx])
+                        idx += 1
+                    else:
+                        result.nli_scores.append(0.0)
+            else:
+                result.nli_scores = [0.0] * len(generated_explanations)
+
+    # Clean up model from GPU memory
+    del model
+    torch.cuda.empty_cache()
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate RLearner-LLM models.")
+    parser.add_argument("--test_data_path", required=True,
+                        help="Test set JSON file (fields: instruction, input, output/Explanation).")
+    parser.add_argument("--verifier_path", required=True,
+                        help="Path to trained Verifier model.")
+    parser.add_argument("--output_path", default="./rl_eval_results/comparison.json",
+                        help="Output path for evaluation results.")
+    parser.add_argument("--device", default="cuda:0", help="Device for generator models.")
+    parser.add_argument("--verifier_device", default="cuda:1", help="Device for verifier model.")
+    parser.add_argument("--cache_dir", default="cache")
+    parser.add_argument("--max_new_tokens", type=int, default=512)
+    parser.add_argument("--nli_model", default="cross-encoder/nli-deberta-v3-small",
+                        help="NLI model for entailment scoring (default: cross-encoder/nli-deberta-v3-small).")
+    parser.add_argument("--nli_device", default="cpu",
+                        help="Device for NLI model (cpu or cuda:N). Defaults to cpu.")
+    parser.add_argument("--skip_nli", action="store_true",
+                        help="Skip NLI entailment metric (faster, no download needed).")
+
+    # Model specification arguments
+    parser.add_argument("--sft_model_path", default=None,
+                        help="Path to baseline SFT model (K=1, no RL).")
+    parser.add_argument("--sft_lora_path", default=None,
+                        help="LoRA adapter for SFT baseline (if applicable).")
+    parser.add_argument("--dpo_model_path", default=None,
+                        help="Base model path for DPO-trained model.")
+    parser.add_argument("--dpo_lora_path", default=None,
+                        help="LoRA adapter path from DPO training.")
+    parser.add_argument("--dpo_v2_model_path", default=None,
+                        help="Base model path for DPO-v2 model (improved preference data).")
+    parser.add_argument("--dpo_v2_lora_path", default=None,
+                        help="LoRA adapter path from DPO-v2 training.")
+    parser.add_argument("--ppo_model_path", default=None,
+                        help="Base model path for PPO-trained model.")
+    parser.add_argument("--ppo_lora_path", default=None,
+                        help="LoRA adapter path from PPO training.")
+    parser.add_argument("--ilearner_model_path", default=None,
+                        help="Path to ILearner-LLM model for K-round baseline.")
+    parser.add_argument("--ilearner_k", type=int, default=5,
+                        help="Number of refinement rounds for ILearner baseline.")
+    parser.add_argument("--ilearner_is_legacy", action="store_true",
+                        help="Use legacy alpaca-style prompt for ILearner model.")
+    args = parser.parse_args()
+
+    os.makedirs(os.path.dirname(args.output_path) or ".", exist_ok=True)
+
+    # ---------- Load test data ----------
+    with open(args.test_data_path, "r", encoding="utf-8") as f:
+        test_data = json.load(f)
+    logger.info(f"Loaded {len(test_data)} test examples from {args.test_data_path}")
+
+    # ---------- Load Verifier ----------
+    logger.info(f"Loading verifier from {args.verifier_path} ...")
+    # use_fast=False: LlamaTokenizerFast has infinite recursion on older model configs
+    verifier_tokenizer = AutoTokenizer.from_pretrained(
+        args.verifier_path, cache_dir=args.cache_dir, trust_remote_code=True, use_fast=False
+    )
+    if verifier_tokenizer.pad_token is None:
+        verifier_tokenizer.pad_token = verifier_tokenizer.eos_token
+    # CPU does not support fp16 matmul; use fp32 for CPU verifier
+    verifier_dtype = torch.float32 if str(args.verifier_device) == "cpu" else torch.float16
+    verifier_model = AutoModelForCausalLM.from_pretrained(
+        args.verifier_path,
+        torch_dtype=verifier_dtype,
+        low_cpu_mem_usage=True,
+        cache_dir=args.cache_dir,
+        trust_remote_code=True,
+    ).to(args.verifier_device)
+    verifier_model.eval()
+    logger.info("Verifier loaded.")
+
+    # ---------- Build model configs ----------
+    model_configs = []
+
+    if args.sft_model_path:
+        model_configs.append(ModelConfig(
+            name="Baseline-SFT (K=1)",
+            model_path=args.sft_model_path,
+            lora_adapter_path=args.sft_lora_path,
+            is_legacy_llama=False,
+            use_kround=False,
+        ))
+
+    if args.dpo_model_path and args.dpo_lora_path:
+        model_configs.append(ModelConfig(
+            name="RL-DPO (K=1)",
+            model_path=args.dpo_model_path,
+            lora_adapter_path=args.dpo_lora_path,
+            use_kround=False,
+        ))
+
+    if args.dpo_v2_model_path and args.dpo_v2_lora_path:
+        model_configs.append(ModelConfig(
+            name="RL-DPO-v2 (K=1)",
+            model_path=args.dpo_v2_model_path,
+            lora_adapter_path=args.dpo_v2_lora_path,
+            use_kround=False,
+        ))
+
+    if args.ppo_model_path and args.ppo_lora_path:
+        model_configs.append(ModelConfig(
+            name="RL-PPO (K=1)",
+            model_path=args.ppo_model_path,
+            lora_adapter_path=args.ppo_lora_path,
+            use_kround=False,
+        ))
+
+    if args.ilearner_model_path:
+        model_configs.append(ModelConfig(
+            name=f"ILearner-LLM (K={args.ilearner_k})",
+            model_path=args.ilearner_model_path,
+            is_legacy_llama=args.ilearner_is_legacy,
+            use_kround=True,
+            k_rounds=args.ilearner_k,
+        ))
+
+    if not model_configs:
+        logger.error("No models specified. Use --sft_model_path, --dpo_model_path, etc.")
+        return
+
+    # ---------- Load NLI model ----------
+    nli_model, nli_tokenizer, nli_entailment_idx = None, None, 1
+    if not args.skip_nli:
+        try:
+            nli_model, nli_tokenizer, nli_entailment_idx = load_nli_model(
+                args.nli_model, device=args.nli_device, cache_dir=args.cache_dir
+            )
+        except Exception as e:
+            logger.warning(f"NLI model load failed ({e}). Skipping NLI metric.")
+
+    # ---------- Evaluate each model ----------
+    all_results = []
+    for config in model_configs:
+        logger.info(f"\n{'='*60}")
+        logger.info(f"Evaluating: {config.name}")
+        logger.info(f"{'='*60}")
+
+        result = evaluate_model(
+            config=config,
+            test_data=test_data,
+            verifier_model=verifier_model,
+            verifier_tokenizer=verifier_tokenizer,
+            device=args.device,
+            cache_dir=args.cache_dir,
+            max_new_tokens=args.max_new_tokens,
+            nli_model=nli_model,
+            nli_tokenizer=nli_tokenizer,
+            nli_entailment_idx=nli_entailment_idx,
+            nli_device=args.nli_device,
+        )
+        all_results.append(result)
+
+        summary = result.summary()
+        logger.info(f"\nResults for {config.name}:")
+        for k, v in summary.items():
+            logger.info(f"  {k}: {v}")
+
+    # ---------- Summary Table ----------
+    logger.info("\n" + "="*100)
+    logger.info("FINAL COMPARISON TABLE")
+    logger.info("="*100)
+    header = (
+        f"{'Model':<28} {'BLEU':>8} {'BERT(Stu)':>10} {'BERT(Ans)':>10} "
+        f"{'ACR':>8} {'NLI':>8} {'Verifier':>10} {'Time(s)':>9}"
+    )
+    logger.info(header)
+    logger.info("-" * 110)
+    for result in all_results:
+        s = result.summary()
+        logger.info(
+            f"{s['model']:<28} {s['avg_bleu']:>8.4f} {s['avg_bert_score_f1']:>10.4f} "
+            f"{s['avg_bert_score_f1_answer_anchored']:>10.4f} "
+            f"{s['avg_answer_coverage_rate']:>8.4f} "
+            f"{s['avg_nli_entailment']:>8.4f} "
+            f"{s['avg_verifier_score']:>10.4f} {s['avg_inference_time_s']:>9.3f}"
+        )
+    logger.info("")
+    logger.info("Column guide:")
+    logger.info("  BERT(Stu) = BERTScore vs student explanation (traditional reference-based)")
+    logger.info("  BERT(Ans) = BERTScore vs correct option text (answer-anchored, reference-free)")
+    logger.info("  ACR       = Answer Coverage Rate — fraction of correct option keywords in explanation")
+    logger.info("  NLI       = DeBERTa entailment probability: explanation -> correct option text")
+
+    # ---------- Save results ----------
+    output_data = {
+        "test_data_path": args.test_data_path,
+        "num_test_examples": len(test_data),
+        "results": [r.summary() for r in all_results],
+        "detailed_results": [
+            {
+                "model": r.model_name,
+                "bleu_scores": r.bleu_scores,
+                "bert_scores_vs_student": r.bert_scores,
+                "bert_scores_vs_answer": r.bert_scores_answer,
+                "acr_scores": r.acr_scores,
+                "nli_entailment_scores": r.nli_scores,
+                "verifier_scores": r.verifier_scores,
+                "inference_times": r.inference_times,
+                "generated_explanations": r.generated_explanations,
+            }
+            for r in all_results
+        ],
+    }
+    with open(args.output_path, "w", encoding="utf-8") as f:
+        json.dump(output_data, f, indent=2, ensure_ascii=False)
+    logger.info(f"\nFull results saved to {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_generate_synthetic_data.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_generate_synthetic_data.py
@@ -50,7 +50,7 @@ import logging
 import os
 import random
 import time
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 logging.basicConfig(
     level=logging.INFO,
@@ -123,16 +123,17 @@ Generate a circular, content-free explanation:
 FLAWED EXPLANATION:"""
 
 HARD_NEGATIVE_TYPES = [
-    ("inverted_logic",   HARD_NEGATIVE_USER_INVERTED,   "Logically inverted reasoning"),
-    ("concept_confused", HARD_NEGATIVE_USER_CONFUSION,  "Mixed-up concepts"),
-    ("gibberish",        HARD_NEGATIVE_USER_GIBBERISH,  "High-score academic gibberish"),
-    ("circular",         HARD_NEGATIVE_USER_CIRCULAR,   "Circular reasoning"),
+    ("inverted_logic", HARD_NEGATIVE_USER_INVERTED, "Logically inverted reasoning"),
+    ("concept_confused", HARD_NEGATIVE_USER_CONFUSION, "Mixed-up concepts"),
+    ("gibberish", HARD_NEGATIVE_USER_GIBBERISH, "High-score academic gibberish"),
+    ("circular", HARD_NEGATIVE_USER_CIRCULAR, "Circular reasoning"),
 ]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # API CLIENTS
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def call_openai(
     client,
@@ -200,6 +201,7 @@ def build_api_caller(provider: str, api_key: str, model: str):
 # DATA HELPERS
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def format_question_block(item: dict) -> str:
     """Format a PeerWise item into a readable question block for the LLM prompt."""
     input_text = item.get("input", "").replace("</s>", "").strip()
@@ -222,6 +224,7 @@ def extract_explanation_from_response(text: str, tag: str = "EXPLANATION:") -> s
 # ─────────────────────────────────────────────────────────────────────────────
 # CORE GENERATION FUNCTIONS
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def generate_positive_demo(
     item: dict,
@@ -291,6 +294,7 @@ def generate_hard_negative(
 # MAIN PIPELINE
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def generate_synthetic_pairs(
     data: List[dict],
     api_call,
@@ -326,7 +330,8 @@ def generate_synthetic_pairs(
 
         # Generate high-quality positive
         positive = generate_positive_demo(
-            item, api_call,
+            item,
+            api_call,
             max_tokens=max_tokens_pos,
             temperature=0.7,
         )
@@ -337,23 +342,26 @@ def generate_synthetic_pairs(
         # Generate hard negatives
         for _ in range(negatives_per_question):
             negative = generate_hard_negative(
-                item, api_call,
+                item,
+                api_call,
                 negative_type="random",
                 max_tokens=max_tokens_neg,
                 temperature=0.9,  # Higher temp for more diverse flaws
             )
             if negative:
-                preference_pairs.append({
-                    "prompt": prompt_text,
-                    "chosen": positive,
-                    "rejected": negative["text"],
-                    "chosen_score": 5.0,   # Expert-level quality
-                    "rejected_score": 0.0, # Intentionally flawed
-                    "score_gap": 5.0,
-                    "is_synthetic": True,
-                    "negative_type": negative["type"],
-                    "negative_description": negative["description"],
-                })
+                preference_pairs.append(
+                    {
+                        "prompt": prompt_text,
+                        "chosen": positive,
+                        "rejected": negative["text"],
+                        "chosen_score": 5.0,  # Expert-level quality
+                        "rejected_score": 0.0,  # Intentionally flawed
+                        "score_gap": 5.0,
+                        "is_synthetic": True,
+                        "negative_type": negative["type"],
+                        "negative_description": negative["description"],
+                    }
+                )
                 generated_count += 1
 
         # Rate limiting
@@ -366,10 +374,7 @@ def generate_synthetic_pairs(
                 f"{generated_count} pairs generated, {failed_count} failed."
             )
 
-    logger.info(
-        f"Synthetic data generation complete: {generated_count} pairs, "
-        f"{failed_count} failed questions."
-    )
+    logger.info(f"Synthetic data generation complete: {generated_count} pairs, " f"{failed_count} failed questions.")
     return preference_pairs
 
 
@@ -378,25 +383,26 @@ def main():
         description="Generate synthetic CoT positive + hard negative data for RLearner-LLM DPO."
     )
     # Data
-    parser.add_argument("--data_path", required=True,
-                        help="Input PeerWise JSON (fields: instruction, input, output).")
-    parser.add_argument("--output_path", required=True,
-                        help="Output path for synthetic preference pairs JSON.")
-    parser.add_argument("--merge_with", default=None,
-                        help="If set, merge with an existing preference pairs JSON.")
-    parser.add_argument("--num_questions", type=int, default=500,
-                        help="Number of questions to generate synthetic data for.")
-    parser.add_argument("--negatives_per_question", type=int, default=2,
-                        help="Number of hard negatives per question (2 = 2 types).")
+    parser.add_argument("--data_path", required=True, help="Input PeerWise JSON (fields: instruction, input, output).")
+    parser.add_argument("--output_path", required=True, help="Output path for synthetic preference pairs JSON.")
+    parser.add_argument("--merge_with", default=None, help="If set, merge with an existing preference pairs JSON.")
+    parser.add_argument(
+        "--num_questions", type=int, default=500, help="Number of questions to generate synthetic data for."
+    )
+    parser.add_argument(
+        "--negatives_per_question", type=int, default=2, help="Number of hard negatives per question (2 = 2 types)."
+    )
     # API
-    parser.add_argument("--api_provider", choices=["openai", "anthropic"], default="openai",
-                        help="Which LLM API to use for generation.")
-    parser.add_argument("--api_key", required=True,
-                        help="API key for the selected provider.")
-    parser.add_argument("--model", default=None,
-                        help="Model ID. Defaults: openai=gpt-4o, anthropic=claude-3-5-sonnet-20241022")
-    parser.add_argument("--api_delay", type=float, default=0.5,
-                        help="Seconds to wait between API calls (rate limiting).")
+    parser.add_argument(
+        "--api_provider", choices=["openai", "anthropic"], default="openai", help="Which LLM API to use for generation."
+    )
+    parser.add_argument("--api_key", required=True, help="API key for the selected provider.")
+    parser.add_argument(
+        "--model", default=None, help="Model ID. Defaults: openai=gpt-4o, anthropic=claude-3-5-sonnet-20241022"
+    )
+    parser.add_argument(
+        "--api_delay", type=float, default=0.5, help="Seconds to wait between API calls (rate limiting)."
+    )
     parser.add_argument("--max_tokens_positive", type=int, default=512)
     parser.add_argument("--max_tokens_negative", type=int, default=256)
     # Options
@@ -436,8 +442,7 @@ def main():
     if args.merge_with and os.path.isfile(args.merge_with):
         with open(args.merge_with, "r", encoding="utf-8") as f:
             existing_pairs = json.load(f)
-        logger.info(f"Merging {len(synthetic_pairs)} synthetic pairs with "
-                    f"{len(existing_pairs)} existing pairs.")
+        logger.info(f"Merging {len(synthetic_pairs)} synthetic pairs with " f"{len(existing_pairs)} existing pairs.")
         all_pairs = existing_pairs + synthetic_pairs
     else:
         all_pairs = synthetic_pairs
@@ -458,12 +463,12 @@ def main():
             t = p.get("negative_type", "unknown")
             type_counts[t] = type_counts.get(t, 0) + 1
 
-    logger.info(f"\nFinal dataset statistics:")
+    logger.info("\nFinal dataset statistics:")
     logger.info(f"  Total pairs:     {len(all_pairs)}")
     logger.info(f"  Organic pairs:   {n_organic}")
     logger.info(f"  Synthetic pairs: {n_synthetic}")
     if type_counts:
-        logger.info(f"  Hard negative breakdown:")
+        logger.info("  Hard negative breakdown:")
         for t, c in sorted(type_counts.items()):
             logger.info(f"    {t}: {c}")
     logger.info(f"\nSaved to: {args.output_path}")

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_generate_synthetic_data.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_generate_synthetic_data.py
@@ -1,0 +1,473 @@
+"""
+RLearner-LLM Synthetic Data Augmentation (亮点三完整实现)
+
+Generates two types of synthetic data to strengthen DPO training:
+
+A) HIGH-QUALITY POSITIVE DEMOS (y_chosen 上限)
+   Uses GPT-4o or Claude-3.5-Sonnet with Chain-of-Thought (CoT) prompting to write
+   "textbook-level" expert explanations for PeerWise questions.
+   These become the gold standard y_chosen in DPO, pushing the model beyond
+   what human students wrote.
+
+B) HARD NEGATIVE EXAMPLES (y_rejected 强负样本)
+   Uses the same LLM to deliberately generate flawed explanations of 4 types:
+     1. Inverted logic: Attributes the correct reasoning to a wrong option
+     2. Concept confusion: Mixes up distractors' explanations with the correct answer
+     3. High-score gibberish: Fluent, formal-sounding text with zero factual content
+     4. Circular reasoning: Re-states the question as the explanation without justification
+
+   These hard negatives teach the DPO model that "confident-sounding" ≠ "correct".
+
+Usage:
+    # Generate with GPT-4o
+    python rl_generate_synthetic_data.py \
+        --data_path ./Paul_new_data/Cardiff/Cardiff_all_generator_train_avg_3_lenexp_10.json \
+        --output_path ./rl_synthetic_data/cardiff_synthetic.json \
+        --api_provider openai \
+        --api_key YOUR_OPENAI_KEY \
+        --model gpt-4o \
+        --num_questions 500
+
+    # Generate with Claude
+    python rl_generate_synthetic_data.py \
+        --data_path ./Paul_new_data/Cardiff/Cardiff_all_generator_train_avg_3_lenexp_10.json \
+        --output_path ./rl_synthetic_data/cardiff_synthetic.json \
+        --api_provider anthropic \
+        --api_key YOUR_ANTHROPIC_KEY \
+        --model claude-3-5-sonnet-20241022 \
+        --num_questions 500
+
+    # Merge with preference pairs from rl_build_preference_data.py
+    python rl_generate_synthetic_data.py \
+        --merge_with ./rl_preference_data/preference_pairs.json \
+        --output_path ./rl_preference_data/preference_pairs_augmented.json \
+        [... other args ...]
+"""
+
+import argparse
+import json
+import logging
+import os
+import random
+import time
+from typing import Any, Dict, List, Optional
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PROMPTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+COT_POSITIVE_SYSTEM = """You are an expert educator writing textbook-quality explanations for exam questions.
+Your explanations must:
+1. Clearly state WHY the correct answer is right using specific domain knowledge
+2. Briefly explain WHY each incorrect option is wrong (to prevent concept confusion)
+3. Use precise academic terminology appropriate for the subject
+4. Be logically structured: state fact → explain mechanism → connect to answer
+5. Be 3-6 sentences long — substantive but not verbose
+
+Do NOT simply restate the question. Do NOT use vague phrases like "clearly" or "obviously".
+Think step-by-step before writing the final explanation."""
+
+COT_POSITIVE_USER = """Here is an exam question. Write a textbook-quality explanation.
+
+{question_block}
+
+First, think through the reasoning step by step (internal chain-of-thought).
+Then write the final explanation in this format:
+EXPLANATION: [Your 3-6 sentence explanation here]"""
+
+HARD_NEGATIVE_SYSTEM = """You are helping build a training dataset by generating intentionally flawed explanations.
+These flawed explanations will be used as negative examples to teach a model what NOT to do.
+Generate the requested type of bad explanation as instructed."""
+
+HARD_NEGATIVE_USER_INVERTED = """Generate a LOGICALLY INVERTED explanation for this question.
+The explanation should confidently attribute the correct reasoning to the WRONG answer choice,
+making it sound plausible but actually backwards.
+
+{question_block}
+
+Generate an inverted explanation (sounds confident, but logic is reversed):
+FLAWED EXPLANATION:"""
+
+HARD_NEGATIVE_USER_CONFUSION = """Generate a CONCEPT CONFUSION explanation for this question.
+Take the reasoning that applies to one of the INCORRECT options and confidently apply it
+to explain why the CORRECT answer is right. Mix up the concepts.
+
+{question_block}
+
+Generate a concept-confused explanation (applies wrong reasoning to right answer):
+FLAWED EXPLANATION:"""
+
+HARD_NEGATIVE_USER_GIBBERISH = """Generate a HIGH-SCORE GIBBERISH explanation for this question.
+Write something that sounds highly academic, uses impressive vocabulary and complex sentence structure,
+but contains absolutely no specific factual content — just generic educational-sounding filler.
+Do NOT mention any specific facts, mechanisms, or domain concepts.
+
+{question_block}
+
+Generate academic-sounding gibberish with no real content:
+FLAWED EXPLANATION:"""
+
+HARD_NEGATIVE_USER_CIRCULAR = """Generate a CIRCULAR REASONING explanation for this question.
+Simply restate what the question already says without adding any new information or justification.
+The explanation should just echo the answer choice without explaining why it is correct.
+
+{question_block}
+
+Generate a circular, content-free explanation:
+FLAWED EXPLANATION:"""
+
+HARD_NEGATIVE_TYPES = [
+    ("inverted_logic",   HARD_NEGATIVE_USER_INVERTED,   "Logically inverted reasoning"),
+    ("concept_confused", HARD_NEGATIVE_USER_CONFUSION,  "Mixed-up concepts"),
+    ("gibberish",        HARD_NEGATIVE_USER_GIBBERISH,  "High-score academic gibberish"),
+    ("circular",         HARD_NEGATIVE_USER_CIRCULAR,   "Circular reasoning"),
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API CLIENTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def call_openai(
+    client,
+    system: str,
+    user: str,
+    model: str = "gpt-4o",
+    max_tokens: int = 512,
+    temperature: float = 0.7,
+) -> str:
+    """Call OpenAI API and return the assistant's message content."""
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def call_anthropic(
+    client,
+    system: str,
+    user: str,
+    model: str = "claude-3-5-sonnet-20241022",
+    max_tokens: int = 512,
+    temperature: float = 0.7,
+) -> str:
+    """Call Anthropic API and return the assistant's message content."""
+    response = client.messages.create(
+        model=model,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return response.content[0].text.strip()
+
+
+def build_api_caller(provider: str, api_key: str, model: str):
+    """Build a unified API call function for the given provider."""
+    if provider == "openai":
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise ImportError("Install openai: pip install openai>=1.0")
+        client = OpenAI(api_key=api_key)
+        return lambda sys, usr, **kw: call_openai(client, sys, usr, model=model, **kw)
+
+    elif provider == "anthropic":
+        try:
+            import anthropic
+        except ImportError:
+            raise ImportError("Install anthropic: pip install anthropic")
+        client = anthropic.Anthropic(api_key=api_key)
+        return lambda sys, usr, **kw: call_anthropic(client, sys, usr, model=model, **kw)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}. Use 'openai' or 'anthropic'.")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DATA HELPERS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def format_question_block(item: dict) -> str:
+    """Format a PeerWise item into a readable question block for the LLM prompt."""
+    input_text = item.get("input", "").replace("</s>", "").strip()
+    # input_text already contains: Question, Options, Correct Answer
+    return input_text
+
+
+def extract_explanation_from_response(text: str, tag: str = "EXPLANATION:") -> str:
+    """Extract the explanation text after the tag marker."""
+    if tag in text:
+        return text.split(tag)[-1].strip()
+    # Fallback: return everything after the last colon
+    lines = text.strip().split("\n")
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip():
+            return "\n".join(lines[i:]).strip()
+    return text.strip()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CORE GENERATION FUNCTIONS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def generate_positive_demo(
+    item: dict,
+    api_call,
+    max_tokens: int = 512,
+    temperature: float = 0.7,
+) -> Optional[str]:
+    """Generate a high-quality CoT explanation using GPT-4o/Claude."""
+    question_block = format_question_block(item)
+    if not question_block:
+        return None
+
+    user_prompt = COT_POSITIVE_USER.format(question_block=question_block)
+    try:
+        response = api_call(
+            COT_POSITIVE_SYSTEM,
+            user_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return extract_explanation_from_response(response, tag="EXPLANATION:")
+    except Exception as e:
+        logger.warning(f"API error generating positive demo: {e}")
+        return None
+
+
+def generate_hard_negative(
+    item: dict,
+    api_call,
+    negative_type: str = "random",
+    max_tokens: int = 256,
+    temperature: float = 0.8,
+) -> Optional[Dict[str, str]]:
+    """Generate a hard negative explanation of the specified type."""
+    question_block = format_question_block(item)
+    if not question_block:
+        return None
+
+    if negative_type == "random":
+        neg_type_key, user_template, description = random.choice(HARD_NEGATIVE_TYPES)
+    else:
+        found = [t for t in HARD_NEGATIVE_TYPES if t[0] == negative_type]
+        if not found:
+            raise ValueError(f"Unknown negative type: {negative_type}")
+        neg_type_key, user_template, description = found[0]
+
+    user_prompt = user_template.format(question_block=question_block)
+    try:
+        response = api_call(
+            HARD_NEGATIVE_SYSTEM,
+            user_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        flawed = extract_explanation_from_response(response, tag="FLAWED EXPLANATION:")
+        return {
+            "text": flawed,
+            "type": neg_type_key,
+            "description": description,
+        }
+    except Exception as e:
+        logger.warning(f"API error generating hard negative ({neg_type_key}): {e}")
+        return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MAIN PIPELINE
+# ─────────────────────────────────────────────────────────────────────────────
+
+def generate_synthetic_pairs(
+    data: List[dict],
+    api_call,
+    num_questions: int,
+    max_tokens_pos: int = 512,
+    max_tokens_neg: int = 256,
+    negatives_per_question: int = 2,
+    api_delay: float = 0.5,
+) -> List[dict]:
+    """
+    For each sampled question, generate:
+      - 1 high-quality positive explanation (y_chosen via CoT)
+      - negatives_per_question hard negatives (y_rejected, random types)
+
+    Returns list of DPO-format preference pairs:
+      [{"prompt": ..., "chosen": ..., "rejected": ..., "chosen_score": 5.0,
+        "rejected_score": 0.0, "score_gap": 5.0, "is_synthetic": True,
+        "negative_type": ...}, ...]
+    """
+    sampled = random.sample(data, min(num_questions, len(data)))
+    preference_pairs = []
+    generated_count = 0
+    failed_count = 0
+
+    for i, item in enumerate(sampled):
+        instruction = item.get("instruction", "").replace("</s>", "").strip()
+        input_text = item.get("input", "").replace("</s>", "").strip()
+        if not input_text:
+            continue
+
+        # Build the DPO prompt
+        prompt_text = f"{instruction}\n\n{input_text}" if instruction else input_text
+
+        # Generate high-quality positive
+        positive = generate_positive_demo(
+            item, api_call,
+            max_tokens=max_tokens_pos,
+            temperature=0.7,
+        )
+        if not positive:
+            failed_count += 1
+            continue
+
+        # Generate hard negatives
+        for _ in range(negatives_per_question):
+            negative = generate_hard_negative(
+                item, api_call,
+                negative_type="random",
+                max_tokens=max_tokens_neg,
+                temperature=0.9,  # Higher temp for more diverse flaws
+            )
+            if negative:
+                preference_pairs.append({
+                    "prompt": prompt_text,
+                    "chosen": positive,
+                    "rejected": negative["text"],
+                    "chosen_score": 5.0,   # Expert-level quality
+                    "rejected_score": 0.0, # Intentionally flawed
+                    "score_gap": 5.0,
+                    "is_synthetic": True,
+                    "negative_type": negative["type"],
+                    "negative_description": negative["description"],
+                })
+                generated_count += 1
+
+        # Rate limiting
+        if api_delay > 0:
+            time.sleep(api_delay)
+
+        if (i + 1) % 50 == 0:
+            logger.info(
+                f"Progress: {i+1}/{len(sampled)} questions processed, "
+                f"{generated_count} pairs generated, {failed_count} failed."
+            )
+
+    logger.info(
+        f"Synthetic data generation complete: {generated_count} pairs, "
+        f"{failed_count} failed questions."
+    )
+    return preference_pairs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate synthetic CoT positive + hard negative data for RLearner-LLM DPO."
+    )
+    # Data
+    parser.add_argument("--data_path", required=True,
+                        help="Input PeerWise JSON (fields: instruction, input, output).")
+    parser.add_argument("--output_path", required=True,
+                        help="Output path for synthetic preference pairs JSON.")
+    parser.add_argument("--merge_with", default=None,
+                        help="If set, merge with an existing preference pairs JSON.")
+    parser.add_argument("--num_questions", type=int, default=500,
+                        help="Number of questions to generate synthetic data for.")
+    parser.add_argument("--negatives_per_question", type=int, default=2,
+                        help="Number of hard negatives per question (2 = 2 types).")
+    # API
+    parser.add_argument("--api_provider", choices=["openai", "anthropic"], default="openai",
+                        help="Which LLM API to use for generation.")
+    parser.add_argument("--api_key", required=True,
+                        help="API key for the selected provider.")
+    parser.add_argument("--model", default=None,
+                        help="Model ID. Defaults: openai=gpt-4o, anthropic=claude-3-5-sonnet-20241022")
+    parser.add_argument("--api_delay", type=float, default=0.5,
+                        help="Seconds to wait between API calls (rate limiting).")
+    parser.add_argument("--max_tokens_positive", type=int, default=512)
+    parser.add_argument("--max_tokens_negative", type=int, default=256)
+    # Options
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility.")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    os.makedirs(os.path.dirname(args.output_path) or ".", exist_ok=True)
+
+    # Set default models
+    if args.model is None:
+        args.model = "gpt-4o" if args.api_provider == "openai" else "claude-3-5-sonnet-20241022"
+
+    logger.info(f"Provider: {args.api_provider}, Model: {args.model}")
+
+    # Build API caller
+    api_call = build_api_caller(args.api_provider, args.api_key, args.model)
+
+    # Load data
+    with open(args.data_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+    logger.info(f"Loaded {len(raw_data)} questions from {args.data_path}")
+
+    # Generate synthetic pairs
+    logger.info(f"Generating synthetic data for {args.num_questions} questions...")
+    synthetic_pairs = generate_synthetic_pairs(
+        data=raw_data,
+        api_call=api_call,
+        num_questions=args.num_questions,
+        max_tokens_pos=args.max_tokens_positive,
+        max_tokens_neg=args.max_tokens_negative,
+        negatives_per_question=args.negatives_per_question,
+        api_delay=args.api_delay,
+    )
+
+    # Merge with existing preference data if requested
+    if args.merge_with and os.path.isfile(args.merge_with):
+        with open(args.merge_with, "r", encoding="utf-8") as f:
+            existing_pairs = json.load(f)
+        logger.info(f"Merging {len(synthetic_pairs)} synthetic pairs with "
+                    f"{len(existing_pairs)} existing pairs.")
+        all_pairs = existing_pairs + synthetic_pairs
+    else:
+        all_pairs = synthetic_pairs
+
+    # Shuffle to mix synthetic and organic pairs
+    random.shuffle(all_pairs)
+
+    # Save
+    with open(args.output_path, "w", encoding="utf-8") as f:
+        json.dump(all_pairs, f, ensure_ascii=False, indent=2)
+
+    # Statistics
+    n_synthetic = sum(1 for p in all_pairs if p.get("is_synthetic"))
+    n_organic = len(all_pairs) - n_synthetic
+    type_counts = {}
+    for p in all_pairs:
+        if p.get("is_synthetic"):
+            t = p.get("negative_type", "unknown")
+            type_counts[t] = type_counts.get(t, 0) + 1
+
+    logger.info(f"\nFinal dataset statistics:")
+    logger.info(f"  Total pairs:     {len(all_pairs)}")
+    logger.info(f"  Organic pairs:   {n_organic}")
+    logger.info(f"  Synthetic pairs: {n_synthetic}")
+    if type_counts:
+        logger.info(f"  Hard negative breakdown:")
+        for t, c in sorted(type_counts.items()):
+            logger.info(f"    {t}: {c}")
+    logger.info(f"\nSaved to: {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_dpo.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_dpo.py
@@ -1,0 +1,237 @@
+"""
+RLearner-LLM Step 3 (Recommended): DPO Fine-tuning with LoRA
+TRL 0.7.1 + Transformers 4.31.0 compatible (llm-tuning conda env)
+
+Direct Preference Optimization trains the model to prefer high-quality
+explanations (chosen) over low-quality ones (rejected) without a separate
+reward model during training.
+
+Dataset format expected (from rl_build_preference_data.py):
+  {"prompt": "<Alpaca prompt ending with ### Response:\\n>",
+   "chosen": "<good explanation>",
+   "rejected": "<bad explanation>"}
+
+Usage (4x A100 80GB, GPUs 4-7):
+    CUDA_VISIBLE_DEVICES=4,5,6,7 torchrun --nproc_per_node=4 --master_port 29501 \\
+        rl_train_dpo.py \\
+        --model_name_or_path /data/shared/llama2/llama-2-13b-hf \\
+        --sft_adapter_path ./rl_sft_llama2_13b_generator \\
+        --preference_data_path ./rl_preference_data/preference_pairs.json \\
+        --output_dir ./rl_dpo_llama2_13b_generator \\
+        --num_train_epochs 2 \\
+        --per_device_train_batch_size 1 \\
+        --gradient_accumulation_steps 8 \\
+        --beta 0.1 \\
+        --bf16 True \\
+        --gradient_checkpointing True \\
+        --report_to none
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+import transformers
+from datasets import Dataset
+from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
+from trl import DPOTrainer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelArguments:
+    model_name_or_path: str = field(
+        default="/data/shared/llama2/llama-2-13b-hf",
+        metadata={"help": "Base model path. Must match the model used for SFT."},
+    )
+    sft_adapter_path: Optional[str] = field(
+        default=None,
+        metadata={"help": "SFT LoRA adapter directory. Merged into base before DPO."},
+    )
+    cache_dir: Optional[str] = field(default="cache")
+
+
+@dataclass
+class DataArguments:
+    preference_data_path: str = field(
+        default="./rl_preference_data/preference_pairs.json",
+        metadata={"help": "Preference pairs JSON (fields: prompt, chosen, rejected)."},
+    )
+    eval_data_path: Optional[str] = field(default=None)
+
+
+@dataclass
+class DPOArguments:
+    beta: float = field(
+        default=0.1,
+        metadata={"help": "KL penalty coefficient. Lower = more aggressive; higher = conservative."},
+    )
+    max_length: int = field(
+        default=1024,
+        metadata={"help": "Max total sequence length (prompt + response)."},
+    )
+    max_prompt_length: int = field(
+        default=512,
+        metadata={"help": "Max prompt length. Longer prompts are truncated."},
+    )
+    min_score_gap_filter: float = field(
+        default=0.0,
+        metadata={"help": "Skip pairs whose score_gap is below this threshold."},
+    )
+
+
+@dataclass
+class LoraArguments:
+    lora_r: int = field(default=16)
+    lora_alpha: int = field(default=32)
+    lora_dropout: float = field(default=0.05)
+    lora_target_modules: str = field(
+        default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj",
+    )
+
+
+def load_preference_dataset(data_path: str, min_score_gap: float = 0.0) -> Dataset:
+    """
+    Load preference pairs as plain-text {prompt, chosen, rejected}.
+
+    TRL 0.7.1 DPOTrainer expects:
+      prompt   -> str (Alpaca-format query ending with '### Response:\\n')
+      chosen   -> str (good explanation text only, no prompt prefix)
+      rejected -> str (bad explanation text only, no prompt prefix)
+    """
+    with open(data_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+
+    examples = []
+    skipped = 0
+    for item in raw_data:
+        prompt = item.get("prompt", "").strip()
+        chosen = item.get("chosen", "").strip()
+        rejected = item.get("rejected", "").strip()
+        score_gap = item.get("score_gap", 1.0)
+
+        if not prompt or not chosen or not rejected:
+            skipped += 1
+            continue
+        if score_gap < min_score_gap:
+            skipped += 1
+            continue
+
+        examples.append({"prompt": prompt, "chosen": chosen, "rejected": rejected})
+
+    logger.info(
+        f"Loaded {len(examples)} preference pairs from {data_path} "
+        f"(skipped {skipped} invalid/low-gap)."
+    )
+    return Dataset.from_list(examples)
+
+
+def main():
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, DPOArguments, LoraArguments, TrainingArguments)
+    )
+    model_args, data_args, dpo_args, lora_args, training_args = parser.parse_args_into_dataclasses()
+
+    # ── Tokenizer ──────────────────────────────────────────────────────────────
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        padding_side="left",   # DPO prefers left-padding for decoder-only models
+        trust_remote_code=True,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # ── Model ──────────────────────────────────────────────────────────────────
+    model = AutoModelForCausalLM.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        torch_dtype=torch.bfloat16,
+        trust_remote_code=True,
+        device_map="auto",
+    )
+    model.config.use_cache = False
+
+    # ── Merge SFT LoRA (optional) ──────────────────────────────────────────────
+    if model_args.sft_adapter_path and os.path.isdir(model_args.sft_adapter_path):
+        logger.info(f"Merging SFT LoRA adapter from {model_args.sft_adapter_path} ...")
+        model = PeftModel.from_pretrained(model, model_args.sft_adapter_path)
+        model = model.merge_and_unload()
+        logger.info("SFT adapter merged into base model.")
+
+    # ── LoRA for DPO ──────────────────────────────────────────────────────────
+    target_modules = [m.strip() for m in lora_args.lora_target_modules.split(",")]
+    lora_config = LoraConfig(
+        r=lora_args.lora_r,
+        lora_alpha=lora_args.lora_alpha,
+        lora_dropout=lora_args.lora_dropout,
+        target_modules=target_modules,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM,
+    )
+    # Apply LoRA manually so we can call enable_input_require_grads() before
+    # the trainer takes ownership. This fixes "element 0 does not require grad"
+    # when gradient_checkpointing=True is used alongside LoRA frozen base weights.
+    model = get_peft_model(model, lora_config)
+    model.enable_input_require_grads()
+    model.print_trainable_parameters()
+    logger.info(f"DPO LoRA: r={lora_args.lora_r}, alpha={lora_args.lora_alpha}, beta={dpo_args.beta}")
+
+    # ── Dataset ────────────────────────────────────────────────────────────────
+    train_dataset = load_preference_dataset(
+        data_args.preference_data_path,
+        min_score_gap=dpo_args.min_score_gap_filter,
+    )
+    eval_dataset = None
+    if data_args.eval_data_path:
+        eval_dataset = load_preference_dataset(data_args.eval_data_path)
+
+    # ── DPO Trainer (TRL 0.7.1 API) ───────────────────────────────────────────
+    # In TRL 0.7.1:
+    #   - beta is a direct positional/keyword arg (not part of a config class)
+    #   - ref_model=None: DPOTrainer creates a frozen copy of the initial model
+    #     weights automatically as the reference policy
+    #   - max_length and max_prompt_length are direct args (not in TrainingArguments)
+    #   - peft_config omitted — LoRA already applied above
+    trainer = DPOTrainer(
+        model=model,
+        ref_model=None,
+        beta=dpo_args.beta,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        tokenizer=tokenizer,
+        max_length=dpo_args.max_length,
+        max_prompt_length=dpo_args.max_prompt_length,
+        disable_dropout=True,
+    )
+
+    logger.info("Starting DPO training...")
+    logger.info(f"  Training examples: {len(train_dataset)}")
+    logger.info(f"  Beta (KL penalty): {dpo_args.beta}")
+    logger.info(f"  Max length: {dpo_args.max_length} / prompt: {dpo_args.max_prompt_length}")
+
+    trainer.train()
+    trainer.save_model(training_args.output_dir)
+    tokenizer.save_pretrained(training_args.output_dir)
+    logger.info(f"DPO LoRA adapter saved to {training_args.output_dir}")
+
+    # Save training log
+    metrics_path = os.path.join(training_args.output_dir, "dpo_train_metrics.json")
+    if hasattr(trainer, "state") and trainer.state.log_history:
+        with open(metrics_path, "w") as f:
+            json.dump(trainer.state.log_history, f, indent=2)
+        logger.info(f"Training metrics saved to {metrics_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_dpo.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_dpo.py
@@ -128,10 +128,7 @@ def load_preference_dataset(data_path: str, min_score_gap: float = 0.0) -> Datas
 
         examples.append({"prompt": prompt, "chosen": chosen, "rejected": rejected})
 
-    logger.info(
-        f"Loaded {len(examples)} preference pairs from {data_path} "
-        f"(skipped {skipped} invalid/low-gap)."
-    )
+    logger.info(f"Loaded {len(examples)} preference pairs from {data_path} " f"(skipped {skipped} invalid/low-gap).")
     return Dataset.from_list(examples)
 
 
@@ -145,7 +142,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.model_name_or_path,
         cache_dir=model_args.cache_dir,
-        padding_side="left",   # DPO prefers left-padding for decoder-only models
+        padding_side="left",  # DPO prefers left-padding for decoder-only models
         trust_remote_code=True,
     )
     if tokenizer.pad_token is None:

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_ppo_nli.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_ppo_nli.py
@@ -1,0 +1,318 @@
+"""
+RLearner-LLM PPO with NLI Reward (LLaMA-2-13B)
+
+Replaces verifier reward with NLI entailment probability:
+  reward = P(entailment | premise=explanation, hypothesis=correct_option_text)
+
+This directly optimises the most discriminative metric (NLI), avoiding the
+alignment tax observed when using verifier reward for Qwen3.
+
+Usage (two GPUs, actor on cuda:0, NLI on CPU):
+    CUDA_VISIBLE_DEVICES=5,7 python rl_train_ppo_nli.py \
+        --model_name_or_path /data/shared/llama2/llama-2-13b-hf \
+        --sft_adapter_path ./rl_dpo_nli_llama2_generator \
+        --output_dir ./rl_ppo_nli_llama2_generator \
+        --data_path ./Paul_new_data/Merged_Sydney_Cardiff_Law_Medical_Y1_Y2/generator_merged_avg_3_lenexp_10.json \
+        --batch_size 4 --mini_batch_size 1 --ppo_epochs 4 \
+        --learning_rate 1e-5 --max_questions 500
+
+Two-stage pipeline: pass --sft_adapter_path ./rl_dpo_nli_llama2_generator to
+initialise PPO from the NLI-DPO adapter instead of the SFT adapter.
+"""
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import torch
+import transformers
+from datasets import Dataset
+from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+from transformers import (
+    AutoModelForCausalLM,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+)
+from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+ALPACA_PROMPT = (
+    "Below is an instruction that describes a task, paired with an input that "
+    "provides further context. Write a response that appropriately completes the request.\n\n"
+    "### Instruction:\n{instruction}\n\n"
+    "### Input:\n{input}\n\n"
+    "### Response:\n"
+)
+
+
+# ── Dataclasses ──────────────────────────────────────────────────────────────
+
+@dataclass
+class ModelArguments:
+    model_name_or_path: str = field(default="/data/shared/llama2/llama-2-13b-hf")
+    sft_adapter_path: Optional[str] = field(
+        default="./rl_sft_llama2_13b_generator",
+        metadata={"help": "SFT or DPO-NLI LoRA adapter to initialise the Actor."},
+    )
+    output_dir: str = field(default="./rl_ppo_nli_llama2_generator")
+    nli_model: str = field(default="cross-encoder/nli-deberta-v3-small")
+    nli_device: str = field(default="cpu", metadata={"help": "Device for NLI reward model."})
+    use_4bit: bool = field(default=False)
+    cache_dir: Optional[str] = field(default="cache")
+    use_flash_attention: bool = field(default=True)
+
+
+@dataclass
+class DataArguments:
+    data_path: str = field(
+        default="./Paul_new_data/Merged_Sydney_Cardiff_Law_Medical_Y1_Y2/generator_merged_avg_3_lenexp_10.json"
+    )
+    max_questions: Optional[int] = field(default=500)
+
+
+@dataclass
+class LoraArguments:
+    lora_r: int = field(default=16)
+    lora_alpha: int = field(default=32)
+    lora_dropout: float = field(default=0.05)
+    lora_target_modules: str = field(
+        default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+    )
+
+
+# ── Helper functions ──────────────────────────────────────────────────────────
+
+def extract_correct_option_text(input_text: str) -> Tuple[Optional[str], Optional[str]]:
+    """Extract the correct answer option text from training data input field."""
+    m = re.search(r"The correct answer is Option ([A-Z])", input_text)
+    if not m:
+        return None, None
+    letter = m.group(1)
+    opt_pat = rf"Option {letter}:\s*(.+?)(?:\s+Option [A-Z]:|The correct answer|$)"
+    opt_m = re.search(opt_pat, input_text, re.DOTALL)
+    return letter, opt_m.group(1).strip() if opt_m else None
+
+
+# ── NLI Reward Model ──────────────────────────────────────────────────────────
+
+class NLIRewardModel:
+    """
+    Uses DeBERTa NLI entailment probability as the PPO reward signal.
+
+    reward = P(entailment | premise=explanation, hypothesis=correct_option_text)
+
+    This directly optimises answer-grounded explanation quality — the most
+    discriminative metric observed in our experiments.
+    """
+
+    def __init__(self, model_name: str = "cross-encoder/nli-deberta-v3-small",
+                 device: str = "cpu", cache_dir: str = "cache"):
+        logger.info(f"Loading NLI reward model: {model_name} on {device} ...")
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, cache_dir=cache_dir, use_fast=False
+        )
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            model_name, cache_dir=cache_dir
+        ).to(device)
+        self.model.eval()
+        self.device = device
+
+        id2label = self.model.config.id2label
+        self.entailment_idx = next(
+            k for k, v in id2label.items() if v.lower() == "entailment"
+        )
+        logger.info(f"NLI reward loaded. entailment_idx={self.entailment_idx}")
+
+    @torch.no_grad()
+    def get_rewards(
+        self, correct_options: List[str], explanations: List[str]
+    ) -> List[torch.Tensor]:
+        """
+        Score batch: P(explanation entails correct_option) for each pair.
+        Returns list of scalar float tensors in [0, 1].
+        """
+        # Skip pairs where correct option could not be extracted
+        enc = self.tokenizer(
+            explanations, correct_options,
+            padding=True, truncation=True, max_length=512, return_tensors="pt",
+        )
+        enc = {k: v.to(self.device) for k, v in enc.items()}
+        logits = self.model(**enc).logits
+        probs = torch.softmax(logits, dim=-1)
+        entailment_probs = probs[:, self.entailment_idx]
+        return [torch.tensor(p.item(), dtype=torch.float32) for p in entailment_probs]
+
+
+# ── Dataset ───────────────────────────────────────────────────────────────────
+
+def build_ppo_dataset(
+    data_path: str, tokenizer, max_questions: Optional[int] = None
+) -> Dataset:
+    with open(data_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+    if max_questions:
+        raw_data = raw_data[:max_questions]
+
+    examples = []
+    skipped = 0
+    for item in raw_data:
+        instruction = item.get("instruction", "").replace("</s>", "").strip()
+        input_text = item.get("input", "").replace("</s>", "").strip()
+        if not input_text:
+            continue
+
+        _, correct_opt = extract_correct_option_text(input_text)
+        if not correct_opt:
+            skipped += 1
+            continue  # NLI reward requires correct option text
+
+        prompt = ALPACA_PROMPT.format(instruction=instruction, input=input_text)
+        tokenized = tokenizer(prompt, truncation=True, max_length=512)
+        examples.append({
+            "input_ids": tokenized["input_ids"],
+            "query": prompt,
+            "question_input": input_text,
+            "correct_option": correct_opt,
+        })
+
+    logger.info(
+        f"PPO dataset: {len(examples)} questions loaded ({skipped} skipped, no option text)"
+    )
+    return Dataset.from_list(examples)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, LoraArguments, PPOConfig)
+    )
+    model_args, data_args, lora_args, ppo_config = parser.parse_args_into_dataclasses()
+    ppo_config.remove_unused_columns = False
+
+    # Tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        padding_side="left",
+        trust_remote_code=True,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # Actor model
+    bnb_config = None
+    if model_args.use_4bit:
+        bnb_config = BitsAndBytesConfig(
+            load_in_4bit=True, bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16, bnb_4bit_use_double_quant=True,
+        )
+
+    attn_impl = "flash_attention_2" if model_args.use_flash_attention else "eager"
+    try:
+        base_model = AutoModelForCausalLM.from_pretrained(
+            model_args.model_name_or_path, cache_dir=model_args.cache_dir,
+            quantization_config=bnb_config, torch_dtype=torch.bfloat16,
+            device_map="auto" if bnb_config else None,
+            trust_remote_code=True, attn_implementation=attn_impl,
+        )
+    except Exception:
+        logger.warning("flash_attention_2 unavailable, falling back to eager.")
+        base_model = AutoModelForCausalLM.from_pretrained(
+            model_args.model_name_or_path, cache_dir=model_args.cache_dir,
+            quantization_config=bnb_config, torch_dtype=torch.bfloat16,
+            device_map="auto" if bnb_config else None, trust_remote_code=True,
+        )
+
+    if model_args.sft_adapter_path and os.path.isdir(model_args.sft_adapter_path):
+        logger.info(f"Merging adapter from {model_args.sft_adapter_path} ...")
+        base_model = PeftModel.from_pretrained(base_model, model_args.sft_adapter_path)
+        base_model = base_model.merge_and_unload()
+        logger.info("Adapter merged.")
+
+    target_modules = [m.strip() for m in lora_args.lora_target_modules.split(",")]
+    lora_config = LoraConfig(
+        r=lora_args.lora_r, lora_alpha=lora_args.lora_alpha,
+        lora_dropout=lora_args.lora_dropout, target_modules=target_modules,
+        bias="none", task_type=TaskType.CAUSAL_LM,
+    )
+    base_model = get_peft_model(base_model, lora_config)
+    base_model.print_trainable_parameters()
+
+    actor_model = AutoModelForCausalLMWithValueHead.from_pretrained(base_model)
+    if not model_args.use_4bit:
+        actor_model = actor_model.cuda()
+        logger.info("Actor moved to GPU.")
+
+    # NLI Reward Model (on CPU — no separate GPU needed)
+    reward_model = NLIRewardModel(
+        model_name=model_args.nli_model,
+        device=model_args.nli_device,
+        cache_dir=model_args.cache_dir,
+    )
+
+    dataset = build_ppo_dataset(
+        data_path=data_args.data_path,
+        tokenizer=tokenizer,
+        max_questions=data_args.max_questions,
+    )
+
+    def collator(data):
+        return {key: [d[key] for d in data] for key in data[0]}
+
+    ppo_trainer = PPOTrainer(
+        config=ppo_config, model=actor_model, ref_model=None,
+        tokenizer=tokenizer, dataset=dataset, data_collator=collator,
+    )
+
+    gen_kwargs = {
+        "max_new_tokens": 300, "do_sample": True, "temperature": 0.7,
+        "top_p": 0.95, "top_k": 50, "repetition_penalty": 1.1,
+        "pad_token_id": tokenizer.eos_token_id,
+    }
+
+    logger.info("Starting PPO-NLI training (LLaMA-2)...")
+
+    for epoch, batch in enumerate(ppo_trainer.dataloader):
+        query_tensors = [torch.tensor(ids, dtype=torch.long) for ids in batch["input_ids"]]
+        correct_options = batch["correct_option"]
+
+        response_tensors = ppo_trainer.generate(
+            query_tensors, return_prompt=False, **gen_kwargs
+        )
+        batch["response"] = [
+            tokenizer.decode(r, skip_special_tokens=True) for r in response_tensors
+        ]
+
+        rewards = reward_model.get_rewards(
+            correct_options=correct_options,
+            explanations=batch["response"],
+        )
+
+        stats = ppo_trainer.step(query_tensors, response_tensors, rewards)
+        ppo_trainer.log_stats(stats, batch, rewards)
+
+        if epoch % 50 == 0:
+            mean_reward = sum(r.item() for r in rewards) / len(rewards)
+            logger.info(
+                f"Step {epoch} | Mean NLI reward: {mean_reward:.4f} | "
+                f"KL: {stats.get('objective/kl', 0):.4f}"
+            )
+
+    os.makedirs(model_args.output_dir, exist_ok=True)
+    ppo_trainer.save_pretrained(model_args.output_dir)
+    tokenizer.save_pretrained(model_args.output_dir)
+    logger.info(f"PPO-NLI adapter saved to {model_args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_ppo_nli.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_ppo_nli.py
@@ -56,6 +56,7 @@ ALPACA_PROMPT = (
 
 # ── Dataclasses ──────────────────────────────────────────────────────────────
 
+
 @dataclass
 class ModelArguments:
     model_name_or_path: str = field(default="/data/shared/llama2/llama-2-13b-hf")
@@ -84,12 +85,11 @@ class LoraArguments:
     lora_r: int = field(default=16)
     lora_alpha: int = field(default=32)
     lora_dropout: float = field(default=0.05)
-    lora_target_modules: str = field(
-        default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
-    )
+    lora_target_modules: str = field(default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj")
 
 
 # ── Helper functions ──────────────────────────────────────────────────────────
+
 
 def extract_correct_option_text(input_text: str) -> Tuple[Optional[str], Optional[str]]:
     """Extract the correct answer option text from training data input field."""
@@ -104,6 +104,7 @@ def extract_correct_option_text(input_text: str) -> Tuple[Optional[str], Optiona
 
 # ── NLI Reward Model ──────────────────────────────────────────────────────────
 
+
 class NLIRewardModel:
     """
     Uses DeBERTa NLI entailment probability as the PPO reward signal.
@@ -114,36 +115,33 @@ class NLIRewardModel:
     discriminative metric observed in our experiments.
     """
 
-    def __init__(self, model_name: str = "cross-encoder/nli-deberta-v3-small",
-                 device: str = "cpu", cache_dir: str = "cache"):
+    def __init__(
+        self, model_name: str = "cross-encoder/nli-deberta-v3-small", device: str = "cpu", cache_dir: str = "cache"
+    ):
         logger.info(f"Loading NLI reward model: {model_name} on {device} ...")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, cache_dir=cache_dir, use_fast=False
-        )
-        self.model = AutoModelForSequenceClassification.from_pretrained(
-            model_name, cache_dir=cache_dir
-        ).to(device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir, use_fast=False)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_name, cache_dir=cache_dir).to(device)
         self.model.eval()
         self.device = device
 
         id2label = self.model.config.id2label
-        self.entailment_idx = next(
-            k for k, v in id2label.items() if v.lower() == "entailment"
-        )
+        self.entailment_idx = next(k for k, v in id2label.items() if v.lower() == "entailment")
         logger.info(f"NLI reward loaded. entailment_idx={self.entailment_idx}")
 
     @torch.no_grad()
-    def get_rewards(
-        self, correct_options: List[str], explanations: List[str]
-    ) -> List[torch.Tensor]:
+    def get_rewards(self, correct_options: List[str], explanations: List[str]) -> List[torch.Tensor]:
         """
         Score batch: P(explanation entails correct_option) for each pair.
         Returns list of scalar float tensors in [0, 1].
         """
         # Skip pairs where correct option could not be extracted
         enc = self.tokenizer(
-            explanations, correct_options,
-            padding=True, truncation=True, max_length=512, return_tensors="pt",
+            explanations,
+            correct_options,
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="pt",
         )
         enc = {k: v.to(self.device) for k, v in enc.items()}
         logits = self.model(**enc).logits
@@ -154,9 +152,8 @@ class NLIRewardModel:
 
 # ── Dataset ───────────────────────────────────────────────────────────────────
 
-def build_ppo_dataset(
-    data_path: str, tokenizer, max_questions: Optional[int] = None
-) -> Dataset:
+
+def build_ppo_dataset(data_path: str, tokenizer, max_questions: Optional[int] = None) -> Dataset:
     with open(data_path, "r", encoding="utf-8") as f:
         raw_data = json.load(f)
     if max_questions:
@@ -177,25 +174,24 @@ def build_ppo_dataset(
 
         prompt = ALPACA_PROMPT.format(instruction=instruction, input=input_text)
         tokenized = tokenizer(prompt, truncation=True, max_length=512)
-        examples.append({
-            "input_ids": tokenized["input_ids"],
-            "query": prompt,
-            "question_input": input_text,
-            "correct_option": correct_opt,
-        })
+        examples.append(
+            {
+                "input_ids": tokenized["input_ids"],
+                "query": prompt,
+                "question_input": input_text,
+                "correct_option": correct_opt,
+            }
+        )
 
-    logger.info(
-        f"PPO dataset: {len(examples)} questions loaded ({skipped} skipped, no option text)"
-    )
+    logger.info(f"PPO dataset: {len(examples)} questions loaded ({skipped} skipped, no option text)")
     return Dataset.from_list(examples)
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+
 def main():
-    parser = transformers.HfArgumentParser(
-        (ModelArguments, DataArguments, LoraArguments, PPOConfig)
-    )
+    parser = transformers.HfArgumentParser((ModelArguments, DataArguments, LoraArguments, PPOConfig))
     model_args, data_args, lora_args, ppo_config = parser.parse_args_into_dataclasses()
     ppo_config.remove_unused_columns = False
 
@@ -213,24 +209,32 @@ def main():
     bnb_config = None
     if model_args.use_4bit:
         bnb_config = BitsAndBytesConfig(
-            load_in_4bit=True, bnb_4bit_quant_type="nf4",
-            bnb_4bit_compute_dtype=torch.bfloat16, bnb_4bit_use_double_quant=True,
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_use_double_quant=True,
         )
 
     attn_impl = "flash_attention_2" if model_args.use_flash_attention else "eager"
     try:
         base_model = AutoModelForCausalLM.from_pretrained(
-            model_args.model_name_or_path, cache_dir=model_args.cache_dir,
-            quantization_config=bnb_config, torch_dtype=torch.bfloat16,
+            model_args.model_name_or_path,
+            cache_dir=model_args.cache_dir,
+            quantization_config=bnb_config,
+            torch_dtype=torch.bfloat16,
             device_map="auto" if bnb_config else None,
-            trust_remote_code=True, attn_implementation=attn_impl,
+            trust_remote_code=True,
+            attn_implementation=attn_impl,
         )
     except Exception:
         logger.warning("flash_attention_2 unavailable, falling back to eager.")
         base_model = AutoModelForCausalLM.from_pretrained(
-            model_args.model_name_or_path, cache_dir=model_args.cache_dir,
-            quantization_config=bnb_config, torch_dtype=torch.bfloat16,
-            device_map="auto" if bnb_config else None, trust_remote_code=True,
+            model_args.model_name_or_path,
+            cache_dir=model_args.cache_dir,
+            quantization_config=bnb_config,
+            torch_dtype=torch.bfloat16,
+            device_map="auto" if bnb_config else None,
+            trust_remote_code=True,
         )
 
     if model_args.sft_adapter_path and os.path.isdir(model_args.sft_adapter_path):
@@ -241,9 +245,12 @@ def main():
 
     target_modules = [m.strip() for m in lora_args.lora_target_modules.split(",")]
     lora_config = LoraConfig(
-        r=lora_args.lora_r, lora_alpha=lora_args.lora_alpha,
-        lora_dropout=lora_args.lora_dropout, target_modules=target_modules,
-        bias="none", task_type=TaskType.CAUSAL_LM,
+        r=lora_args.lora_r,
+        lora_alpha=lora_args.lora_alpha,
+        lora_dropout=lora_args.lora_dropout,
+        target_modules=target_modules,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM,
     )
     base_model = get_peft_model(base_model, lora_config)
     base_model.print_trainable_parameters()
@@ -270,13 +277,21 @@ def main():
         return {key: [d[key] for d in data] for key in data[0]}
 
     ppo_trainer = PPOTrainer(
-        config=ppo_config, model=actor_model, ref_model=None,
-        tokenizer=tokenizer, dataset=dataset, data_collator=collator,
+        config=ppo_config,
+        model=actor_model,
+        ref_model=None,
+        tokenizer=tokenizer,
+        dataset=dataset,
+        data_collator=collator,
     )
 
     gen_kwargs = {
-        "max_new_tokens": 300, "do_sample": True, "temperature": 0.7,
-        "top_p": 0.95, "top_k": 50, "repetition_penalty": 1.1,
+        "max_new_tokens": 300,
+        "do_sample": True,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 50,
+        "repetition_penalty": 1.1,
         "pad_token_id": tokenizer.eos_token_id,
     }
 
@@ -286,12 +301,8 @@ def main():
         query_tensors = [torch.tensor(ids, dtype=torch.long) for ids in batch["input_ids"]]
         correct_options = batch["correct_option"]
 
-        response_tensors = ppo_trainer.generate(
-            query_tensors, return_prompt=False, **gen_kwargs
-        )
-        batch["response"] = [
-            tokenizer.decode(r, skip_special_tokens=True) for r in response_tensors
-        ]
+        response_tensors = ppo_trainer.generate(query_tensors, return_prompt=False, **gen_kwargs)
+        batch["response"] = [tokenizer.decode(r, skip_special_tokens=True) for r in response_tensors]
 
         rewards = reward_model.get_rewards(
             correct_options=correct_options,
@@ -304,8 +315,7 @@ def main():
         if epoch % 50 == 0:
             mean_reward = sum(r.item() for r in rewards) / len(rewards)
             logger.info(
-                f"Step {epoch} | Mean NLI reward: {mean_reward:.4f} | "
-                f"KL: {stats.get('objective/kl', 0):.4f}"
+                f"Step {epoch} | Mean NLI reward: {mean_reward:.4f} | " f"KL: {stats.get('objective/kl', 0):.4f}"
             )
 
     os.makedirs(model_args.output_dir, exist_ok=True)

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_sft.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_sft.py
@@ -1,0 +1,185 @@
+"""
+RLearner-LLM Step 1: SFT Fine-tuning with LoRA
+TRL 0.7.1 + Transformers 4.31.0 compatible (llm-tuning conda env)
+
+Fine-tunes LLaMA-2-13B on PeerWise explanation data using LoRA (PEFT).
+Uses standard Alpaca prompt format consistent with the legacy ILearner pipeline.
+
+Usage (4x A100 80GB, GPUs 4-7):
+    CUDA_VISIBLE_DEVICES=4,5,6,7 torchrun --nproc_per_node=4 --master_port 29500 \\
+        rl_train_sft.py \\
+        --model_name_or_path /data/shared/llama2/llama-2-13b-hf \\
+        --data_path ./Paul_new_data/Merged_Sydney_Cardiff_Law_Medical_Y1_Y2/generator_merged_avg_3_lenexp_10.json \\
+        --output_dir ./rl_sft_llama2_13b_generator \\
+        --num_train_epochs 3 \\
+        --per_device_train_batch_size 1 \\
+        --gradient_accumulation_steps 8 \\
+        --bf16 True \\
+        --gradient_checkpointing True \\
+        --report_to none
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+import transformers
+from datasets import Dataset
+from peft import LoraConfig, TaskType, get_peft_model
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
+from trl import SFTTrainer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Alpaca-style prompt template — must match rl_build_preference_data.py
+ALPACA_TEMPLATE = (
+    "Below is an instruction that describes a task, paired with an input that "
+    "provides further context. Write a response that appropriately completes the request.\n\n"
+    "### Instruction:\n{instruction}\n\n"
+    "### Input:\n{input}\n\n"
+    "### Response:\n{output}"
+)
+
+
+@dataclass
+class ModelArguments:
+    model_name_or_path: str = field(
+        default="/data/shared/llama2/llama-2-13b-hf",
+        metadata={"help": "Local path or HuggingFace model ID. Default: LLaMA-2-13B-HF."},
+    )
+    cache_dir: Optional[str] = field(default="cache")
+
+
+@dataclass
+class DataArguments:
+    data_path: str = field(
+        default="./Paul_new_data/Merged_Sydney_Cardiff_Law_Medical_Y1_Y2/generator_merged_avg_3_lenexp_10.json",
+        metadata={"help": "Training data JSON with fields: instruction, input, output."},
+    )
+    eval_data_path: Optional[str] = field(default=None)
+    max_seq_length: int = field(default=1024)
+
+
+@dataclass
+class LoraArguments:
+    lora_r: int = field(default=16)
+    lora_alpha: int = field(default=32)
+    lora_dropout: float = field(default=0.05)
+    lora_target_modules: str = field(
+        default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj",
+        metadata={"help": "Comma-separated LoRA target modules. Works for LLaMA-2/Qwen3."},
+    )
+
+
+def load_peerwise_data(data_path: str) -> Dataset:
+    """Load PeerWise JSON and convert to Alpaca text format for SFTTrainer."""
+    with open(data_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+
+    examples = []
+    skipped = 0
+    for item in raw_data:
+        instruction = item.get("instruction", "").replace("</s>", "").strip()
+        input_text = item.get("input", "").replace("</s>", "").strip()
+        output_text = item.get("output", "").replace("</s>", "").strip()
+
+        if not input_text or not output_text:
+            skipped += 1
+            continue
+
+        text = ALPACA_TEMPLATE.format(
+            instruction=instruction,
+            input=input_text,
+            output=output_text,
+        )
+        examples.append({"text": text})
+
+    logger.info(f"Loaded {len(examples)} training examples from {data_path} (skipped {skipped} empty).")
+    return Dataset.from_list(examples)
+
+
+def main():
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, LoraArguments, TrainingArguments)
+    )
+    model_args, data_args, lora_args, training_args = parser.parse_args_into_dataclasses()
+
+    # ── Tokenizer ──────────────────────────────────────────────────────────────
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        padding_side="right",
+        trust_remote_code=True,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+        logger.info("pad_token set to eos_token.")
+
+    # ── Model ──────────────────────────────────────────────────────────────────
+    model = AutoModelForCausalLM.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        torch_dtype=torch.bfloat16,
+        trust_remote_code=True,
+    )
+    model.config.use_cache = False  # Required when gradient_checkpointing=True
+
+    # ── LoRA ───────────────────────────────────────────────────────────────────
+    target_modules = [m.strip() for m in lora_args.lora_target_modules.split(",")]
+    lora_config = LoraConfig(
+        r=lora_args.lora_r,
+        lora_alpha=lora_args.lora_alpha,
+        lora_dropout=lora_args.lora_dropout,
+        target_modules=target_modules,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM,
+    )
+    # Apply LoRA manually so we can call enable_input_require_grads().
+    # When gradient_checkpointing=True, PyTorch requires at least one input to
+    # have requires_grad=True at each checkpointed module boundary. LoRA freezes
+    # the base weights, so we register a forward hook on the input embeddings to
+    # propagate gradients through the checkpointed regions.
+    model = get_peft_model(model, lora_config)
+    model.enable_input_require_grads()
+    model.print_trainable_parameters()
+
+    # ── Dataset ────────────────────────────────────────────────────────────────
+    train_dataset = load_peerwise_data(data_args.data_path)
+    eval_dataset = None
+    if data_args.eval_data_path:
+        eval_dataset = load_peerwise_data(data_args.eval_data_path)
+
+    # ── SFT Training (TRL 0.7.1 API) ──────────────────────────────────────────
+    # peft_config is omitted — LoRA is already applied above.
+    # TRL 0.7.1: SFTTrainer takes dataset_text_field and max_seq_length directly.
+    trainer = SFTTrainer(
+        model=model,
+        tokenizer=tokenizer,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        dataset_text_field="text",
+        max_seq_length=data_args.max_seq_length,
+    )
+
+    logger.info("Starting SFT training...")
+    logger.info(f"  Model: {model_args.model_name_or_path}")
+    logger.info(f"  Training examples: {len(train_dataset)}")
+    logger.info(f"  Epochs: {training_args.num_train_epochs}")
+    logger.info(f"  Per-device batch size: {training_args.per_device_train_batch_size}")
+    logger.info(f"  Gradient accumulation: {training_args.gradient_accumulation_steps}")
+
+    trainer.train()
+    trainer.save_model(training_args.output_dir)
+    tokenizer.save_pretrained(training_args.output_dir)
+    logger.info(f"LoRA adapter saved to {training_args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_sft.py
+++ b/contrib/14H034160212-logically-grounded-dpo/logically-grounded-dpo/rl_train_sft.py
@@ -105,9 +105,7 @@ def load_peerwise_data(data_path: str) -> Dataset:
 
 
 def main():
-    parser = transformers.HfArgumentParser(
-        (ModelArguments, DataArguments, LoraArguments, TrainingArguments)
-    )
+    parser = transformers.HfArgumentParser((ModelArguments, DataArguments, LoraArguments, TrainingArguments))
     model_args, data_args, lora_args, training_args = parser.parse_args_into_dataclasses()
 
     # ── Tokenizer ──────────────────────────────────────────────────────────────

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -8,6 +8,7 @@ Think of `contrib/` as the front porch. Promising contributions may later be pro
 
 | Contribution | Contributor(s) | Status | What it is |
 | :----------- | :------------- | :----- | :--------- |
+| [`14H034160212-logically-grounded-dpo`](14H034160212-logically-grounded-dpo/README.md) | 14H034160212 | Candidate | Verifier-based DPO/PPO preference pipeline replacing reference-text similarity with an NLI-entailment reward for checkable explanations |
 | [`jneums-consortium-experiment`](jneums-consortium-experiment/README.md) | jneums | Speculative | Deterministic measurement layer around the consortium-training proof of concept |
 | [`jneums-cultural-cpt-validation`](jneums-cultural-cpt-validation/README.md) | jneums | Speculative | Runnable harness for EXP-001: does culturally grounded continued pretraining shift alignment beyond language exposure? |
 | [`jneums-flower-wan-spike`](jneums-flower-wan-spike/README.md) | jneums | Speculative | De-risk spike for #70: 2B-parameter weight round-trip through a Flower SuperLink over a real WAN |


### PR DESCRIPTION
## New Contribution Check List

- [x] I created a subdirectory named with the format `contrib/<my_github_user_name>-<feature_name>`: `contrib/14H034160212-logically-grounded-dpo/`.
- [x] I included a short `README.md` that describes the contribution, its motivation and status, and how to try/evaluate it.
- [x] I added a `LICENSE`. Follows the repo defaults: Apache-2.0 for code, CC-BY-4.0 for docs.
- [x] Code is in a `logically-grounded-dpo` subdirectory. (No `tests` subdirectory: this is an excerpted reference implementation from a published, evaluated pipeline — see below.) **No data is included** — see the README's "Data clearance" section.

## Description of Contribution

This is a documentation + reference-code contribution (status: **Validated / published**, not speculative) of a post-training technique relevant to any consortium base model expected to produce explanations or reasoning traces.

**Problem:** a model can be fluent and still fail to justify the correct answer — surface-similarity metrics (BLEU, BERTScore vs. a reference explanation) don't measure whether a generated explanation actually *logically entails* the answer it's justifying. We built and evaluated a fix for this in the educational-explanation domain, but the technique (automated verifier-based preference-pair construction + an NLI-grounded reward) is domain-agnostic.

**What's contributed:** an SFT → verifier-based preference-pair construction → DPO/PPO pipeline that replaces reference-text similarity with a reward tied to NLI entailment against the correct answer. In our experiments this metric is the most discriminative signal: the SFT baseline scores ~0.05 while RL-trained models score 0.22–0.30 (4–5x gap).

Paper: https://arxiv.org/abs/2605.04539 — "RLearner-LLM: Balancing Logical Grounding and Fluency in Large Language Models via Hybrid Direct Preference Optimization" (Bao, Leinonen, Denny, Witbrock)
Full code: https://github.com/14H034160212/Explanation-Generation

**Relevance to Tapestry:** the verifier-based preference construction and NLI-grounded reward are reusable as a general post-training technique for any Tapestry-derived model expected to produce checkable explanations or reasoning traces, not just fluent ones.

## Related Issues

None yet — happy to link this against a relevant training/evaluation issue if a maintainer points me to one.

## If Code Is Included

### Code Description

- `rl_train_sft.py` — LoRA SFT baseline (stage 1).
- `rl_build_preference_data.py` — builds DPO preference pairs by sampling N candidates per question and scoring them with a domain-trained verifier, instead of relying on human annotation or a fixed external teacher.
- `rl_generate_synthetic_data.py` — augments preference pairs with GPT-4o/Claude CoT synthetic positives and model-generated hard negatives (counters reward hacking).
- `rl_train_dpo.py` — offline DPO training over the constructed pairs.
- `rl_train_ppo_nli.py` — online PPO alternative using a live NLI-entailment reward.
- `rl_evaluation.py` — the three-tier answer-grounded evaluation suite (BERTScore-vs-answer, Answer Coverage Rate, NLI entailment).
- LoRA fine-tuning / RL training (PEFT + `transformers` `Trainer`, TRL for DPO/PPO) across LLaMA-2-13B, LLaMA-3-8B, Qwen3-8B, and Gemma-3-4B backbones.

### Testing Performed

These scripts are excerpted as-is from the published, evaluated pipeline (results above and in the paper). No additional tests were added for this excerpt; the full evaluation logs and results are in the linked repository. All six files were verified to `py_compile` cleanly, and checked for hardcoded local paths/secrets before inclusion — none found.

### Example Usage

See each script's module docstring / `--help` for the expected input schema and CLI usage (e.g. `python rl_build_preference_data.py --input_path <peerwise.json> --output_path ./rl_preference_data/preference_pairs.json ...`). Data must be supplied by the user from their own cleared source — see "Data clearance" in the README.