### PR TITLE
Clarify placement vs sovereignty; ask for plain English on issues/PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,17 @@ Keep new code aligned with that split. Add tests under the matching `src/tests/t
 - For new inline Mermaid in architecture/reference docs, follow the conventions in `docs/architecture/diagrams/README.md` § Inline Mermaid style (TAP-009 for decision/sovereignty flows; `0-tva-methodology.md` for phased process/status diagrams).
 - Treat governance documents as load-bearing design constraints, not after-the-fact policy notes.
 
+## Plain English (PRs and issues)
+
+Write so a busy reviewer or contributor can understand the point without decoding jargon. Technical precision belongs *after* a clear opening, not instead of one.
+
+- Prefer short sentences and common words when they still say the same thing (“who controls the data” over “control-plane sovereignty boundary”).
+- Define project terms on first use, or link the glossary / ADR — do not assume every reader has the full corpus memorized.
+- Avoid stacking abstractions, acronyms, and file paths in the first screen of text.
+- Comments on issues and PRs should answer in plain language first; optional detail or links can follow.
+
+This applies especially to **issue bodies**, **issue comments**, **PR titles**, and **PR description openings**.
+
 ## Pull request descriptions
 
 Write PR titles and bodies for human skimming first. Detail is welcome later; the opening must stand alone in plain English.
@@ -85,7 +96,7 @@ Write PR titles and bodies for human skimming first. Detail is welcome later; th
 1. **Why** — the problem or gap this PR addresses.
 2. **What** — the proposed approach and what reviewers, users, or the project get when it lands (the result, not the mechanism).
 
-A reviewer who reads only the title and these two beats should understand the forest.
+A reviewer who reads only the title and these two beats should understand the forest. If those two beats need a glossary to parse, rewrite them.
 
 **How (details after).** Implementation notes, files touched, edge cases, test evidence, and checklist items come next. Density is fine here.
 
@@ -94,6 +105,21 @@ A reviewer who reads only the title and these two beats should understand the fo
 - Prefer project language over repo archaeology in the opening (“propose a gate-then-score selection method” rather than “updated `classDef` in README”).
 
 Keep using the repo PR templates under `.github/PULL_REQUEST_TEMPLATE/` for checklists and contribution process; lead their description sections with Why → What as above.
+
+## Issue titles and bodies
+
+Same skimming bar as PRs: a reader should know the ask from the title plus the first short paragraph.
+
+**Title.** Name the outcome or question, not the internal ticket shape (e.g. `Pick base model for the #70 two-node experiment`, not `Task/Feature/Issue follow-up`).
+
+**Body opening.** In plain English, state:
+
+1. **Why this exists** — the gap, risk, or decision needed.
+2. **What success looks like** — a concrete done condition, decision, or artifact.
+
+Then add background, acceptance criteria, links to ADRs/issues, and checklists. Template fields under `.github/ISSUE_TEMPLATE/` still apply; fill them in readable prose, not telegram-style jargon.
+
+**Comments.** Prefer a clear recommendation or question in the first sentences. Long analysis is welcome after that. When comparing options, say what each option *does for the project* before naming tools or stacks.
 
 ## Practical Notes
 

--- a/docs/architecture/decisions/adr-002-consortium-training.md
+++ b/docs/architecture/decisions/adr-002-consortium-training.md
@@ -5,7 +5,7 @@
 | Status | Proposed |
 | Confidence | High (5/5) |
 | Date | May 7, 2026 |
-| Revised | Jun 19, 2026 — terminology aligned (Shared Base, Contributed CPT); added N+1 two-phase diagram; consolidated as the canonical definition. |
+| Revised | Jun 19, 2026 — terminology aligned (Shared Base, Contributed CPT); added N+1 two-phase diagram; consolidated as the canonical definition. Jul 15, 2026 — clarified that nodes may share a building or fabric; what matters is who controls the data, not where the machines sit. |
 | Deciders | Christopher Nguyen (proposed), workshop participants (to ratify) |
 
 ## Context
