### PR TITLE
fix(contrib): enable pytest for nguyennm1024-sociocultural-alignment

### DIFF
--- a/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
+++ b/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
@@ -1,34 +1,4 @@
-# TODO: While the process for running the unit tests works locally, it fails
-# in the PR process. See issue #146 (https://github.com/The-AI-Alliance/tapestry/issues/146)
-# for details.
-
-# unit-tests-prerequisite::
-# 	@cd ${SRC_DIR}; \
-# 	echo "${INFO_LABEL}Building $@ in $$(pwd)."; \
-# 	if [ -d .venv ]; \
-# 	then echo "${WARNING_LABEL}'.venv' already exists; not running 'uv venv'."; \
-# 	else \
-# 		uv venv; \
-# 		echo "${INFO_LABEL}running: uv pip install --requirements requirements.txt"; \
-# 		uv pip install --requirements requirements.txt; \
-# 	fi
-
-# Override the default, even though we run similar commands as are used in
-# ../../Makefile, because the unit-tests-default defined there runs in the
-# project root directory, whereas we have to run the test commands in this
-# directory, because a separate environment is setup here.
-# unit-tests-default:
-# 	@cd ${SRC_DIR}; \
-# 	echo "${INFO_LABEL}Building $@ in $$(pwd)."; \
-# 	echo "${INFO_LABEL}running: which source"; \
-# 	which source; \
-# 	echo "${INFO_LABEL}running: source $$(pwd)/.venv/bin/activate"; \
-# 	source $$(pwd)/.venv/bin/activate; \
-# 	echo "${INFO_LABEL}running: ${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}"; \
-# 	${PYTEST_RUN_CMD} && ${PYTEST_COV_REPORT_CMD}
-
-# This definition effectively skips the, "ruff", "pylint", "type-check",
-# and "unit-tests" targets defined in the top-level Makefile.
-ruff-default pylint-default type-check-default unit-tests-default:
+# Skip linters - this contrib's code style differs from top-level
+ruff-default pylint-default type-check-default:
 	@echo "${skip-contrib-target}"
 	@true

--- a/contrib/nguyennm1024-sociocultural-alignment/pyproject.toml
+++ b/contrib/nguyennm1024-sociocultural-alignment/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nguyennm1024-sociocultural-alignment"
+version = "0.1.0"
+description = "An experiment with cultural alignment tuning."
+license = { text = "Apache-2.0" }
+requires-python = ">=3.12"
+dependencies = [
+    # --- data synthesis (data_synthesis/) ---
+    "openai>=1.100.0",
+    "python-dotenv>=1.0.0",
+    "datasets>=2.20.0",
+    "huggingface_hub>=0.24.0",
+    # --- training + evaluation (training/, evaluation/) ---
+    "numpy>=1.26.0",
+    "matplotlib>=3.8.0",
+]
+
+[project.optional-dependencies]
+# GPU deps - won't install on Mac, skip for CI tests
+gpu = [
+    "torch>=2.4.0",
+    "transformers>=4.44.0",
+    "peft>=0.12.0",
+    "accelerate>=0.33.0",
+    "vllm>=0.6.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["consortium", "evaluation", "training"]

--- a/contrib/nguyennm1024-sociocultural-alignment/tests/test_consortium.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/tests/test_consortium.py
@@ -26,7 +26,8 @@ def test_consortium_method_is_abstract():
 def test_soup_is_a_consortium_method():
     import pytest
 
-    pytest.importorskip("torch")  # the soup implementation pulls torch/transformers
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
     from consortium import ConsortiumMethod
     from consortium.soup import Soup
 


### PR DESCRIPTION
## Summary

Fixes #146 — pytest now runs in CI for `contrib/nguyennm1024-sociocultural-alignment`.

**Root cause**: The contrib used `requirements.txt` + manual venv activation, which failed on Linux CI due to shell incompatibility (`source` is bash-only, CI uses `/bin/sh`).

**Fix**: Add `pyproject.toml` so `uv run` handles the environment automatically. GPU-bound deps (torch, vllm, transformers, etc.) moved to optional `[gpu]` extra — tests don't need them (uses `pytest.importorskip`).

## Changes

- Add `pyproject.toml` with standard uv/hatch config
- Remove `unit-tests-default` from `.custom.mk` skip list
- GPU deps now optional; base deps sufficient for tests

## Test results

```
4 passed, 1 skipped in 0.17s (torch test skipped, expected)
68% coverage
```

## Notes

- `requirements.txt` retained for users who need full training deps (`pip install -r requirements.txt`)
- Follows same pattern as `jneums-flower-wan-spike` contrib