@@ -46,7 +46,7 @@ This is distinct from federated learning (designed for millions of small edge cl
 | **Data per node** | All data centralized | Small (one user's or site's data) | Massive (national/institutional corpora) |
 | **Sovereignty motive** | N/A — one owner | Individual / site-level data protection | National/institutional sovereignty + cultural alignment |
 | **What crosses the network** | N/A — internal interconnect | FedSGD: per-step gradients; FedAvg: local model weight vectors after local training | Local model weight vectors after Contributed CPT |
-| **Communication cadence** | Every step; fast interconnect | Varies by method and deployment | Operational choice — frequent (cluster-like) or infrequent (geo-distributed) |
+| **Communication cadence** | Every step; fast interconnect | Varies by method and deployment | Operational choice — frequent (cluster-like) or infrequent (geo-distributed); where the machines sit is not what defines sovereignty (see Rationale) |
 | **Model scale** | Frontier | Typically small to medium | Frontier |
 | **Governance** | Single owner decides all | Aggregator-driven; clients have no architectural voice | Consortium with shared ownership and governance rights |
 | **Each node's outcome** | N/A — one model | Same global model (or personalized variant in PFL) | Sovereign Model: Shared Base + community-specific Sovereign Build |
@@ -58,6 +58,7 @@ Consortium training borrows techniques from the federated learning literature �
 - Tapestry's members are few (dozens) and are **collaborating institutions with governance voice** — not millions of mutually untrusted edge clients. Each member operates large nodes (national GPU clusters). See [Design principles for architecture work](../0-tva-methodology.md#design-principles-for-architecture-work).
 - The sovereignty motive is national/institutional, not individual data protection. The governance model, trust assumptions, and communication patterns all differ.
 - Using "federated" to describe Tapestry borrows the right principle (data stays put) but the wrong connotations (edge devices, FedAvg, cross-silo averaging). "Consortium training" accurately describes the participants, the purpose, and the governance.
+- **Placement is not sovereignty.** "Cluster-like" is about sync speed and network, not ownership. Members may share a building or datacenter and still do consortium training if each keeps control of its own data, only approved weight updates leave that boundary, and the consortium decides membership and weighting. What we reject is one owner holding all the data and the controls — not members sharing a room or a network. Examples are in [`training-approaches.md`](../../reference/training-approaches.md#placement-is-not-sovereignty).
 
 ## Confidence assessment
 
@@ -74,6 +75,7 @@ This is a framing and communication decision as much as a technical one. The ter
 - Requires updating all documentation and communications from "federated" to "consortium" when referring to Tapestry's own approach. (Largely complete as of May 2026.)
 - The term "consortium training" is novel — it doesn't have an established literature. This is a feature (we define what it means) and a risk (no prior art to reference). FedAvg is the closest technical precedent for the default aggregation mechanism; DiLoCo is an optional outer-optimizer variant.
 - References to federated learning techniques (FedAvg, DiLoCo, etc.) remain valid as technical building blocks. The distinction is between the paradigm (consortium) and the techniques it may use.
+- Early experiments may put nodes close together (same cluster or site) without weakening sovereignty rules. Training across distant sites remains important longer term, but it is not required for consortium training to be valid.
 
 ## References
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -14,7 +14,7 @@ Two roles recur throughout: a **Member** is the participating organization (gove
 
 ## A–Z
 
-**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous members collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.* The umbrella over Shared-Base Loop and Sovereign Build.
+**Consortium training** — The paradigm Tapestry uses: a small number of large, trusted, heterogeneous members collaboratively training a shared model, where data sovereignty is a first-order architectural constraint and cultural alignment is the goal. Nodes may be nearby or far apart; what matters is that each member controls its data and that the consortium shares governance — not that the machines sit in different countries. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) for the full definition and the comparison with centralized and federated training.* The umbrella over Shared-Base Loop and Sovereign Build.
 
 **Contributed CPT** — Continued pre-training performed *inside* the Shared-Base Loop; its post-training weights are contributed back to the Shared Base. *Contrast* Private CPT. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
@@ -26,7 +26,7 @@ Two roles recur throughout: a **Member** is the participating organization (gove
 
 **N+1** — Tapestry's model-outcome structure: one Shared Base (the shared substrate) plus N Sovereign Models (one per member). *See [TAP-005](../architecture/decisions/adr-005-sovereign-pipeline.md).*
 
-**Node** — The compute environment a member operates: where sovereign data physically resides, where Contributed CPT and the Sovereign Build run, and what disconnects in island mode. A member may operate one or more nodes. Compound usages like *sovereign node* (a node operated by a member, with sovereignty guarantees) and *member node* (a member's node) follow from this distinction. *Contrast* Member. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) and [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
+**Node** — The compute environment a member operates: where that member's data lives under its control, where Contributed CPT and the Sovereign Build run, and what disconnects in island mode. A member may operate one or more nodes. Nodes can be far apart or in the same building; sovereignty is about who controls the data, not which building the machines are in. Compound usages like *sovereign node* (a node operated by a member, with sovereignty guarantees) and *member node* (a member's node) follow from this distinction. *Contrast* Member. *See [TAP-002](../architecture/decisions/adr-002-consortium-training.md) and [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 
 **Private CPT** — Continued pre-training performed *inside* a Sovereign Build; stays local and is never contributed. This is how a member adds culturally-grounded knowledge that does not flow back to the consortium. *Contrast* Contributed CPT. *See [TAP-004](../architecture/decisions/adr-004-training-loop.md).*
 

--- a/docs/reference/training-approaches.md
+++ b/docs/reference/training-approaches.md
@@ -20,7 +20,7 @@ Three distinct approaches to training large models are relevant to Tapestry's de
 | **Governance** | Single owner | Aggregator plus clients | Consortium with shared voice and rules |
 | **Model scale (typical)** | Frontier | Often modest | Frontier-class shared model |
 | **Primary goal** | Maximum capability | Learn without centralizing raw data | Frontier capability **and** culturally aligned outcomes |
-| **Tapestry** | Incompatible (colocation, capture) | Wrong fit (scale, motive, governance) | **This is Tapestry’s paradigm** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) |
+| **Tapestry** | Incompatible (one owner holds all the data and control) | Wrong fit (scale, motive, governance) | **This is Tapestry’s paradigm** ([TAP-002](../architecture/decisions/adr-002-consortium-training.md)) |
 
 The sections below spell out each column in prose. Consortium training runs in two phases — the **Shared-Base Loop** and the **Sovereign Build** — specified in [TAP-004](../architecture/decisions/adr-004-training-loop.md).
 
@@ -104,6 +104,12 @@ flowchart LR
 | **Node autonomy** | Nodes are step-locked to the aggregator | Nodes train independently between syncs |
 
 **Sync cadence is not fixed by the architecture.** Deployments may sync frequently (cluster-like, high-bandwidth interconnect) or less often (geo-distributed nodes over WAN). What defines consortium training is *who* participates, *what* crosses the wire (weight vectors after Contributed CPT), and *how* governance works — not a particular sync interval.
+
+### Placement is not sovereignty
+
+"Cluster-like" means how often nodes sync and how fast the network is — not who owns the data. Members can put nodes in the same building or datacenter and still do consortium training, as long as each member keeps control of its own data, only approved weight updates leave that boundary, and the consortium — not a single operator — decides who joins and how contributions are weighted. What Tapestry rejects is *one owner holding all the data and the controls*. Sharing a building is fine; handing everything to one organization is not.
+
+*Real-world examples (for illustration only — not Tapestry requirements):* Organizations already train together on a [shared cloud](https://docs.cloud.google.com/architecture/cross-silo-cross-device-federated-learning-google-cloud) while keeping separate accounts and datasets. [Data embassies](https://e-estonia.com/solutions/e-governance/data-embassy/) go further: Estonia keeps a sovereign section of a Luxembourg government datacenter; Bahrain lets foreign parties host under their own laws; [G42's Digital Embassies / Greenshield](https://www.mediaoffice.abudhabi/en/technology/g42-launches-digital-embassies-and-greenshield-enabling-remote-immediate-ai-deployment-with-full-sovereign-control/) partition shared AI infrastructure so each nation keeps legal and operational control. Same site or campus does not, by itself, mean one party owns the others' data.
 
 The coordinator may compute parameter deltas internally (`θ_local − θ_start`); that is an implementation detail, not the communicated artifact. Yann LeCun's correction: nodes communicate **weight vectors**, not per-step gradients and not deltas as the primary abstraction.
 


### PR DESCRIPTION
## Description of the PR

**Why.** "Cluster-like" sync and "colocation" were easy to read as opposites, so some readers thought consortium training required remote/WAN placement. Same-site / shared-fabric nodes were **always an allowed configuration** when each member keeps control of its data and the consortium governs membership and weighting — the docs just did not say that clearly enough.

**What.** This PR does not change the architecture. It makes the existing rule explicit: placement is not sovereignty. Updates land in the training reference and TAP-002 (with short real-world examples), the glossary, plus plain-English guidance for issues and PRs in `AGENTS.md`.

## How

```mermaid
flowchart LR
  Place["Where machines sit<br/>same building or WAN"]:::place
  Control["Who controls data<br/>and governance"]:::control
  Place -.->|"does not decide"| Outcome
  Control --> Outcome["Valid consortium training"]:::ok

  classDef place fill:#5c6b7a,stroke:#3d4a56,color:#fff
  classDef control fill:#1b4965,stroke:#62b6cb,color:#fff
  classDef ok fill:#2c7da0,stroke:#a9d6e5,color:#fff
```

**Rule (from the docs).** "Cluster-like" means sync speed and network, not ownership. Members can share a building or datacenter and still do consortium training if each keeps control of its own data, only approved weight updates leave that boundary, and the consortium — not a single operator — decides who joins and how contributions are weighted. What we reject is one owner holding all the data and the controls — not members sharing a room or a network.

**Illustrative examples (not Tapestry requirements):**
- Organizations already train together on a [shared cloud](https://docs.cloud.google.com/architecture/cross-silo-cross-device-federated-learning-google-cloud) while keeping separate accounts and datasets.
- [Data embassies](https://e-estonia.com/solutions/e-governance/data-embassy/): Estonia keeps a sovereign section of a Luxembourg government datacenter; Bahrain lets foreign parties host under their own laws.
- [G42 Digital Embassies / Greenshield](https://www.mediaoffice.abudhabi/en/technology/g42-launches-digital-embassies-and-greenshield-enabling-remote-immediate-ai-deployment-with-full-sovereign-control/) partition shared AI infrastructure so each nation keeps legal and operational control.

Same site or campus does not, by itself, mean one party owns the others' data.

**Files.**
- `docs/reference/training-approaches.md` — new **Placement is not sovereignty** section; clearer table wording.
- `docs/architecture/decisions/adr-002-consortium-training.md` — rationale + consequences; link to the reference section.
- `docs/reference/glossary.md` — Consortium training and Node definitions.
- `AGENTS.md` — plain-English section; issue title/body/comment guidance; stronger PR opening check.

## Related Issues

- Context for stack/placement discussions on #70 (docs clarification only; does not close the epic)

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For documentation changes, including `docs`:

- [x] I have followed the existing documentation styles and conventions.
- [x] I have included helpful diagrams, screenshots, tables, etc.