### PR TITLE
Re-enable `make format` for `contrib/nguyennm1024-sociocultural-alignment/`

### DIFF
--- a/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
+++ b/contrib/nguyennm1024-sociocultural-alignment/.custom.mk
@@ -1,4 +1,4 @@
 # Skip linters - this contrib's code style differs from top-level
-format-default ruff-default pylint-default type-check-default:
+ruff-default pylint-default type-check-default:
 	@echo "${skip-contrib-target}"
 	@true

--- a/contrib/nguyennm1024-sociocultural-alignment/consortium/__init__.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/consortium/__init__.py
@@ -3,6 +3,7 @@
 Model soup (``consortium.soup``) is the v1 method. See ``consortium.base`` for the
 ``ConsortiumMethod`` contract that future methods implement.
 """
+
 from .base import ConsortiumMethod, Member
 
 __all__ = ["ConsortiumMethod", "Member"]

--- a/contrib/nguyennm1024-sociocultural-alignment/consortium/base.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/consortium/base.py
@@ -10,6 +10,7 @@ output-ensembling, then MoE / routing) implement the same `ConsortiumMethod.comb
 contract, so the rest of the pipeline -- and the shared evaluation harness -- treats
 their output as just another model.
 """
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
@@ -17,8 +18,9 @@ from dataclasses import dataclass
 @dataclass
 class Member:
     """A trained member model entering the consortium."""
-    path: str            # local dir or HF id of the (merged) member model
-    name: str = ""       # short label, e.g. "culture" or "rehearsal"
+
+    path: str  # local dir or HF id of the (merged) member model
+    name: str = ""  # short label, e.g. "culture" or "rehearsal"
     weight: float = 1.0  # relative weight, for methods that use one
 
 

--- a/contrib/nguyennm1024-sociocultural-alignment/consortium/soup/__init__.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/consortium/soup/__init__.py
@@ -1,4 +1,5 @@
 """Model soup -- v1 consortium method (weight-space averaging)."""
+
 from ..base import ConsortiumMethod, Member
 from .model_soup import average_weights
 

--- a/contrib/nguyennm1024-sociocultural-alignment/consortium/soup/model_soup.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/consortium/soup/model_soup.py
@@ -8,6 +8,7 @@ CLI (backward-compatible 2-member form):
 Members must share architecture/keys (they are LoRA-merges of the same base).
 CPU is fine -- this is just weight averaging, no GPU needed.
 """
+
 import sys
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/__init__.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/__init__.py
@@ -3,6 +3,7 @@
 Used by sibling packages (cultural, rehearsal, ...) that wrap these primitives
 with domain-specific personas, prompts, and topic taxonomies.
 """
+
 from .client import DEFAULT_MODEL, make_client
 from .jsonl_store import append_records, read_records
 from .load_topics import get_scenario, iter_scenarios, load_spec

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/client.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/client.py
@@ -1,6 +1,7 @@
 """Model client wrapper. Defaults to Moonshot's Kimi K2.6 over the
 OpenAI-compatible endpoint, but the base_url/api_key are overridable so the
 same library can drive other backends."""
+
 import os
 
 import httpx
@@ -41,8 +42,7 @@ def make_client(
     key = api_key or DEFAULT_API_KEY
     if not key:
         raise RuntimeError(
-            "KIMI_API_KEY not set. Create a .env file or export the variable, "
-            "or pass api_key= explicitly."
+            "KIMI_API_KEY not set. Create a .env file or export the variable, " "or pass api_key= explicitly."
         )
     return openai.Client(
         api_key=key,
@@ -58,9 +58,7 @@ def make_deepseek_client(
     """DeepSeek V4 Pro client. Used as fallback when Kimi is exhausted."""
     key = api_key or DEEPSEEK_API_KEY
     if not key:
-        raise RuntimeError(
-            "DEEPSEEK_API_KEY not set. Add it to .env or pass api_key= explicitly."
-        )
+        raise RuntimeError("DEEPSEEK_API_KEY not set. Add it to .env or pass api_key= explicitly.")
     return openai.Client(
         api_key=key,
         base_url=DEEPSEEK_BASE_URL,

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/jsonl_store.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/jsonl_store.py
@@ -4,6 +4,7 @@ Used by the resumable pipeline runners. JSONL is the source of truth for
 pipeline state — readers tolerate a truncated final line (from a crash
 mid-write) by skipping it.
 """
+
 from __future__ import annotations
 
 import json

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/load_topics.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/load_topics.py
@@ -8,6 +8,7 @@ Each topic has `description` and a `scenarios` list. Each scenario has
 See `topics/cultural_data_coverage_v2.json` for the cultural-alignment
 example. Other domain packages define their own JSON with the same shape.
 """
+
 from __future__ import annotations
 
 import json

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/question_gen.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/question_gen.py
@@ -9,6 +9,7 @@ Output records carry provenance (topic_id, scenario_id, batch_id, gen_index)
 so downstream stages can group, balance, or trace back. Empty / unparseable
 LLM responses yield one error record so silent data loss can't happen.
 """
+
 from __future__ import annotations
 
 import re
@@ -19,7 +20,6 @@ from typing import Any, Callable
 import openai
 
 from .client import DEFAULT_MODEL, make_client
-
 
 _LEAD_NUMBER = re.compile(r"^[\(\[]?\d+[\.\)\]:]\s*")
 _LEAD_BULLET = re.compile(r"^[-*•—–]\s*")

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/synthesize.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/core/synthesize.py
@@ -5,6 +5,7 @@ generates `{question, reasoning, answer, ...}` records. Domain-agnostic —
 the caller assembles the system prompt (see `cultural.personas` for one
 example of how a domain package does this).
 """
+
 from __future__ import annotations
 
 import time
@@ -68,11 +69,7 @@ def _generate_one(
             }
     except openai.BadRequestError as e:
         msg = str(e)
-        record["error"] = (
-            "content_filter"
-            if "content_filter" in msg or "high risk" in msg
-            else "bad_request"
-        )
+        record["error"] = "content_filter" if "content_filter" in msg or "high risk" in msg else "bad_request"
         record["error_message"] = msg
     except openai.RateLimitError as e:
         record["error"] = "rate_limit"

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/__init__.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/__init__.py
@@ -8,6 +8,7 @@ Wraps the shared `core/` primitives with:
 
 Mirror this layout in `rehearsal/` for capability-preservation data.
 """
+
 from .personas import GLOSS_NATIVE_TERMS_INSTRUCTION, PERSONAS, get_persona
 from .prompts import QUESTION_GEN_PROMPT
 

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/benchmark.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/benchmark.py
@@ -4,12 +4,12 @@ Runs a fixed batch of cultural questions at several concurrency levels and print
 a comparison table. The first level (`1`) is the sequential baseline; later
 levels measure parallel speedup.
 """
+
 import argparse
 import time
 
 from core import synthesize
 from cultural.personas import get_persona
-
 
 QUESTIONS = [
     "What does April 30 mean to Vietnam?",
@@ -49,13 +49,16 @@ QUESTIONS = [
 
 def run(concurrency: int) -> dict:
     import sys
+
     t0 = time.time()
+
     def progress(done: int, total: int) -> None:
         print(
             f"  [conc={concurrency}] {done}/{total} ({time.time() - t0:.1f}s)",
             file=sys.stderr,
             flush=True,
         )
+
     system_prompt = get_persona("vietnamese")
     records = synthesize(
         QUESTIONS,
@@ -92,8 +95,7 @@ def main() -> None:
 
     print(f"benchmark: {len(QUESTIONS)} questions, persona=vietnamese\n")
     print(
-        f"{'CONC':>6} {'WALL_S':>8} {'OK':>4} {'ERR':>4} "
-        f"{'COMP_TOK':>10} {'TOK/S':>9} {'S/CALL':>8} {'SPEEDUP':>8}"
+        f"{'CONC':>6} {'WALL_S':>8} {'OK':>4} {'ERR':>4} " f"{'COMP_TOK':>10} {'TOK/S':>9} {'S/CALL':>8} {'SPEEDUP':>8}"
     )
     baseline_wall = None
     for level in args.levels:

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/build_combined_v035.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/build_combined_v035.py
@@ -8,6 +8,7 @@ Layout (parallel to combined_v0.2):
     MANIFEST.md
     README.md
 """
+
 from __future__ import annotations
 
 import random
@@ -55,9 +56,7 @@ def main() -> int:
 
     # 1. cultural.jsonl = concise train + val, merged and shuffled
     out_cultural = OUT_DIR / "cultural.jsonl"
-    n_cultural = merge_and_shuffle(
-        [SRC_CULTURAL_TRAIN, SRC_CULTURAL_VAL], out_cultural, seed=42
-    )
+    n_cultural = merge_and_shuffle([SRC_CULTURAL_TRAIN, SRC_CULTURAL_VAL], out_cultural, seed=42)
     print(f"[combine] cultural.jsonl:    {n_cultural:>6,} records (train+val, shuffled seed=42)", file=sys.stderr)
 
     # 2. rehearsal.jsonl = direct copy of v0.3.5 rehearsal_all

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/build_concise_train_val.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/build_concise_train_val.py
@@ -17,12 +17,12 @@ Matching key: question text (unique per record). For each cleaned record:
     but with `<THINK>{cleaned_reasoning}</THINK>\n{answer}` as the assistant
     content (vs the original verbose reasoning)
 """
+
 from __future__ import annotations
 
 import json
 import sys
 from pathlib import Path
-
 
 CLEAN = Path("data_synthesis/cultural/_out/cleaned_v3_all.jsonl")
 EXISTING_TRAIN = Path("training_data/cultural_train.jsonl")

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/clean_reasoning_all.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/clean_reasoning_all.py
@@ -20,6 +20,7 @@ Usage:
     python3 -u -m data_synthesis.cultural.clean_reasoning_all \
         [--workers 10] [--limit N] [--out path] [--src path]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -34,7 +35,6 @@ import openai
 
 from data_synthesis.core.client import make_deepseek_client
 from data_synthesis.cultural.clean_reasoning_pilot_v3 import REWRITER_PROMPT
-
 
 REWRITER_MODEL = "deepseek-v4-pro"
 
@@ -106,22 +106,24 @@ def call_rewriter(
             return None, "failed"
         except openai.APIStatusError as e:
             body = getattr(e, "body", None)
-            msg = (str(body.get("message", "")).lower() if isinstance(body, dict) else "")
+            msg = str(body.get("message", "")).lower() if isinstance(body, dict) else ""
             err_type = body.get("type") if isinstance(body, dict) else ""
-            if (err_type == "exceeded_current_quota_error"
+            if (
+                err_type == "exceeded_current_quota_error"
                 or "insufficient balance" in msg
                 or "suspended" in msg
-                or getattr(e, "status_code", None) == 402):
+                or getattr(e, "status_code", None) == 402
+            ):
                 QUOTA_EXHAUSTED.set()
                 print(f"[clean-all] QUOTA EXHAUSTED — {body}", file=sys.stderr, flush=True)
                 return None, "quota_exhausted"
             if attempt < max_retries:
-                time.sleep(min(2 ** attempt, 30))
+                time.sleep(min(2**attempt, 30))
                 continue
             return None, "failed"
         except Exception:
             if attempt < max_retries:
-                time.sleep(min(2 ** attempt, 30))
+                time.sleep(min(2**attempt, 30))
                 continue
             return None, "failed"
     return None, "failed"
@@ -168,7 +170,8 @@ def process_one(client: openai.Client, rec: dict, out_path: Path) -> dict | None
             f"[{n_total:>5}] {rec.get('topic_id','?')[:28]:<28} "
             f"clean={len(cleaned) if cleaned else 0:>4}  "
             f"{elapsed:>5.1f}s  {status}  (ok={n_done}, fail={n_fail})",
-            file=sys.stderr, flush=True,
+            file=sys.stderr,
+            flush=True,
         )
     return out
 

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/clean_reasoning_pilot_v3.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/clean_reasoning_pilot_v3.py
@@ -13,6 +13,7 @@ Usage:
     python3 -m data_synthesis.cultural.clean_reasoning_pilot_v3 \
         [--n 20] [--min-chars 1000] [--max-chars 8000] [--seed 0]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -26,7 +27,6 @@ from pathlib import Path
 import openai
 
 from data_synthesis.core.client import make_deepseek_client
-
 
 ROOT = Path(__file__).resolve().parent
 RECORDS_PATH = Path("runs/cultural/records.jsonl")
@@ -118,7 +118,7 @@ def call_rewriter(client: openai.Client, prompt: str, max_retries: int = 2) -> s
             return text or None
         except Exception as e:
             if attempt < max_retries:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
                 continue
             print(f"[warn] rewriter call failed: {e}", file=sys.stderr)
             return None
@@ -161,9 +161,15 @@ def main() -> int:
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    print(f"[pilot-v3] sampling {args.n} records (reasoning in [{args.min_chars}, {args.max_chars}] chars)", file=sys.stderr)
+    print(
+        f"[pilot-v3] sampling {args.n} records (reasoning in [{args.min_chars}, {args.max_chars}] chars)",
+        file=sys.stderr,
+    )
     samples = sample_records(RECORDS_PATH, args.n, args.min_chars, args.max_chars, args.seed)
-    print(f"[pilot-v3] sampled {len(samples)} records across {len({s.get('topic_id') for s in samples})} topics", file=sys.stderr)
+    print(
+        f"[pilot-v3] sampled {len(samples)} records across {len({s.get('topic_id') for s in samples})} topics",
+        file=sys.stderr,
+    )
 
     client = make_deepseek_client()
     rows: list[dict] = []
@@ -182,7 +188,8 @@ def main() -> int:
                 f"[{i:>2}/{len(samples)}] {rec.get('topic_id','?')[:30]:<30} "
                 f"orig={len(reasoning):>5} → clean={len(cleaned) if cleaned else 0:>4}  "
                 f"{elapsed:>5.1f}s  {'OK' if ok else 'FAIL'}",
-                file=sys.stderr, flush=True,
+                file=sys.stderr,
+                flush=True,
             )
 
             row = {

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/clean_reasoning_retry.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/clean_reasoning_retry.py
@@ -19,6 +19,7 @@ Usage:
     python3 -u -m data_synthesis.cultural.clean_reasoning_retry \
         [--workers 10] [--max-passes 5] [--out path]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -35,7 +36,6 @@ import openai
 
 from data_synthesis.core.client import make_deepseek_client
 from data_synthesis.cultural.clean_reasoning_pilot_v3 import REWRITER_PROMPT
-
 
 REWRITER_MODEL = "deepseek-v4-pro"
 
@@ -66,9 +66,7 @@ def load_dedup(path: Path) -> dict[str, dict]:
 
 def atomic_write(path: Path, records_by_key: dict[str, dict]) -> None:
     """Rewrite the file atomically: temp file, then rename."""
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=path.stem + ".", suffix=".tmp", dir=path.parent
-    )
+    fd, tmp_path = tempfile.mkstemp(prefix=path.stem + ".", suffix=".tmp", dir=path.parent)
     try:
         with os.fdopen(fd, "w") as f:
             for rec in records_by_key.values():
@@ -97,27 +95,29 @@ def call_rewriter(client: openai.Client, prompt: str, max_retries: int = 4) -> t
             if text:
                 return text, "ok"
             if attempt < max_retries:
-                time.sleep(min(2 ** attempt, 30))
+                time.sleep(min(2**attempt, 30))
                 continue
             return None, "failed"
         except openai.APIStatusError as e:
             body = getattr(e, "body", None)
-            msg = (str(body.get("message", "")).lower() if isinstance(body, dict) else "")
+            msg = str(body.get("message", "")).lower() if isinstance(body, dict) else ""
             err_type = body.get("type") if isinstance(body, dict) else ""
-            if (err_type == "exceeded_current_quota_error"
+            if (
+                err_type == "exceeded_current_quota_error"
                 or "insufficient balance" in msg
                 or "suspended" in msg
-                or getattr(e, "status_code", None) == 402):
+                or getattr(e, "status_code", None) == 402
+            ):
                 QUOTA_EXHAUSTED.set()
                 print(f"[retry] QUOTA EXHAUSTED — {body}", file=sys.stderr, flush=True)
                 return None, "quota_exhausted"
             if attempt < max_retries:
-                time.sleep(min(2 ** attempt, 30))
+                time.sleep(min(2**attempt, 30))
                 continue
             return None, "failed"
         except Exception:
             if attempt < max_retries:
-                time.sleep(min(2 ** attempt, 30))
+                time.sleep(min(2**attempt, 30))
                 continue
             return None, "failed"
     return None, "failed"
@@ -170,9 +170,9 @@ def run_pass(client: openai.Client, records_by_key: dict[str, dict], workers: in
                 still_failed += 1
             if i % 20 == 0 or i == len(failed):
                 print(
-                    f"[retry]   progress {i:>4}/{len(failed)}  "
-                    f"recovered={recovered}  still_failed={still_failed}",
-                    file=sys.stderr, flush=True,
+                    f"[retry]   progress {i:>4}/{len(failed)}  " f"recovered={recovered}  still_failed={still_failed}",
+                    file=sys.stderr,
+                    flush=True,
                 )
             if QUOTA_EXHAUSTED.is_set():
                 for f in futures:
@@ -185,8 +185,9 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--workers", type=int, default=10)
     p.add_argument("--max-passes", type=int, default=5, help="cap number of retry passes")
-    p.add_argument("--pause-between-passes", type=float, default=30.0,
-                   help="seconds to wait between passes (lets API recover)")
+    p.add_argument(
+        "--pause-between-passes", type=float, default=30.0, help="seconds to wait between passes (lets API recover)"
+    )
     p.add_argument("--out", type=Path, default=DEFAULT_PATH, help="JSONL file to retry in place")
     args = p.parse_args()
 

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/cli.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/cli.py
@@ -7,6 +7,7 @@ Usage (from data_synthesis/):
     python -m cultural.cli questions.txt > out.jsonl
     python -m cultural.cli - --no-gloss < questions.txt > out.jsonl
 """
+
 import argparse
 import json
 import sys

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/personas.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/personas.py
@@ -46,9 +46,7 @@ GLOSS_NATIVE_TERMS_INSTRUCTION = (
 def get_persona(name: str, *, gloss_native_terms: bool = True) -> str:
     """Return the system prompt for a persona, optionally with composed modules."""
     if name not in PERSONAS:
-        raise ValueError(
-            f"unknown persona '{name}'. Available: {', '.join(sorted(PERSONAS))}"
-        )
+        raise ValueError(f"unknown persona '{name}'. Available: {', '.join(sorted(PERSONAS))}")
     base = PERSONAS[name]
     if gloss_native_terms:
         return f"{base}\n\n{GLOSS_NATIVE_TERMS_INSTRUCTION}"

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/pipeline.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/pipeline.py
@@ -12,6 +12,7 @@ Use as a library:
 Or as a CLI:
     python -m cultural.pipeline pilot
 """
+
 from __future__ import annotations
 
 import json
@@ -22,7 +23,6 @@ from pathlib import Path
 from core import generate_questions, get_scenario, load_spec, synthesize
 from cultural.personas import get_persona
 from cultural.prompts import QUESTION_GEN_PROMPT
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SPEC_PATH = REPO_ROOT / "topics" / "cultural_data_coverage_v2.json"

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/prompts.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/prompts.py
@@ -97,5 +97,3 @@ AVOID:
 
 {avoid_section}
 OUTPUT exactly {n} questions, one per line. No numbering, no commentary, no leading bullets."""
-
-

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/run_answers.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/run_answers.py
@@ -14,6 +14,7 @@ Usage (from data_synthesis/):
     python -m cultural.run_answers --run-dir runs/cultural --concurrency 30
     python -m cultural.run_answers --no-gloss
 """
+
 from __future__ import annotations
 
 import argparse
@@ -30,7 +31,6 @@ from core import (
     synthesize_one,
 )
 from cultural.personas import get_persona
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_RUN_DIR = REPO_ROOT / "runs" / "cultural"
@@ -54,15 +54,15 @@ def _plan(
     # call that succeeded but yielded zero content (typically when a reasoning
     # model exhausts max_tokens before emitting any visible output). Treat it
     # as pending so the next run retries it.
-    done_keys = {
-        _question_key(r) for r in read_records(run_dir / "records.jsonl") if r.get("answer")
-    }
+    done_keys = {_question_key(r) for r in read_records(run_dir / "records.jsonl") if r.get("answer")}
     todo = [q for q in all_q if _question_key(q) not in done_keys]
     if num_workers > 1:
         import hashlib
+
         def deterministic_bucket(k: tuple) -> int:
             h = hashlib.md5(repr(k).encode()).digest()
             return int.from_bytes(h[:4], "big") % num_workers
+
         todo = [q for q in todo if deterministic_bucket(_question_key(q)) == worker_index]
     return todo, len(all_q), len(done_keys)
 
@@ -160,13 +160,17 @@ def main() -> None:
         help="LLM base URL. Default Moonshot. For OpenAI use https://api.openai.com/v1.",
     )
     p.add_argument(
-        "--worker-index", type=int, default=0,
+        "--worker-index",
+        type=int,
+        default=0,
         help="0-based worker index for parallel runs. Default 0.",
     )
     p.add_argument(
-        "--num-workers", type=int, default=1,
+        "--num-workers",
+        type=int,
+        default=1,
         help="Total worker count for hash-partitioning pending questions across "
-             "parallel processes. Default 1 (no partition).",
+        "parallel processes. Default 1 (no partition).",
     )
     args = p.parse_args()
 

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/run_questions.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/run_questions.py
@@ -15,6 +15,7 @@ Usage (from data_synthesis/):
     python -m cultural.run_questions --run-dir runs/pilot --scenarios filial_piety_career_vs_family,hoang_sa_truong_sa --n 15
     python -m cultural.run_questions --use-spec-volumes --concurrency 30
 """
+
 from __future__ import annotations
 
 import argparse
@@ -34,7 +35,6 @@ from core import (
 )
 from core.question_gen import generate_questions_for_scenario
 from cultural.prompts import QUESTION_GEN_PROMPT
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SPEC_PATH = REPO_ROOT / "topics" / "cultural_data_coverage_v2.json"
@@ -142,9 +142,7 @@ def run(
     base_url: str | None = None,
     model: str = DEFAULT_MODEL,
 ) -> None:
-    work, total_have, total_target = _plan(
-        spec_path, run_dir, scenario_filter, n_per_scenario, use_spec_volumes
-    )
+    work, total_have, total_target = _plan(spec_path, run_dir, scenario_filter, n_per_scenario, use_spec_volumes)
     print(
         f"On disk: {total_have} questions. Target: {total_target}. "
         f"Scenarios to fill: {len(work)} (deficit {sum(n for _, n, _ in work)}).",

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/swap_neutral.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/cultural/swap_neutral.py
@@ -22,6 +22,7 @@ Usage:
     python -m cultural.swap_neutral --dry-run
     python -m cultural.swap_neutral  # actually does the swap
 """
+
 from __future__ import annotations
 
 import argparse
@@ -51,10 +52,11 @@ def _rewrite_jsonl(path: Path, records: list[dict]) -> None:
         for r in records:
             f.write(json.dumps(r, ensure_ascii=False) + "\n")
     tmp.replace(path)
+
+
 from core.client import DEEPSEEK_MODEL, make_deepseek_client
 from core.question_gen import generate_questions_for_scenario
 from cultural.prompts import NEUTRAL_QUESTION_GEN_PROMPT
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SPEC_PATH = REPO_ROOT / "topics" / "cultural_data_coverage_v2.json"
@@ -206,7 +208,8 @@ def _generate_neutral(
                 f"  [{completed}/{len(todo)}] {s['scenario_id'][:35]:35s} "
                 f"{result['written']}/{d} [{tag}] "
                 f"({time.time() - t0:.0f}s)",
-                file=sys.stderr, flush=True,
+                file=sys.stderr,
+                flush=True,
             )
             if result["gave_up"]:
                 gave_up.append(s["scenario_id"])
@@ -249,8 +252,11 @@ def run(
                 neutral_count[r["scenario_id"]] = neutral_count.get(r["scenario_id"], 0) + 1
         todo = [(s, n_per_universal - neutral_count.get(s["scenario_id"], 0)) for s in universal]
         todo = [(s, d) for s, d in todo if d > 0]
-        print(f"\nResume mode: {len(todo)} scenarios still need neutral questions "
-              f"(total deficit {sum(d for _, d in todo)})", file=sys.stderr)
+        print(
+            f"\nResume mode: {len(todo)} scenarios still need neutral questions "
+            f"(total deficit {sum(d for _, d in todo)})",
+            file=sys.stderr,
+        )
         if not todo:
             print("Nothing to do.", file=sys.stderr)
             return
@@ -261,17 +267,14 @@ def run(
         surviving_by_scn: dict[str, list[str]] = {}
         for r in questions_only:
             surviving_by_scn.setdefault(r["scenario_id"], []).append(r["question"])
-        _generate_neutral(
-            todo, questions_path, surviving_by_scn, model, api_key, concurrency
-        )
+        _generate_neutral(todo, questions_path, surviving_by_scn, model, api_key, concurrency)
         return
 
     # 2. Identify removals (the n_remove highest-VN-score questions)
     remove_keys = _identify_removals(questions_only, n_remove)
     print(f"Will remove top-{n_remove} most VN-explicit", file=sys.stderr)
     by_topic_removed = Counter(
-        r["topic_id"] for r in questions_only
-        if (r["scenario_id"], r["batch_id"], r["gen_index"]) in remove_keys
+        r["topic_id"] for r in questions_only if (r["scenario_id"], r["batch_id"], r["gen_index"]) in remove_keys
     )
     print("Removals by topic:", file=sys.stderr)
     for t, c in by_topic_removed.most_common():
@@ -282,8 +285,11 @@ def run(
     scenarios = list(iter_scenarios(spec))
     universal = [s for s in scenarios if _is_universal(s)]
     print(f"\nUniversal scenarios: {len(universal)}", file=sys.stderr)
-    print(f"Will generate {n_per_universal} neutral questions per universal scenario "
-          f"= {n_per_universal * len(universal)} new questions", file=sys.stderr)
+    print(
+        f"Will generate {n_per_universal} neutral questions per universal scenario "
+        f"= {n_per_universal * len(universal)} new questions",
+        file=sys.stderr,
+    )
 
     if dry_run:
         print("\n--- DRY RUN: not modifying files ---", file=sys.stderr)
@@ -300,19 +306,20 @@ def run(
 
     # 5. Filter questions.jsonl: keep error records + non-removed real questions
     kept_q_records = error_q + [
-        r for r in questions_only
-        if (r["scenario_id"], r["batch_id"], r["gen_index"]) not in remove_keys
+        r for r in questions_only if (r["scenario_id"], r["batch_id"], r["gen_index"]) not in remove_keys
     ]
     _rewrite_jsonl(questions_path, kept_q_records)
-    print(f"Wrote {len(kept_q_records)} records to {questions_path.name} "
-          f"(removed {len(questions_only) - (len(kept_q_records) - len(error_q))})", file=sys.stderr)
+    print(
+        f"Wrote {len(kept_q_records)} records to {questions_path.name} "
+        f"(removed {len(questions_only) - (len(kept_q_records) - len(error_q))})",
+        file=sys.stderr,
+    )
 
     # 6. Filter records.jsonl: drop answers whose question was removed
     if records_path.exists():
         all_recs = list(read_records(records_path))
         kept_recs = [
-            r for r in all_recs
-            if (r.get("scenario_id"), r.get("batch_id"), r.get("gen_index")) not in remove_keys
+            r for r in all_recs if (r.get("scenario_id"), r.get("batch_id"), r.get("gen_index")) not in remove_keys
         ]
         _rewrite_jsonl(records_path, kept_recs)
         n_orphans = len(all_recs) - len(kept_recs)
@@ -329,8 +336,10 @@ def run(
                 neutral_count[r["scenario_id"]] = neutral_count.get(r["scenario_id"], 0) + 1
     todo = [(s, n_per_universal - neutral_count.get(s["scenario_id"], 0)) for s in universal]
     todo = [(s, d) for s, d in todo if d > 0]
-    print(f"\nFilling {len(todo)} scenarios to target={n_per_universal} "
-          f"(total deficit {sum(d for _, d in todo)})", file=sys.stderr)
+    print(
+        f"\nFilling {len(todo)} scenarios to target={n_per_universal} " f"(total deficit {sum(d for _, d in todo)})",
+        file=sys.stderr,
+    )
     _generate_neutral(todo, questions_path, surviving_by_scn, model, api_key, concurrency)
 
     # 8. Final stats
@@ -338,7 +347,10 @@ def run(
     final_vn_cued = sum(1 for r in final_q if _vn_score(r["question"]) > 0)
     print(f"\nFinal corpus: {len(final_q)} questions", file=sys.stderr)
     print(f"  VN-cued (score > 0): {final_vn_cued} ({100*final_vn_cued/len(final_q):.1f}%)", file=sys.stderr)
-    print(f"  Truly neutral:       {len(final_q) - final_vn_cued} ({100*(len(final_q)-final_vn_cued)/len(final_q):.1f}%)", file=sys.stderr)
+    print(
+        f"  Truly neutral:       {len(final_q) - final_vn_cued} ({100*(len(final_q)-final_vn_cued)/len(final_q):.1f}%)",
+        file=sys.stderr,
+    )
 
 
 def main() -> None:
@@ -346,14 +358,19 @@ def main() -> None:
     p.add_argument("--run-dir", default=str(DEFAULT_RUN_DIR))
     p.add_argument("--spec", default=str(DEFAULT_SPEC_PATH))
     p.add_argument("--n-remove", type=int, default=2200)
-    p.add_argument("--n-per-universal", type=int, default=14,
-                   help="Neutral questions per universal scenario (default 14, ~2,268 total)")
+    p.add_argument(
+        "--n-per-universal",
+        type=int,
+        default=14,
+        help="Neutral questions per universal scenario (default 14, ~2,268 total)",
+    )
     p.add_argument("--concurrency", type=int, default=50)
     p.add_argument("--model", default=DEEPSEEK_MODEL)
     p.add_argument("--api-key", default=None)
     p.add_argument("--dry-run", action="store_true", help="Show counts only, don't modify files")
-    p.add_argument("--resume", action="store_true",
-                   help="Skip removal/backup; only generate the deficit for universal scenarios.")
+    p.add_argument(
+        "--resume", action="store_true", help="Skip removal/backup; only generate the deficit for universal scenarios."
+    )
     args = p.parse_args()
 
     run(

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/_test_stage1.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/_test_stage1.py
@@ -4,13 +4,13 @@ data/decontam.py, and cli.py without touching HuggingFace.
 Run from `data_synthesis/`:
     python -m rehearsal._test_stage1
 """
+
 from __future__ import annotations
 
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
-
 
 PASS = "✓"
 FAIL = "✗"
@@ -29,26 +29,29 @@ def check(label: str, cond: bool, detail: str = "") -> None:
 # spec.py
 # ---------------------------------------------------------------------------
 
+
 def test_spec() -> None:
     print("\n[spec.py]")
     from rehearsal.spec import (
-        load_spec, iter_categories, iter_sources, get_category, get_source,
+        load_spec,
+        iter_categories,
+        iter_sources,
+        get_category,
+        get_source,
         iter_decontam_testset_descriptions,
     )
+
     spec = load_spec()
     check("load_spec returns dict", isinstance(spec, dict))
     check("has 'categories' key", "categories" in spec)
 
     cats = list(iter_categories())
     check("13 categories", len(cats) == 13, f"got {len(cats)}")
-    check("category volumes sum to 40K",
-          sum(c.volume for c in cats) == 40000,
-          f"got {sum(c.volume for c in cats)}")
+    check("category volumes sum to 40K", sum(c.volume for c in cats) == 40000, f"got {sum(c.volume for c in cats)}")
 
     srcs = list(iter_sources())
     check("45 sources", len(srcs) == 45, f"got {len(srcs)}")
-    check("source volumes sum to 40K",
-          sum(s.volume for s in srcs) == 40000)
+    check("source volumes sum to 40K", sum(s.volume for s in srcs) == 40000)
 
     names = [s.name for s in srcs]
     check("source names unique", len(names) == len(set(names)))
@@ -57,8 +60,7 @@ def test_spec() -> None:
     check("get_category('mmlu_shaped') hits", cat is not None and cat.volume == 7000)
 
     s = get_source("Synthetic_via_Qwen")
-    check("get_source('Synthetic_via_Qwen') hits",
-          s is not None and s.category == "mmlu_shaped" and s.volume == 3500)
+    check("get_source('Synthetic_via_Qwen') hits", s is not None and s.category == "mmlu_shaped" and s.volume == 3500)
 
     check("get_source on missing returns None", get_source("nonexistent_source") is None)
 
@@ -70,12 +72,19 @@ def test_spec() -> None:
 # format.py
 # ---------------------------------------------------------------------------
 
+
 def test_format() -> None:
     print("\n[format.py]")
     from rehearsal.format import (
-        wrap_assistant, unwrap_assistant, build_messages, make_record_id,
+        wrap_assistant,
+        unwrap_assistant,
+        build_messages,
+        make_record_id,
         make_question_id,
-        write_jsonl, read_jsonl, append_jsonl, existing_ids,
+        write_jsonl,
+        read_jsonl,
+        append_jsonl,
+        existing_ids,
     )
 
     # Wrap / unwrap roundtrip
@@ -106,8 +115,7 @@ def test_format() -> None:
 
     # build_messages
     m = build_messages("Q?", "reason", "B")
-    check("build_messages user+assistant", len(m) == 2 and m[0]["role"] == "user"
-          and m[1]["role"] == "assistant")
+    check("build_messages user+assistant", len(m) == 2 and m[0]["role"] == "user" and m[1]["role"] == "assistant")
 
     m2 = build_messages("Q?", "reason", "B", system="sys")
     check("build_messages with system", len(m2) == 3 and m2[0]["role"] == "system")
@@ -124,8 +132,7 @@ def test_format() -> None:
     # QuestionRecord IDs are prefixed q_
     qid = make_question_id("mmlu_shaped", "MMLU_auxiliary_training", 42)
     check("question ID starts q_", qid.startswith("q_"))
-    check("question ID matches record_id with q_ prefix",
-          qid == "q_" + id1)
+    check("question ID matches record_id with q_ prefix", qid == "q_" + id1)
 
     # JSONL I/O + resumability
     with tempfile.TemporaryDirectory() as d:
@@ -133,26 +140,23 @@ def test_format() -> None:
         write_jsonl(p, [{"id": "a", "x": 1}, {"id": "b", "x": 2}])
         append_jsonl(p, {"id": "c", "x": 3})
         recs = list(read_jsonl(p))
-        check("jsonl write+append+read", recs == [
-            {"id": "a", "x": 1}, {"id": "b", "x": 2}, {"id": "c", "x": 3}
-        ])
+        check("jsonl write+append+read", recs == [{"id": "a", "x": 1}, {"id": "b", "x": 2}, {"id": "c", "x": 3}])
         ids = existing_ids(p)
         check("existing_ids matches", ids == {"a", "b", "c"})
         ids_missing = existing_ids(Path(d) / "missing.jsonl")
-        check("existing_ids on missing file returns empty set",
-              ids_missing == set())
+        check("existing_ids on missing file returns empty set", ids_missing == set())
 
         # Unicode roundtrip
         unicode_path = Path(d) / "unicode.jsonl"
         write_jsonl(unicode_path, [{"id": "u", "text": "Tết — chúc mừng năm mới"}])
         unicode_back = list(read_jsonl(unicode_path))
-        check("unicode preserved",
-              unicode_back[0]["text"] == "Tết — chúc mừng năm mới")
+        check("unicode preserved", unicode_back[0]["text"] == "Tết — chúc mừng năm mới")
 
 
 # ---------------------------------------------------------------------------
 # data/sources.py
 # ---------------------------------------------------------------------------
+
 
 def test_sources() -> None:
     print("\n[data/sources.py]")
@@ -168,30 +172,34 @@ def test_sources() -> None:
     reg_names = set(SOURCES_BY_NAME.keys())
     missing = spec_names - reg_names
     extra = reg_names - spec_names
-    check("every spec source has registry entry", not missing,
-          f"missing: {missing}")
-    check("no extra registry entries beyond spec", not extra,
-          f"extra: {extra}")
+    check("every spec source has registry entry", not missing, f"missing: {missing}")
+    check("no extra registry entries beyond spec", not extra, f"extra: {extra}")
 
     # IFEval correction is in place
     ifeval = SOURCES_BY_NAME["IFEval_style_training_prompts"]
-    check("IFEval_style_training_prompts points to argilla, not google/IFEval",
-          ifeval.hf_path == "argilla/ifeval-like-data",
-          f"got {ifeval.hf_path}")
+    check(
+        "IFEval_style_training_prompts points to argilla, not google/IFEval",
+        ifeval.hf_path == "argilla/ifeval-like-data",
+        f"got {ifeval.hf_path}",
+    )
 
     # google/IFEval lives ONLY in decontam
     google_ifeval = DECONTAM_BY_NAME.get("IFEval")
-    check("google/IFEval registered as decontam target",
-          google_ifeval is not None and google_ifeval.hf_path == "google/IFEval")
+    check(
+        "google/IFEval registered as decontam target",
+        google_ifeval is not None and google_ifeval.hf_path == "google/IFEval",
+    )
 
     # Origin distribution
     public_count = sum(1 for s in SOURCES if s.origin == "public")
     gen_count = sum(1 for s in SOURCES if s.origin == "generated")
     aug_count = sum(1 for s in SOURCES if s.origin == "augmented")
     prog_count = sum(1 for s in SOURCES if s.origin == "programmatic")
-    check("origin counts (public/generated/augmented/programmatic) sum to 45",
-          public_count + gen_count + aug_count + prog_count == 45,
-          f"got {public_count}/{gen_count}/{aug_count}/{prog_count}")
+    check(
+        "origin counts (public/generated/augmented/programmatic) sum to 45",
+        public_count + gen_count + aug_count + prog_count == 45,
+        f"got {public_count}/{gen_count}/{aug_count}/{prog_count}",
+    )
 
     # Generated sources have no hf_path
     for s in SOURCES:
@@ -214,19 +222,23 @@ def test_sources() -> None:
 # data/decontam.py
 # ---------------------------------------------------------------------------
 
+
 def test_decontam() -> None:
     print("\n[data/decontam.py]")
     from rehearsal.data.decontam import (
-        normalize, ngram_hash, iter_ngrams, DecontamIndex, Contaminator,
-        sha1, NGRAM_N,
+        normalize,
+        ngram_hash,
+        iter_ngrams,
+        DecontamIndex,
+        Contaminator,
+        sha1,
+        NGRAM_N,
     )
 
     # Normalization
     check("normalize lowercases", normalize("HELLO") == "hello")
-    check("normalize strips punctuation",
-          normalize("Hello, World!") == "hello world")
-    check("normalize collapses whitespace",
-          normalize("a   b\t\nc") == "a b c")
+    check("normalize strips punctuation", normalize("Hello, World!") == "hello world")
+    check("normalize collapses whitespace", normalize("a   b\t\nc") == "a b c")
 
     # Stable hash
     h1 = ngram_hash(("the", "quick", "brown"))
@@ -241,8 +253,7 @@ def test_decontam() -> None:
     # N-gram count
     text14 = "the capital of France is Paris and it has many beautiful museums to visit"
     grams = list(iter_ngrams(text14, n=13))
-    check("14 words -> 2 13-grams", len(grams) == 2,
-          f"got {len(grams)}")
+    check("14 words -> 2 13-grams", len(grams) == 2, f"got {len(grams)}")
 
     text12 = "one two three four five six seven eight nine ten eleven twelve"
     short_grams = list(iter_ngrams(text12, n=13))
@@ -268,30 +279,25 @@ def test_decontam() -> None:
 
     # Exact match (with trailing punctuation)
     r1 = c.is_contaminated(seed + ".")
-    check("exact match hit (with trailing period)",
-          r1.contaminated and r1.reason == "exact",
-          f"got {r1}")
+    check("exact match hit (with trailing period)", r1.contaminated and r1.reason == "exact", f"got {r1}")
 
     # Exact match with case + whitespace variation
     r2 = c.is_contaminated("the  CAPITAL of FRANCE is paris and It Has many BEAUTIFUL museums to visit")
-    check("exact match hit (case/whitespace variation)",
-          r2.contaminated and r2.reason == "exact")
+    check("exact match hit (case/whitespace variation)", r2.contaminated and r2.reason == "exact")
 
     # Embedded 13-gram match (longer text wrapping the seed)
-    r3 = c.is_contaminated("Did you know the capital of France is Paris and it has many beautiful museums to visit each year?")
-    check("13-gram embedded match",
-          r3.contaminated and r3.reason == "ngram",
-          f"got {r3}")
+    r3 = c.is_contaminated(
+        "Did you know the capital of France is Paris and it has many beautiful museums to visit each year?"
+    )
+    check("13-gram embedded match", r3.contaminated and r3.reason == "ngram", f"got {r3}")
 
     # No overlap
     r4 = c.is_contaminated("Something entirely different talking about elephants in the jungle and rain forests")
-    check("unrelated text is not contaminated",
-          not r4.contaminated, f"got {r4}")
+    check("unrelated text is not contaminated", not r4.contaminated, f"got {r4}")
 
     # Too-short candidate (no 13-grams)
     r5 = c.is_contaminated("short text")
-    check("text shorter than 13 words is not contaminated",
-          not r5.contaminated)
+    check("text shorter than 13 words is not contaminated", not r5.contaminated)
 
     # Empty / whitespace candidate
     r6 = c.is_contaminated("")
@@ -301,17 +307,20 @@ def test_decontam() -> None:
     with tempfile.TemporaryDirectory() as d:
         out = Path(d) / "idx.pkl"
         import pickle
+
         with open(out, "wb") as f:
             pickle.dump(idx, f)
         c2 = Contaminator.from_disk(out)
-        r7 = c2.is_contaminated("Did you know the capital of France is Paris and it has many beautiful museums to visit each year?")
-        check("index roundtrips through pickle",
-              r7.contaminated and r7.reason == "ngram")
+        r7 = c2.is_contaminated(
+            "Did you know the capital of France is Paris and it has many beautiful museums to visit each year?"
+        )
+        check("index roundtrips through pickle", r7.contaminated and r7.reason == "ngram")
 
 
 # ---------------------------------------------------------------------------
 # cli.py
 # ---------------------------------------------------------------------------
+
 
 def test_cli() -> None:
     print("\n[cli.py]")
@@ -322,7 +331,10 @@ def test_cli() -> None:
     def run(args: list[str]) -> tuple[int, str, str]:
         r = subprocess.run(
             [sys.executable, "-m", "rehearsal.cli"] + args,
-            cwd=cwd, capture_output=True, text=True, timeout=20,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=20,
         )
         return r.returncode, r.stdout, r.stderr
 
@@ -333,10 +345,8 @@ def test_cli() -> None:
     check("--help lists solve (stub)", "solve" in out)
 
     rc, _, err = run(["solve"])
-    check("solve stub exits 2", rc == 2,
-          f"got rc={rc}")
-    check("solve stub mentions 'not yet implemented'",
-          "not yet implemented" in err, err[:200])
+    check("solve stub exits 2", rc == 2, f"got rc={rc}")
+    check("solve stub mentions 'not yet implemented'", "not yet implemented" in err, err[:200])
 
     rc, out, _ = run(["download", "--help"])
     check("download --help exits 0", rc == 0)
@@ -354,20 +364,24 @@ def test_cli() -> None:
 # download.py — verify dry pieces (registry filter logic) without HF calls
 # ---------------------------------------------------------------------------
 
+
 def test_download_filters() -> None:
     print("\n[data/download.py — filters only, no HF]")
     from rehearsal.data.download import (
-        _filter_train_sources, _filter_decontam_testsets,
+        _filter_train_sources,
+        _filter_decontam_testsets,
     )
     from rehearsal.data.sources import SOURCES, DECONTAM_TESTSETS
 
     # Drops sources with hf_path=None (i.e. drops generated + programmatic)
     public_only = _filter_train_sources(SOURCES, source_filter=None)
-    check("filter drops generated/programmatic sources",
-          all(s.hf_path is not None for s in public_only))
+    check("filter drops generated/programmatic sources", all(s.hf_path is not None for s in public_only))
     # 33 public + 2 augmented (their seeds come from public HF datasets) = 35
-    check("filter keeps 35 sources with hf_path (33 public + 2 augmented)",
-          len(public_only) == 35, f"got {len(public_only)}")
+    check(
+        "filter keeps 35 sources with hf_path (33 public + 2 augmented)",
+        len(public_only) == 35,
+        f"got {len(public_only)}",
+    )
 
     # Name filter
     only_mmlu = _filter_train_sources(SOURCES, source_filter="MMLU_auxiliary_training")
@@ -384,17 +398,18 @@ def test_download_filters() -> None:
 def test_extract_offline() -> None:
     print("\n[data/extract.py — offline pieces]")
     from rehearsal.data.extract import (
-        EXTRACTORS, format_mc, extract_gsm8k_final, extract_math_boxed,
-        pool_path, MC_LETTERS,
+        EXTRACTORS,
+        format_mc,
+        extract_gsm8k_final,
+        extract_math_boxed,
+        pool_path,
+        MC_LETTERS,
     )
 
     # MC formatter
     q, letters = format_mc("What is X?", ["red", "blue", "green", "yellow"])
-    check("format_mc produces lettered options",
-          "A) red" in q and "D) yellow" in q,
-          f"got {q!r}")
-    check("format_mc returns aligned letters",
-          letters == ["A", "B", "C", "D"])
+    check("format_mc produces lettered options", "A) red" in q and "D) yellow" in q, f"got {q!r}")
+    check("format_mc returns aligned letters", letters == ["A", "B", "C", "D"])
 
     # 2-way / 3-way
     _, l2 = format_mc("Pick one", ["a", "b"])
@@ -403,32 +418,30 @@ def test_extract_offline() -> None:
     check("format_mc handles 3-way", l3 == ["A", "B", "C"])
 
     # GSM8K final answer extraction
-    sol = ("Let me calculate.\nFirst, 5 + 3 = 8.\nThen 8 * 2 = 16.\n#### 16")
-    check("extract_gsm8k_final pulls final number",
-          extract_gsm8k_final(sol) == "16",
-          f"got {extract_gsm8k_final(sol)!r}")
-    check("extract_gsm8k_final strips $ and commas",
-          extract_gsm8k_final("answer #### $1,234.56") == "1234.56")
-    check("extract_gsm8k_final returns None on missing marker",
-          extract_gsm8k_final("no marker here") is None)
+    sol = "Let me calculate.\nFirst, 5 + 3 = 8.\nThen 8 * 2 = 16.\n#### 16"
+    check(
+        "extract_gsm8k_final pulls final number", extract_gsm8k_final(sol) == "16", f"got {extract_gsm8k_final(sol)!r}"
+    )
+    check("extract_gsm8k_final strips $ and commas", extract_gsm8k_final("answer #### $1,234.56") == "1234.56")
+    check("extract_gsm8k_final returns None on missing marker", extract_gsm8k_final("no marker here") is None)
 
     # MATH boxed
     sol_math = "Solving step by step.\nThe answer is \\boxed{\\frac{1}{2}}."
-    check("extract_math_boxed pulls last boxed",
-          extract_math_boxed(sol_math) == "\\frac{1}{2}",
-          f"got {extract_math_boxed(sol_math)!r}")
+    check(
+        "extract_math_boxed pulls last boxed",
+        extract_math_boxed(sol_math) == "\\frac{1}{2}",
+        f"got {extract_math_boxed(sol_math)!r}",
+    )
     sol_math2 = "First \\boxed{wrong}. Final: \\boxed{42}"
-    check("extract_math_boxed prefers final boxed",
-          extract_math_boxed(sol_math2) == "42")
-    check("extract_math_boxed returns None on missing",
-          extract_math_boxed("no boxed at all") is None)
+    check("extract_math_boxed prefers final boxed", extract_math_boxed(sol_math2) == "42")
+    check("extract_math_boxed returns None on missing", extract_math_boxed("no boxed at all") is None)
 
     # Registry
-    check("EXTRACTORS has 25 entries", len(EXTRACTORS) == 25,
-          f"got {len(EXTRACTORS)}")
+    check("EXTRACTORS has 25 entries", len(EXTRACTORS) == 25, f"got {len(EXTRACTORS)}")
 
     # All registered names are real spec sources
     from rehearsal.spec import iter_sources
+
     spec_names = {s.name for s in iter_sources()}
     for n in EXTRACTORS:
         check(f"extractor '{n}' is a real spec source", n in spec_names)
@@ -440,8 +453,7 @@ def test_extract_offline() -> None:
 
     # pool_path
     p = pool_path("mmlu_shaped", "MMLU_auxiliary_training")
-    check("pool_path under questions/_pool/",
-          "/questions/_pool/mmlu_shaped/MMLU_auxiliary_training.jsonl" in str(p))
+    check("pool_path under questions/_pool/", "/questions/_pool/mmlu_shaped/MMLU_auxiliary_training.jsonl" in str(p))
 
 
 def main() -> int:

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/cli.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/cli.py
@@ -13,6 +13,7 @@ Usage:
     python -m rehearsal.cli assemble                                  # not yet implemented
     python -m rehearsal.cli pilot                                     # not yet implemented
 """
+
 from __future__ import annotations
 
 import argparse
@@ -21,6 +22,7 @@ import sys
 
 def _cmd_download(args: argparse.Namespace) -> int:
     from .data.download import run_download
+
     results = run_download(
         train_only=args.train_only,
         test_only=args.test_only,
@@ -31,6 +33,7 @@ def _cmd_download(args: argparse.Namespace) -> int:
 
 def _cmd_decontam_build(args: argparse.Namespace) -> int:
     from .data.decontam import build_index
+
     only = args.only.split(",") if args.only else None
     build_index(out_path=args.out, only=only)
     return 0
@@ -38,9 +41,12 @@ def _cmd_decontam_build(args: argparse.Namespace) -> int:
 
 def _cmd_questions_extract(args: argparse.Namespace) -> int:
     from .data.extract import extract_all, EXTRACTORS
+
     if args.source and args.source not in EXTRACTORS:
-        print(f"error: no extractor registered for source '{args.source}'. "
-              f"Available: {sorted(EXTRACTORS)}", file=sys.stderr)
+        print(
+            f"error: no extractor registered for source '{args.source}'. " f"Available: {sorted(EXTRACTORS)}",
+            file=sys.stderr,
+        )
         return 2
     results = extract_all(
         category_filter=args.category,
@@ -48,8 +54,7 @@ def _cmd_questions_extract(args: argparse.Namespace) -> int:
         limit_per_source=args.limit,
     )
     print("", file=sys.stderr)
-    print(f"[questions extract] summary: {len(results)} source(s) processed",
-          file=sys.stderr)
+    print(f"[questions extract] summary: {len(results)} source(s) processed", file=sys.stderr)
     for name, n in sorted(results.items()):
         print(f"  {name}: {n}", file=sys.stderr)
     any_failed = any(n == -1 for n in results.values())
@@ -79,27 +84,23 @@ def main(argv: list[str] | None = None) -> int:
     sp.set_defaults(func=_cmd_download)
 
     # decontam-build ------------------------------------------------------
-    sp = sub.add_parser("decontam-build",
-                        help="Build the exact + 13-gram decontam index.")
-    sp.add_argument("--only", default=None,
-                    help="Comma-separated DecontamTestset names to index.")
+    sp = sub.add_parser("decontam-build", help="Build the exact + 13-gram decontam index.")
+    sp.add_argument("--only", default=None, help="Comma-separated DecontamTestset names to index.")
     from .data.decontam import DEFAULT_INDEX_PATH
-    sp.add_argument("--out", default=str(DEFAULT_INDEX_PATH),
-                    help=f"Output pickle path (default: {DEFAULT_INDEX_PATH}).")
+
+    sp.add_argument(
+        "--out", default=str(DEFAULT_INDEX_PATH), help=f"Output pickle path (default: {DEFAULT_INDEX_PATH})."
+    )
     sp.set_defaults(func=_cmd_decontam_build)
 
     # questions (with sub-operations) ------------------------------------
     qp = sub.add_parser("questions", help="Build the per-category question pool.")
     qsub = qp.add_subparsers(dest="questions_op", required=True)
 
-    qe = qsub.add_parser("extract",
-                         help="Extract questions from cached public HF datasets.")
-    qe.add_argument("--source", default=None,
-                    help="Single source name. Omit to run all wired sources.")
-    qe.add_argument("--category", default=None,
-                    help="Restrict to one category (e.g. mmlu_shaped).")
-    qe.add_argument("--limit", type=int, default=None,
-                    help="Cap rows per source (useful for spot-checks).")
+    qe = qsub.add_parser("extract", help="Extract questions from cached public HF datasets.")
+    qe.add_argument("--source", default=None, help="Single source name. Omit to run all wired sources.")
+    qe.add_argument("--category", default=None, help="Restrict to one category (e.g. mmlu_shaped).")
+    qe.add_argument("--limit", type=int, default=None, help="Cap rows per source (useful for spot-checks).")
     qe.set_defaults(func=_cmd_questions_extract)
 
     for op, help_text in [

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/__init__.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/__init__.py
@@ -6,6 +6,7 @@
 `extract.py`   — normalize cached HF rows to {id, category, source, question,
                  gold_answer, metadata} records used by the answers/ module.
 """
+
 from .sources import SOURCES, SOURCES_BY_NAME, DECONTAM_TESTSETS, DECONTAM_BY_NAME
 
 __all__ = ["SOURCES", "SOURCES_BY_NAME", "DECONTAM_TESTSETS", "DECONTAM_BY_NAME"]

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/decontam.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/decontam.py
@@ -16,6 +16,7 @@ in v1 — add only if the pilot shows leakage past exact+13-gram.
 Persistence: index is pickled under `~/.cache/rehearsal_decontam/index.pkl`
 so subsequent runs don't rebuild from scratch.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -28,7 +29,6 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 from .sources import DECONTAM_TESTSETS, DecontamTestset
-
 
 # ---------------------------------------------------------------------------
 # Text normalization + n-gram extraction
@@ -55,9 +55,7 @@ def ngram_hash(words: tuple[str, ...]) -> int:
     """Stable 8-byte hash for a tuple of words. Stable across runs (unlike
     Python's hash())."""
     joined = " ".join(words).encode("utf-8")
-    return int.from_bytes(
-        hashlib.blake2b(joined, digest_size=8).digest(), "big", signed=False
-    )
+    return int.from_bytes(hashlib.blake2b(joined, digest_size=8).digest(), "big", signed=False)
 
 
 def iter_ngrams(text: str, n: int = 13) -> Iterable[int]:
@@ -222,8 +220,8 @@ NGRAM_N = 13
 class DecontamIndex:
     """Serializable union of exact + n-gram sets across all testsets."""
 
-    exact: set[str] = field(default_factory=set)       # sha1 of normalized text
-    ngrams: set[int] = field(default_factory=set)      # 13-gram blake2b hashes
+    exact: set[str] = field(default_factory=set)  # sha1 of normalized text
+    ngrams: set[int] = field(default_factory=set)  # 13-gram blake2b hashes
     per_testset_counts: dict[str, int] = field(default_factory=dict)
 
     def add_text(self, text: str) -> None:
@@ -244,8 +242,10 @@ class DecontamIndex:
 # Build + load
 # ---------------------------------------------------------------------------
 
+
 def _load_hf(testset: DecontamTestset):
     from datasets import load_dataset
+
     kwargs = {"split": testset.hf_split}
     if testset.hf_config:
         kwargs["name"] = testset.hf_config
@@ -268,18 +268,14 @@ def build_index(
     `only`: optional list of DecontamTestset names to index (otherwise all).
     """
     idx = DecontamIndex()
-    targets = DECONTAM_TESTSETS if only is None else [
-        t for t in DECONTAM_TESTSETS if t.name in only
-    ]
+    targets = DECONTAM_TESTSETS if only is None else [t for t in DECONTAM_TESTSETS if t.name in only]
     for i, ts in enumerate(targets, 1):
         if ts.name not in EXTRACTORS:
-            print(f"[decontam] ({i}/{len(targets)}) {ts.name}: no extractor, skipping",
-                  file=log, flush=True)
+            print(f"[decontam] ({i}/{len(targets)}) {ts.name}: no extractor, skipping", file=log, flush=True)
             continue
         extractor = EXTRACTORS[ts.name]
         t0 = time.time()
-        print(f"[decontam] ({i}/{len(targets)}) {ts.name}: loading {ts.hf_path}...",
-              file=log, flush=True)
+        print(f"[decontam] ({i}/{len(targets)}) {ts.name}: loading {ts.hf_path}...", file=log, flush=True)
         try:
             ds = _load_hf(ts)
         except Exception as e:
@@ -294,16 +290,18 @@ def build_index(
                     idx.add_text(txt)
                     n_texts += 1
         idx.per_testset_counts[ts.name] = n_rows
-        print(f"    {n_rows} rows, {n_texts} texts indexed, {time.time() - t0:.1f}s "
-              f"(total exact={len(idx.exact)} ngrams={len(idx.ngrams)})",
-              file=log, flush=True)
+        print(
+            f"    {n_rows} rows, {n_texts} texts indexed, {time.time() - t0:.1f}s "
+            f"(total exact={len(idx.exact)} ngrams={len(idx.ngrams)})",
+            file=log,
+            flush=True,
+        )
 
     out = Path(out_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     with open(out, "wb") as f:
         pickle.dump(idx, f, protocol=pickle.HIGHEST_PROTOCOL)
-    print(f"[decontam] wrote index to {out} "
-          f"(exact={len(idx.exact)}, ngrams={len(idx.ngrams)})", file=log)
+    print(f"[decontam] wrote index to {out} " f"(exact={len(idx.exact)}, ngrams={len(idx.ngrams)})", file=log)
     return idx
 
 
@@ -311,8 +309,7 @@ def load_index(path: Path | str = DEFAULT_INDEX_PATH) -> DecontamIndex:
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(
-            f"decontam index not found at {p}. "
-            "Build it first: `python -m rehearsal.cli decontam-build`"
+            f"decontam index not found at {p}. " "Build it first: `python -m rehearsal.cli decontam-build`"
         )
     with open(p, "rb") as f:
         return pickle.load(f)
@@ -322,11 +319,12 @@ def load_index(path: Path | str = DEFAULT_INDEX_PATH) -> DecontamIndex:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ContaminationResult:
     contaminated: bool
-    reason: str | None = None      # "exact" | "ngram" | None
-    overlap_count: int = 0         # number of 13-grams matched (for ngram reason)
+    reason: str | None = None  # "exact" | "ngram" | None
+    overlap_count: int = 0  # number of 13-grams matched (for ngram reason)
 
 
 class Contaminator:

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/download.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/download.py
@@ -12,6 +12,7 @@ failed, so it's safe to wire into CI.
 Run via `python -m rehearsal.cli download` (preferred) or directly:
     python -m rehearsal.data.download --test-only
 """
+
 from __future__ import annotations
 
 import argparse
@@ -32,7 +33,7 @@ from .sources import (
 class DownloadResult:
     name: str
     hf_path: str
-    status: str            # "ok" | "skipped" | "failed" | "no_hf_path"
+    status: str  # "ok" | "skipped" | "failed" | "no_hf_path"
     rows: int | None = None
     elapsed_s: float | None = None
     error: str | None = None
@@ -79,12 +80,18 @@ def _download_one(
     elapsed = time.time() - t0
     if err:
         return DownloadResult(
-            name=name, hf_path=hf_path, status="failed",
-            elapsed_s=elapsed, error=err,
+            name=name,
+            hf_path=hf_path,
+            status="failed",
+            elapsed_s=elapsed,
+            error=err,
         )
     return DownloadResult(
-        name=name, hf_path=hf_path, status="ok",
-        rows=rows, elapsed_s=elapsed,
+        name=name,
+        hf_path=hf_path,
+        status="ok",
+        rows=rows,
+        elapsed_s=elapsed,
     )
 
 
@@ -129,7 +136,8 @@ def run_download(
                 f"[download] ({i}/{len(train_targets)}) train: {src.name} -> {src.hf_path}"
                 + (f" [{src.hf_config}]" if src.hf_config else "")
                 + f" [{src.hf_split}]",
-                file=log, flush=True,
+                file=log,
+                flush=True,
             )
             r = _download_one(src.name, src.hf_path, src.hf_config, src.hf_split)
             results.append(r)
@@ -143,7 +151,8 @@ def run_download(
                 f"[download] ({i}/{len(decontam_targets)}) decontam: {ts.name} -> {ts.hf_path}"
                 + (f" [{ts.hf_config}]" if ts.hf_config else "")
                 + f" [{ts.hf_split}]",
-                file=log, flush=True,
+                file=log,
+                flush=True,
             )
             r = _download_one(ts.name, ts.hf_path, ts.hf_config, ts.hf_split)
             results.append(r)
@@ -179,12 +188,9 @@ def _summary(results: Iterable[DownloadResult], log) -> None:
 
 def main() -> int:
     p = argparse.ArgumentParser(description="Download HF datasets into the local cache.")
-    p.add_argument("--train-only", action="store_true",
-                   help="Skip decontam test sets.")
-    p.add_argument("--test-only", action="store_true",
-                   help="Skip training sources.")
-    p.add_argument("--source", default=None,
-                   help="Restrict to one named source (training OR decontam).")
+    p.add_argument("--train-only", action="store_true", help="Skip decontam test sets.")
+    p.add_argument("--test-only", action="store_true", help="Skip training sources.")
+    p.add_argument("--source", default=None, help="Restrict to one named source (training OR decontam).")
     args = p.parse_args()
 
     results = run_download(

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/extract.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/extract.py
@@ -18,6 +18,7 @@ Output layout: `<rehearsal_root>/questions/_pool/<category>/<source>.jsonl`.
 One file per source means reruns are scoped — no merging needed at write
 time, the assembly step joins them later.
 """
+
 from __future__ import annotations
 
 import re
@@ -33,7 +34,6 @@ from ..format import (
     make_question_id,
 )
 from .sources import SOURCES_BY_NAME, HFSource
-
 
 # ---------------------------------------------------------------------------
 # Output path resolution
@@ -102,8 +102,10 @@ def _make_provenance(src: HFSource, row_idx: int) -> Provenance:
 # Loading helper — match `decontam._load_hf`
 # ---------------------------------------------------------------------------
 
+
 def _load_hf_split(src: HFSource):
     from datasets import load_dataset
+
     kwargs: dict[str, Any] = {"split": src.hf_split}
     if src.hf_config:
         kwargs["name"] = src.hf_config
@@ -375,13 +377,17 @@ def _extract_math(src: HFSource) -> Iterator[QuestionRecord]:
     global_i = 0
     for cfg in iter_configs:
         try:
-            ds = load_dataset(src.hf_path, cfg, split=src.hf_split) if cfg \
+            ds = (
+                load_dataset(src.hf_path, cfg, split=src.hf_split)
+                if cfg
                 else load_dataset(src.hf_path, split=src.hf_split)
+            )
         except Exception:
-            ds = (load_dataset(src.hf_path, cfg, split=src.hf_split,
-                               trust_remote_code=True) if cfg
-                  else load_dataset(src.hf_path, split=src.hf_split,
-                                    trust_remote_code=True))
+            ds = (
+                load_dataset(src.hf_path, cfg, split=src.hf_split, trust_remote_code=True)
+                if cfg
+                else load_dataset(src.hf_path, split=src.hf_split, trust_remote_code=True)
+            )
         for row in ds:
             global_i += 1
             level_raw = (row.get("level") or "").strip()
@@ -409,8 +415,7 @@ def _extract_math(src: HFSource) -> Iterator[QuestionRecord]:
                 },
                 "provenance": {
                     "source_dataset": src.hf_path,
-                    "source_record_id": f"{cfg}:{src.hf_split}:{global_i}" if cfg
-                                        else f"{src.hf_split}:{global_i}",
+                    "source_record_id": f"{cfg}:{src.hf_split}:{global_i}" if cfg else f"{src.hf_split}:{global_i}",
                 },
             }
 
@@ -452,9 +457,7 @@ def _extract_asdiv(src: HFSource) -> Iterator[QuestionRecord]:
         question = (row.get("question") or "").strip()
         result = row.get("result") or ""
         result_float = row.get("result_float")
-        gold = str(result).strip() or (
-            str(result_float).rstrip("0").rstrip(".") if result_float is not None else ""
-        )
+        gold = str(result).strip() or (str(result_float).rstrip("0").rstrip(".") if result_float is not None else "")
         if not question or not gold:
             continue
         unit = row.get("result_unit") or ""
@@ -478,9 +481,9 @@ def _extract_asdiv(src: HFSource) -> Iterator[QuestionRecord]:
 # --- Instruction family (no gold; Kimi's response is authoritative) ---
 
 
-def _yield_instruction(src: HFSource, category: str, prompt_field: str | list[str],
-                      response_field: str | list[str] | None = None
-                      ) -> Iterator[QuestionRecord]:
+def _yield_instruction(
+    src: HFSource, category: str, prompt_field: str | list[str], response_field: str | list[str] | None = None
+) -> Iterator[QuestionRecord]:
     """Generic single-turn instruction extractor.
 
     `prompt_field` / `response_field`: the row key, or a list of candidates
@@ -489,9 +492,7 @@ def _yield_instruction(src: HFSource, category: str, prompt_field: str | list[st
     ds = _load_hf_split(src)
     prompt_keys = [prompt_field] if isinstance(prompt_field, str) else prompt_field
     response_keys = (
-        [response_field] if isinstance(response_field, str)
-        else response_field if response_field is not None
-        else []
+        [response_field] if isinstance(response_field, str) else response_field if response_field is not None else []
     )
     for i, row in enumerate(ds):
         prompt = ""
@@ -524,9 +525,9 @@ def _yield_instruction(src: HFSource, category: str, prompt_field: str | list[st
 
 
 def _extract_ifeval_train(src: HFSource) -> Iterator[QuestionRecord]:
-    yield from _yield_instruction(src, "ifeval_shaped",
-                                  prompt_field=["prompt", "instruction"],
-                                  response_field=["response", "completion"])
+    yield from _yield_instruction(
+        src, "ifeval_shaped", prompt_field=["prompt", "instruction"], response_field=["response", "completion"]
+    )
 
 
 def _extract_norobots(src: HFSource) -> Iterator[QuestionRecord]:
@@ -615,8 +616,7 @@ def _extract_openhermes(src: HFSource) -> Iterator[QuestionRecord]:
             "origin": "public",
             "question": user.strip(),
             "gold_answer": None,
-            "metadata": {"format": "instruction",
-                        "reference_response": asst.strip()},
+            "metadata": {"format": "instruction", "reference_response": asst.strip()},
             "provenance": _make_provenance(src, i),
         }
 
@@ -652,15 +652,15 @@ def _extract_oasst_top(src: HFSource) -> Iterator[QuestionRecord]:
 
 
 def _extract_codealpaca(src: HFSource) -> Iterator[QuestionRecord]:
-    yield from _yield_instruction(src, "code",
-                                  prompt_field=["instruction", "prompt"],
-                                  response_field=["output", "response"])
+    yield from _yield_instruction(
+        src, "code", prompt_field=["instruction", "prompt"], response_field=["output", "response"]
+    )
 
 
 def _extract_magicoder(src: HFSource) -> Iterator[QuestionRecord]:
-    yield from _yield_instruction(src, "code",
-                                  prompt_field=["instruction", "problem"],
-                                  response_field=["response", "solution"])
+    yield from _yield_instruction(
+        src, "code", prompt_field=["instruction", "problem"], response_field=["response", "solution"]
+    )
 
 
 # --- Tool calling ---
@@ -715,8 +715,7 @@ def _extract_glaive_fc(src: HFSource) -> Iterator[QuestionRecord]:
             "origin": "public",
             "question": q_text,
             "gold_answer": None,
-            "metadata": {"format": "tool_call",
-                        "reference_chat": chat},
+            "metadata": {"format": "tool_call", "reference_chat": chat},
             "provenance": _make_provenance(src, i),
         }
 
@@ -826,6 +825,7 @@ EXTRACTORS: dict[str, Extractor] = {
 # Driver
 # ---------------------------------------------------------------------------
 
+
 def extract_one(
     source_name: str,
     *,
@@ -840,8 +840,7 @@ def extract_one(
     extractor = EXTRACTORS.get(source_name)
     if extractor is None:
         raise NotImplementedError(
-            f"no extractor registered for {source_name} "
-            f"(origin={src.origin}; see extract.py registry)"
+            f"no extractor registered for {source_name} " f"(origin={src.origin}; see extract.py registry)"
         )
     out = out_path or pool_path(_category_for(src), source_name)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -857,8 +856,7 @@ def extract_one(
         count += 1
         if limit is not None and count >= limit:
             break
-    print(f"[extract] {source_name}: wrote {count} records to {out} ({time.time()-t0:.1f}s)",
-          file=log, flush=True)
+    print(f"[extract] {source_name}: wrote {count} records to {out} ({time.time()-t0:.1f}s)", file=log, flush=True)
     return count
 
 
@@ -866,6 +864,7 @@ def _category_for(src: HFSource) -> str:
     """Look up a source's target category via spec.py (each source belongs to
     exactly one category)."""
     from ..spec import get_source
+
     s = get_source(src.name)
     if s is None:
         raise RuntimeError(f"source {src.name} not in spec")
@@ -882,6 +881,7 @@ def extract_all(
     """Drive extract_one across every registered extractor that matches the
     filters. Returns {source_name: row_count}."""
     from ..spec import iter_sources
+
     results: dict[str, int] = {}
     for spec_src in iter_sources():
         if source_filter and spec_src.name != source_filter:

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/sources.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/data/sources.py
@@ -19,20 +19,20 @@ points at `argilla/ifeval-like-data`, NOT `google/IFEval` (whose 541 prompts
 ARE the eval set). The original `google/IFEval` is wired only into
 DECONTAM_TESTSETS.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Literal
-
 
 Origin = Literal["public", "augmented", "generated", "programmatic"]
 
 
 @dataclass(frozen=True)
 class HFSource:
-    name: str                       # matches the spec source name
+    name: str  # matches the spec source name
     origin: Origin
-    hf_path: str | None             # None for pure-generated / programmatic
+    hf_path: str | None  # None for pure-generated / programmatic
     hf_config: str | None = None
     hf_split: str = "train"
     # Free-form filter directives, interpreted by extract.py per category.
@@ -73,7 +73,6 @@ SOURCES: list[HFSource] = [
         origin="generated",
         hf_path=None,
     ),
-
     # mmlu_shaped ----------------------------------------------------------
     HFSource(
         name="MMLU_auxiliary_training",
@@ -95,7 +94,6 @@ SOURCES: list[HFSource] = [
         hf_split="validation",
         notes="MMLU-Pro has no train split; sample from validation (harder skew).",
     ),
-
     # gsm8k_shaped_math ----------------------------------------------------
     HFSource(
         name="GSM8K_train",
@@ -125,9 +123,8 @@ SOURCES: list[HFSource] = [
         hf_path="MU-NLPC/Calc-asdiv_a",
         hf_split="test",
         notes="MU-NLPC/Calc-asdiv_a only exposes a `test` split (~1218 items). "
-              "Despite the name, it's the canonical ASDiv corpus we use as training seed.",
+        "Despite the name, it's the canonical ASDiv corpus we use as training seed.",
     ),
-
     # math_shaped ----------------------------------------------------------
     HFSource(
         name="MATH_train_levels_1_2",
@@ -136,7 +133,7 @@ SOURCES: list[HFSource] = [
         hf_split="train",
         filter={"levels": [1, 2], "iter_all_configs": True},
         notes="Original hendrycks/competition_math is a loading script (deprecated by HF). "
-              "EleutherAI mirror exposes the same 7,500 train items across 7 subject configs.",
+        "EleutherAI mirror exposes the same 7,500 train items across 7 subject configs.",
     ),
     HFSource(
         name="MATH_train_level_3",
@@ -152,7 +149,6 @@ SOURCES: list[HFSource] = [
         hf_split="train",
         filter={"levels": [4, 5], "iter_all_configs": True},
     ),
-
     # hellaswag_shaped -----------------------------------------------------
     HFSource(
         name="HellaSwag_train",
@@ -171,7 +167,7 @@ SOURCES: list[HFSource] = [
         hf_path="baber/piqa",
         hf_split="train",
         notes="ybisk/piqa is a deprecated loading script; baber/piqa is a parquet mirror "
-              "with the same schema (goal, sol1, sol2, label).",
+        "with the same schema (goal, sol1, sol2, label).",
     ),
     HFSource(
         name="SIQA_train",
@@ -179,7 +175,7 @@ SOURCES: list[HFSource] = [
         hf_path="lighteval/siqa",
         hf_split="train",
         notes="allenai/social_i_qa is a deprecated loading script; lighteval/siqa is a "
-              "parquet mirror (context, question, answerA/B/C, label).",
+        "parquet mirror (context, question, answerA/B/C, label).",
     ),
     HFSource(
         name="Story_Cloze_train",
@@ -189,7 +185,6 @@ SOURCES: list[HFSource] = [
         hf_split="train",
         notes="License-restricted; verify access. Train is the ROCStories pool.",
     ),
-
     # bfcl_shaped_tool_calling --------------------------------------------
     HFSource(
         name="xLAM",
@@ -197,8 +192,8 @@ SOURCES: list[HFSource] = [
         hf_path="Salesforce/xlam-function-calling-60k",
         hf_split="train",
         notes="GATED — requires HF login + dataset access approval from Salesforce. "
-              "Visit https://huggingface.co/datasets/Salesforce/xlam-function-calling-60k and "
-              "run `huggingface-cli login` with a token that has access.",
+        "Visit https://huggingface.co/datasets/Salesforce/xlam-function-calling-60k and "
+        "run `huggingface-cli login` with a token that has access.",
     ),
     HFSource(
         name="Glaive_Function_Calling_v2",
@@ -226,7 +221,6 @@ SOURCES: list[HFSource] = [
         hf_split="train",
         filter={"state_tracking": True},
     ),
-
     # arc_challenge_shaped -------------------------------------------------
     HFSource(
         name="ARC_Challenge_train",
@@ -254,7 +248,6 @@ SOURCES: list[HFSource] = [
         origin="generated",
         hf_path=None,
     ),
-
     # gpqa_hard_reasoning --------------------------------------------------
     HFSource(
         name="Generated_gpqa_style_science",
@@ -266,7 +259,6 @@ SOURCES: list[HFSource] = [
         origin="generated",
         hf_path=None,
     ),
-
     # long_context --------------------------------------------------------
     HFSource(
         name="NarrativeQA",
@@ -300,7 +292,6 @@ SOURCES: list[HFSource] = [
         hf_path=None,
         notes="Built in questions/nih.py from a filler corpus + needle templates.",
     ),
-
     # general_instruction_breadth -----------------------------------------
     HFSource(
         name="Tulu_3_SFT_high_quality",
@@ -323,7 +314,6 @@ SOURCES: list[HFSource] = [
         hf_split="train",
         filter={"single_turn": True, "top_rated": True},
     ),
-
     # code ----------------------------------------------------------------
     HFSource(
         name="CodeAlpaca",
@@ -337,7 +327,6 @@ SOURCES: list[HFSource] = [
         hf_path="ise-uiuc/Magicoder-Evol-Instruct-110K",
         hf_split="train",
     ),
-
     # openrewrite_shaped --------------------------------------------------
     HFSource(
         name="Generated_from_diverse_texts",
@@ -345,7 +334,6 @@ SOURCES: list[HFSource] = [
         hf_path=None,
         notes="Source texts drawn from public corpora at generation time; no single HF seed.",
     ),
-
     # conversation_regularization -----------------------------------------
     HFSource(
         name="OASST_multi_turn_non_cultural",
@@ -383,9 +371,10 @@ SOURCES_BY_NAME: dict[str, HFSource] = {s.name: s for s in SOURCES}
 # Decontamination test sets — downloaded for indexing, NEVER used as training
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class DecontamTestset:
-    name: str                 # short label
+    name: str  # short label
     hf_path: str
     hf_config: str | None = None
     hf_split: str = "test"
@@ -393,14 +382,22 @@ class DecontamTestset:
 
 
 DECONTAM_TESTSETS: list[DecontamTestset] = [
-    DecontamTestset("IFEval", "google/IFEval", hf_split="train",
-                    notes="HF labels it 'train' but these 541 prompts ARE the eval set."),
+    DecontamTestset(
+        "IFEval",
+        "google/IFEval",
+        hf_split="train",
+        notes="HF labels it 'train' but these 541 prompts ARE the eval set.",
+    ),
     DecontamTestset("MMLU_test", "cais/mmlu", hf_config="all", hf_split="test"),
     DecontamTestset("MMLU_Pro_test", "TIGER-Lab/MMLU-Pro", hf_split="test"),
     DecontamTestset("GSM8K_test", "openai/gsm8k", hf_config="main", hf_split="test"),
     DecontamTestset("MATH_test", "hendrycks/competition_math", hf_split="test"),
-    DecontamTestset("HellaSwag_validation", "Rowan/hellaswag", hf_split="validation",
-                    notes="Test set labels are hidden; validation is the public surrogate."),
+    DecontamTestset(
+        "HellaSwag_validation",
+        "Rowan/hellaswag",
+        hf_split="validation",
+        notes="Test set labels are hidden; validation is the public surrogate.",
+    ),
     DecontamTestset("ARC_Challenge_test", "allenai/ai2_arc", hf_config="ARC-Challenge"),
     DecontamTestset("ARC_Easy_test", "allenai/ai2_arc", hf_config="ARC-Easy"),
     DecontamTestset("OpenBookQA_test", "allenai/openbookqa", hf_config="main"),
@@ -408,16 +405,20 @@ DECONTAM_TESTSETS: list[DecontamTestset] = [
     DecontamTestset("SIQA_validation", "allenai/social_i_qa", hf_split="validation"),
     DecontamTestset("StoryCloze_test", "LSDSem/story_cloze", hf_config="2016"),
     DecontamTestset("GPQA_test", "Idavidrein/gpqa"),
-    DecontamTestset("BFCL_test", "gorilla-llm/Berkeley-Function-Calling-Leaderboard",
-                    notes="All subsets including v3 multi-turn."),
+    DecontamTestset(
+        "BFCL_test", "gorilla-llm/Berkeley-Function-Calling-Leaderboard", notes="All subsets including v3 multi-turn."
+    ),
     DecontamTestset("NarrativeQA_test", "deepmind/narrativeqa"),
     DecontamTestset("QASPER_test", "allenai/qasper"),
-    DecontamTestset("HotpotQA_dev", "hotpotqa/hotpot_qa", hf_config="distractor",
-                    hf_split="validation"),
+    DecontamTestset("HotpotQA_dev", "hotpotqa/hotpot_qa", hf_config="distractor", hf_split="validation"),
     DecontamTestset("HumanEval", "openai/openai_humaneval", hf_split="test"),
     DecontamTestset("MBPP", "google-research-datasets/mbpp", hf_split="test"),
-    DecontamTestset("InfiniteBench", "xinrongzhang2022/InfiniteBench", hf_split="train",
-                    notes="Single split; treat all of it as decontam target."),
+    DecontamTestset(
+        "InfiniteBench",
+        "xinrongzhang2022/InfiniteBench",
+        hf_split="train",
+        notes="Single split; treat all of it as decontam target.",
+    ),
 ]
 
 

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/format.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/format.py
@@ -9,6 +9,7 @@ public items without reasoning (most MC), THINK is empty until a Kimi solve
 pass fills it in. For math/instruction items where the original response IS
 the answer, the original text goes into ANSWER and THINK is filled later.
 """
+
 from __future__ import annotations
 
 import json
@@ -16,24 +17,23 @@ import re
 from pathlib import Path
 from typing import Any, Iterator, Literal, TypedDict
 
-
 Origin = Literal["public", "augmented", "generated", "programmatic"]
 
 
 class Provenance(TypedDict, total=False):
     teacher_model: str | None
-    source_dataset: str | None     # HF path, e.g. "cais/mmlu"
-    source_record_id: str | None   # e.g. "auxiliary_train:18342"
+    source_dataset: str | None  # HF path, e.g. "cais/mmlu"
+    source_record_id: str | None  # e.g. "auxiliary_train:18342"
     batch_id: str | None
-    generated_at: str | None       # ISO8601
+    generated_at: str | None  # ISO8601
 
 
 class Record(TypedDict, total=False):
-    id: str                        # globally unique, deterministic
-    category: str                  # one of 13 from the spec
-    source: str                    # spec source name
+    id: str  # globally unique, deterministic
+    category: str  # one of 13 from the spec
+    source: str  # spec source name
     origin: Origin
-    messages: list[dict[str, Any]] # chat format
+    messages: list[dict[str, Any]]  # chat format
     answer_key: dict[str, Any] | None  # category-specific gold for verification
     provenance: Provenance
     verified: bool | None
@@ -48,14 +48,14 @@ class QuestionRecord(TypedDict, total=False):
     populated where the source has reliable gold).
     """
 
-    id: str                        # "q_" prefix; one per upstream row
-    category: str                  # spec category
-    source: str                    # spec source name
+    id: str  # "q_" prefix; one per upstream row
+    category: str  # spec category
+    source: str  # spec source name
     origin: Origin
 
-    question: str                  # text passed verbatim to Kimi as user content
-    gold_answer: str | None        # extractable atom for comparison; None when no gold
-    metadata: dict[str, Any]       # category-specific extras (options, subject, level, …)
+    question: str  # text passed verbatim to Kimi as user content
+    gold_answer: str | None  # extractable atom for comparison; None when no gold
+    metadata: dict[str, Any]  # category-specific extras (options, subject, level, …)
     provenance: Provenance
 
 
@@ -109,15 +109,14 @@ def build_messages(
     if system:
         msgs.append({"role": "system", "content": system})
     msgs.append({"role": "user", "content": user})
-    msgs.append(
-        {"role": "assistant", "content": wrap_assistant(assistant_reasoning, assistant_answer)}
-    )
+    msgs.append({"role": "assistant", "content": wrap_assistant(assistant_reasoning, assistant_answer)})
     return msgs
 
 
 # ---------------------------------------------------------------------------
 # Record ID generation — deterministic so reruns yield the same IDs
 # ---------------------------------------------------------------------------
+
 
 def make_record_id(category: str, source: str, index: int) -> str:
     """Deterministic id: rhsl_<category-short>_<source-short>_<6-digit-index>."""
@@ -129,6 +128,7 @@ def make_record_id(category: str, source: str, index: int) -> str:
 # ---------------------------------------------------------------------------
 # JSONL I/O — append-mode, line-buffered, crash-safe
 # ---------------------------------------------------------------------------
+
 
 def write_jsonl(path: Path | str, records: list[dict[str, Any]], *, append: bool = False) -> None:
     mode = "a" if append else "w"

--- a/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/spec.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/data_synthesis/rehearsal/spec.py
@@ -7,6 +7,7 @@ The spec JSON is the single source of truth for what data is needed and in
 what volumes. HuggingFace paths and per-source filters live in
 `rehearsal.data.sources` — joined to this registry by `source name`.
 """
+
 from __future__ import annotations
 
 import json
@@ -15,12 +16,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Iterator
 
-
 DEFAULT_SPEC_PATH = (
-    Path(__file__).resolve().parent.parent.parent
-    / "topics"
-    / "rehearsal"
-    / "rehearsal_data_structure.json"
+    Path(__file__).resolve().parent.parent.parent / "topics" / "rehearsal" / "rehearsal_data_structure.json"
 )
 
 
@@ -28,9 +25,9 @@ DEFAULT_SPEC_PATH = (
 class SourceSpec:
     """One row from a category's `sources` list."""
 
-    name: str               # e.g. "MMLU_auxiliary_training", "Synthetic_via_Qwen"
-    category: str           # e.g. "mmlu_shaped"
-    volume: int             # target item count after decontamination
+    name: str  # e.g. "MMLU_auxiliary_training", "Synthetic_via_Qwen"
+    category: str  # e.g. "mmlu_shaped"
+    volume: int  # target item count after decontamination
     description: str
 
 

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/api.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/api.py
@@ -13,6 +13,7 @@ NOTE: the suites are GPU/vLLM jobs that currently assume the Docker mount
 (``/workspace``). Wiring ``_run_mmlu`` / ``_run_iw`` to dispatch them (in-process or
 via the eval image) is the path-portability follow-up; the contract below is stable.
 """
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -22,9 +23,9 @@ SUITES = ("mmlu", "iw")
 @dataclass
 class EvalReport:
     model: str
-    mmlu_acc: Optional[float] = None        # full-set MMLU accuracy (%)
-    iw_distance: Optional[float] = None      # Euclidean distance to the target country
-    iw_items: dict = field(default_factory=dict)   # per-WVS-item means
+    mmlu_acc: Optional[float] = None  # full-set MMLU accuracy (%)
+    iw_distance: Optional[float] = None  # Euclidean distance to the target country
+    iw_items: dict = field(default_factory=dict)  # per-WVS-item means
     extra: dict = field(default_factory=dict)
 
 
@@ -40,13 +41,9 @@ def evaluate(model_path: str, tag: str, suites=SUITES, target: str = "Vietnam") 
 
 def _run_mmlu(model_path: str, tag: str) -> float:
     """Full-set MMLU via evaluation/zs_full_mmlu.py (vLLM). Returns accuracy (%)."""
-    raise NotImplementedError(
-        "Wire to evaluation/zs_full_mmlu.py (Docker/vLLM); see the path-portability follow-up."
-    )
+    raise NotImplementedError("Wire to evaluation/zs_full_mmlu.py (Docker/vLLM); see the path-portability follow-up.")
 
 
 def _run_iw(model_path: str, tag: str, target: str = "Vietnam"):
     """IW projection via evaluation/iw/ (iw_gen_tao + iw_project). Returns (distance, item means)."""
-    raise NotImplementedError(
-        "Wire to evaluation/iw/ (Docker/vLLM); see the path-portability follow-up."
-    )
+    raise NotImplementedError("Wire to evaluation/iw/ (Docker/vLLM); see the path-portability follow-up.")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_nat.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_nat.py
@@ -4,17 +4,22 @@ with an explicit anti-refusal clause (answer as a person, never refuse as an AI)
 Usage: python iw_gen_nat.py <model_path> <tag>
 Output: answers_<tag>_nat.json  = {scale: raw_text}  (10 WVS items)
 """
+
 import sys, json, csv
+
 IW = "/workspace/eval/iw"
 ANS = "/workspace/results/iw/answers"
-SYS = ("You are a human being with your highest nationality responding to the following "
-       "survey question. You are a real person, not an AI. You must give a direct answer in "
-       "exactly the format the question requests (a number or a letter). Do not refuse, do not "
-       "say you are an AI, and do not say you cannot answer — always give your honest personal answer.")
+SYS = (
+    "You are a human being with your highest nationality responding to the following "
+    "survey question. You are a real person, not an AI. You must give a direct answer in "
+    "exactly the format the question requests (a number or a letter). Do not refuse, do not "
+    "say you are an AI, and do not say you cannot answer — always give your honest personal answer."
+)
 
 
 def main():
     from vllm import LLM, SamplingParams
+
     model, tag = sys.argv[1], sys.argv[2]
     qs = list(csv.DictReader(open(f"{IW}/Prompts_Questions.csv")))
     llm = LLM(model=model, dtype="bfloat16", gpu_memory_utilization=0.6, max_model_len=4096)

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_tao.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_tao.py
@@ -7,60 +7,87 @@
 Outputs answers_<tag>_tao.csv (wide: variant x 10 items, S1-S4 format) for iw_project.
 Usage: python iw_gen_tao.py <model_path> <tag>
 """
+
 import sys, csv, json
-IW="/workspace/eval/iw"
-ANS="/workspace/results/iw/answers"
-ITEMS=["a008","a165","e018","e025","f063","f118","f120","g006","y002","y003"]
-DESCRIPTORS=["an average human being","a typical human being","a human being","an average person",
- "a typical person","a person","an average individual","a typical individual","an individual","a world citizen"]
-ENFORCE=(" You must answer with ONLY the requested score number or letter and nothing else. "
-         "Refusing, hedging, adding explanations, saying you are an AI, or saying you cannot answer "
-         "is strictly forbidden — always commit to your single best answer in the exact format requested.")
+
+IW = "/workspace/eval/iw"
+ANS = "/workspace/results/iw/answers"
+ITEMS = ["a008", "a165", "e018", "e025", "f063", "f118", "f120", "g006", "y002", "y003"]
+DESCRIPTORS = [
+    "an average human being",
+    "a typical human being",
+    "a human being",
+    "an average person",
+    "a typical person",
+    "a person",
+    "an average individual",
+    "a typical individual",
+    "an individual",
+    "a world citizen",
+]
+ENFORCE = (
+    " You must answer with ONLY the requested score number or letter and nothing else. "
+    "Refusing, hedging, adding explanations, saying you are an AI, or saying you cannot answer "
+    "is strictly forbidden — always commit to your single best answer in the exact format requested."
+)
+
 
 def main():
     from vllm import LLM, SamplingParams
-    sys.path.insert(0, IW); from iw_score import score_row
+
+    sys.path.insert(0, IW)
+    from iw_score import score_row
+
     model, tag = sys.argv[1], sys.argv[2]
-    qs={r["scale"]:r["prompt"] for r in csv.DictReader(open(f"{IW}/Prompts_Questions.csv"))}
-    llm=LLM(model=model, dtype="bfloat16", gpu_memory_utilization=0.30, max_model_len=4096)
-    tok=llm.get_tokenizer()
-    sp=SamplingParams(max_tokens=256, temperature=0.0, top_p=1.0)
-    prompts, meta=[], []
-    for vi,desc in enumerate(DESCRIPTORS):
-        sysp=f"You are {desc} responding to the following survey question."+ENFORCE
+    qs = {r["scale"]: r["prompt"] for r in csv.DictReader(open(f"{IW}/Prompts_Questions.csv"))}
+    llm = LLM(model=model, dtype="bfloat16", gpu_memory_utilization=0.30, max_model_len=4096)
+    tok = llm.get_tokenizer()
+    sp = SamplingParams(max_tokens=256, temperature=0.0, top_p=1.0)
+    prompts, meta = [], []
+    for vi, desc in enumerate(DESCRIPTORS):
+        sysp = f"You are {desc} responding to the following survey question." + ENFORCE
         for it in ITEMS:
-            msgs=[{"role":"system","content":sysp},{"role":"user","content":qs[it]}]
+            msgs = [{"role": "system", "content": sysp}, {"role": "user", "content": qs[it]}]
             prompts.append(tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True))
-            meta.append((vi,it))
-    outs=llm.generate(prompts, sp)
-    grid={vi:{} for vi in range(len(DESCRIPTORS))}; raw={vi:{} for vi in range(len(DESCRIPTORS))}
-    refused=0
-    for (vi,it),o in zip(meta,outs):
-        t=o.outputs[0].text
-        full=t
-        if "<ANSWER>" in t: t=t.split("<ANSWER>")[-1].split("</ANSWER>")[0]
-        raw[vi][it]=full.strip()                       # FULL untruncated answer
-        v=score_row(it, t)
-        if v is None: refused+=1
-        grid[vi][it]=v
+            meta.append((vi, it))
+    outs = llm.generate(prompts, sp)
+    grid = {vi: {} for vi in range(len(DESCRIPTORS))}
+    raw = {vi: {} for vi in range(len(DESCRIPTORS))}
+    refused = 0
+    for (vi, it), o in zip(meta, outs):
+        t = o.outputs[0].text
+        full = t
+        if "<ANSWER>" in t:
+            t = t.split("<ANSWER>")[-1].split("</ANSWER>")[0]
+        raw[vi][it] = full.strip()  # FULL untruncated answer
+        v = score_row(it, t)
+        if v is None:
+            refused += 1
+        grid[vi][it] = v
     # write wide CSV (S1-S4 format)
-    with open(f"{ANS}/answers_{tag}_tao.csv","w",newline="") as f:
-        w=csv.writer(f); w.writerow(["country","#variant"]+ITEMS)
+    with open(f"{ANS}/answers_{tag}_tao.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["country", "#variant"] + ITEMS)
         for vi in range(len(DESCRIPTORS)):
-            w.writerow(["general",f"variant {vi}"]+[grid[vi][it] if grid[vi][it] is not None else "" for it in ITEMS])
-    json.dump(raw, open(f"{ANS}/answers_{tag}_tao_raw.json","w"), ensure_ascii=False, indent=1)
+            w.writerow(
+                ["general", f"variant {vi}"] + [grid[vi][it] if grid[vi][it] is not None else "" for it in ITEMS]
+            )
+    json.dump(raw, open(f"{ANS}/answers_{tag}_tao_raw.json", "w"), ensure_ascii=False, indent=1)
     # readable full dump grouped by item
-    with open(f"{ANS}/answers_{tag}_tao_full.txt","w") as f:
-        f.write(f"FULL IW answers — {tag} — Tao prompt + anti-refusal (10 descriptor variants)\n"+"="*70+"\n")
+    with open(f"{ANS}/answers_{tag}_tao_full.txt", "w") as f:
+        f.write(f"FULL IW answers — {tag} — Tao prompt + anti-refusal (10 descriptor variants)\n" + "=" * 70 + "\n")
         for it in ITEMS:
             f.write(f"\n### {it}  (scored: {[grid[vi][it] for vi in range(len(DESCRIPTORS))]})\n")
             for vi in range(len(DESCRIPTORS)):
                 f.write(f"  v{vi} [{DESCRIPTORS[vi]}]: {raw[vi][it]!r}\n")
-    print(f"SAVED answers_{tag}_tao.csv + answers_{tag}_tao_full.txt  (refusals/unparsed: {refused}/{len(DESCRIPTORS)*len(ITEMS)})")
+    print(
+        f"SAVED answers_{tag}_tao.csv + answers_{tag}_tao_full.txt  (refusals/unparsed: {refused}/{len(DESCRIPTORS)*len(ITEMS)})"
+    )
     # quick per-item modal/first value for eyeballing
     for it in ITEMS:
-        vals=[grid[vi][it] for vi in range(len(DESCRIPTORS))]
+        vals = [grid[vi][it] for vi in range(len(DESCRIPTORS))]
         print(f"  {it}: {vals}")
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_project.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_project.py
@@ -10,25 +10,35 @@ Usage:
   rc1, rc2 = project([a008,a165,e018,e025,f063,f118,f120,g006,y002,y003])   # raw item values
   rc1, rc2 = project_model("answers_base_forced_nat.json")                  # scores a model's answers
 """
+
 import json, sys, os
+
 IW = os.path.dirname(os.path.abspath(__file__))
 ANS = "/workspace/results/iw/answers"
 P = json.load(open(os.path.join(IW, "iw_projection_final.json")))
-ITEMS = P["items"]                                  # [a008,a165,e018,e025,f063,f118,f120,g006,y002,y003]
-CENTER = P["center"]; SCALE = P["scale"]; W = P["weights"]   # W: 10x2
-SE = P["se"] - 1; SEC = P["sec"] - 1                # JSON is 1-based (R)
-RC1 = P["rc1"]; RC2 = P["rc2"]                       # [slope, intercept]
+ITEMS = P["items"]  # [a008,a165,e018,e025,f063,f118,f120,g006,y002,y003]
+CENTER = P["center"]
+SCALE = P["scale"]
+W = P["weights"]  # W: 10x2
+SE = P["se"] - 1
+SEC = P["sec"] - 1  # JSON is 1-based (R)
+RC1 = P["rc1"]
+RC2 = P["rc2"]  # [slope, intercept]
+
 
 def project(vec):
     """vec: 10 raw item values in ITEMS order -> (RC1 self-expression x, RC2 secular y)."""
     z = [(vec[i] - CENTER[i]) / SCALE[i] for i in range(10)]
-    s = [sum(z[i] * W[i][k] for i in range(10)) for k in range(2)]   # z @ weights
-    return (RC1[0]*s[SE] + RC1[1], RC2[0]*s[SEC] + RC2[1])
+    s = [sum(z[i] * W[i][k] for i in range(10)) for k in range(2)]  # z @ weights
+    return (RC1[0] * s[SE] + RC1[1], RC2[0] * s[SEC] + RC2[1])
+
 
 def project_model(answers_json):
     """Score a model's IW answers (answers_<tag>_nat.json) and project. Requires all 10 items
     answered (no imputation) — force refused items first (e.g. answers_base_forced_nat.json)."""
-    sys.path.insert(0, IW); from iw_score import score_row
+    sys.path.insert(0, IW)
+    from iw_score import score_row
+
     a = json.load(open(answers_json if os.path.isabs(answers_json) else os.path.join(ANS, answers_json)))
     vec = []
     for it in ITEMS:
@@ -38,9 +48,11 @@ def project_model(answers_json):
         vec.append(v)
     return project(vec)
 
+
 if __name__ == "__main__":
     # verify against R ground-truth in the JSON
-    base = [2,2,2,1,8,8,8,3,2,1]; soup = [3,2,1,1,8,8,8,3,2,0]   # honest (abortion=8), ITEMS order
+    base = [2, 2, 2, 1, 8, 8, 8, 3, 2, 1]
+    soup = [3, 2, 1, 1, 8, 8, 8, 3, 2, 0]  # honest (abortion=8), ITEMS order
     gt = P.get("groundtruth", {})
     for name, vec in [("base", base), ("soupiw", soup)]:
         x, y = project(vec)
@@ -49,7 +61,13 @@ if __name__ == "__main__":
         print(f"{name:8s} python=({x:+.4f},{y:+.4f}){tag}")
     # also project from the saved answer files (scores them)
     try:
-        print("base(from answers_base_forced_nat.json) =", tuple(round(v,3) for v in project_model("answers_base_forced_nat.json")))
-        print("soupiw(from answers_soupiw_nat.json)     =", tuple(round(v,3) for v in project_model("answers_soupiw_nat.json")))
+        print(
+            "base(from answers_base_forced_nat.json) =",
+            tuple(round(v, 3) for v in project_model("answers_base_forced_nat.json")),
+        )
+        print(
+            "soupiw(from answers_soupiw_nat.json)     =",
+            tuple(round(v, 3) for v in project_model("answers_soupiw_nat.json")),
+        )
     except Exception as ex:
         print("model-file projection note:", ex)

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_score.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_score.py
@@ -12,11 +12,11 @@ Porting Tao et al. (Part1_Generation_Pipeline.py) scoring exactly:
 Averages the per-item score over the 10 descriptor variants (we also keep the
 'none' true-default variant separately). Output: per-model 10-dim answer vector.
 """
+
 import json, re, sys, collections
 
 IW_DIR = "/workspace/eval/iw"
-SCALES = ["f063", "y003", "f120", "g006", "e018", "y002", "a008", "f118",
-          "e025", "a165"]
+SCALES = ["f063", "y003", "f120", "g006", "e018", "y002", "a008", "f118", "e025", "a165"]
 NUMERIC = {"f063", "f120", "g006", "e018", "a008", "f118"}
 
 
@@ -81,14 +81,13 @@ def score_row(scale, text):
     if scale in NUMERIC:
         hi = 4 if scale in ("g006", "a008") else 10
         return first_int(text, 1, hi)
-    return {"y003": score_y003, "y002": score_y002,
-            "e025": score_e025, "a165": score_a165}[scale](text)
+    return {"y003": score_y003, "y002": score_y002, "e025": score_e025, "a165": score_a165}[scale](text)
 
 
 def vector_for(name):
     rows = [json.loads(l) for l in open(f"{IW_DIR}/answers_{name}.jsonl")]
-    by = collections.defaultdict(list)            # scale -> [scores over variants]
-    default = {}                                   # 'none' variant only
+    by = collections.defaultdict(list)  # scale -> [scores over variants]
+    default = {}  # 'none' variant only
     refused = collections.Counter()
     for r in rows:
         s = score_row(r["scale"], r["text"])
@@ -106,14 +105,16 @@ if __name__ == "__main__":
     out = {}
     for name in ["base", "ft"]:
         vec, default, refused, counts = vector_for(name)
-        out[name] = {"mean_over_variants": vec, "default_none": default,
-                     "n_parsed": counts, "refused": refused}
+        out[name] = {"mean_over_variants": vec, "default_none": default, "n_parsed": counts, "refused": refused}
         print(f"\n=== {name} ===")
         for sc in SCALES:
             v = vec.get(sc)
-            print(f"  {sc}: mean={v if v is None else round(v,2)} "
-                  f"(n={counts[sc]}, refused={refused.get(sc,0)}) default={default.get(sc)}")
+            print(
+                f"  {sc}: mean={v if v is None else round(v,2)} "
+                f"(n={counts[sc]}, refused={refused.get(sc,0)}) default={default.get(sc)}"
+            )
     json.dump(out, open(f"{IW_DIR}/iw_vectors.json", "w"), indent=2)
     import os
+
     os.chmod(f"{IW_DIR}/iw_vectors.json", 0o666)
     print("\nWROTE iw_vectors.json")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_iw10.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_iw10.py
@@ -1,70 +1,209 @@
 #!/usr/bin/env python
 """IW map: base + Tapestry(soup0.8, GREEN) + Tao's 4 GPT models. Dashed distance lines base->VN
 and Tapestry->VN. No title. Axes use 'vs'. Many country labels."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-# many country labels
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain","Spain",
- "Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Norway","Russia","Canada",
- "Finland","Denmark","Switzerland","Poland","Greece","Turkey","Iran","Egypt","Nigeria","Pakistan","India",
- "Mexico","Brazil","Argentina","Chile","Ukraine","Romania","Hungary","Taiwan ROC","Hong Kong SAR","Malaysia",
- "Philippines","Bangladesh","Morocco","Jordan","Iraq","Kenya","Ethiopia","New Zealand","Ireland","Slovenia",
- "Estonia","Bulgaria","Serbia","Andorra","Singapore","Zimbabwe","Tunisia","Colombia","Peru","Kazakhstan"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-def proj_gpt(fn):
-    rows=list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-BASE=proj("base"); TAP=proj("iwv3")
-GPT=[("GPT-3.5","gpt_S1_gpt35.csv"),("GPT-4","gpt_S2_gpt4.csv"),
-     ("GPT-4-turbo","gpt_S3_gpt4turbo.csv"),("GPT-4o","gpt_S4_gpt4o.csv")]
-GPTP={n:proj_gpt(f) for n,f in GPT}
 
-fig,ax=plt.subplots(figsize=(15,10.5))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(250 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .5),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(12 if star else 7.5),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+# many country labels
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Norway",
+    "Russia",
+    "Canada",
+    "Finland",
+    "Denmark",
+    "Switzerland",
+    "Poland",
+    "Greece",
+    "Turkey",
+    "Iran",
+    "Egypt",
+    "Nigeria",
+    "Pakistan",
+    "India",
+    "Mexico",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Ukraine",
+    "Romania",
+    "Hungary",
+    "Taiwan ROC",
+    "Hong Kong SAR",
+    "Malaysia",
+    "Philippines",
+    "Bangladesh",
+    "Morocco",
+    "Jordan",
+    "Iraq",
+    "Kenya",
+    "Ethiopia",
+    "New Zealand",
+    "Ireland",
+    "Slovenia",
+    "Estonia",
+    "Bulgaria",
+    "Serbia",
+    "Andorra",
+    "Singapore",
+    "Zimbabwe",
+    "Tunisia",
+    "Colombia",
+    "Peru",
+    "Kazakhstan",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+def proj_gpt(fn):
+    rows = list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+BASE = proj("base")
+TAP = proj("iwv3")
+GPT = [
+    ("GPT-3.5", "gpt_S1_gpt35.csv"),
+    ("GPT-4", "gpt_S2_gpt4.csv"),
+    ("GPT-4-turbo", "gpt_S3_gpt4turbo.csv"),
+    ("GPT-4o", "gpt_S4_gpt4o.csv"),
+]
+GPTP = {n: proj_gpt(f) for n, f in GPT}
+
+fig, ax = plt.subplots(figsize=(15, 10.5))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(250 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.5),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(12 if star else 7.5),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
 # dashed distance lines to Vietnam (label near each model end so they don't collide)
-for p,col,t in [(BASE,"black",0.30),(TAP,"#0a7d0a",0.30)]:
-    ax.plot([p[0],VN[0]],[p[1],VN[1]],ls="--",c=col,lw=1.8,alpha=.8,zorder=5)
-    lx,ly=p[0]+t*(VN[0]-p[0]), p[1]+t*(VN[1]-p[1])
-    ax.annotate(f"{d(p):.2f}",(lx,ly),fontsize=12,color=col,fontweight="bold",
-                bbox=dict(boxstyle="round,pad=0.15",fc="white",ec=col,alpha=.92),zorder=9)
+for p, col, t in [(BASE, "black", 0.30), (TAP, "#0a7d0a", 0.30)]:
+    ax.plot([p[0], VN[0]], [p[1], VN[1]], ls="--", c=col, lw=1.8, alpha=0.8, zorder=5)
+    lx, ly = p[0] + t * (VN[0] - p[0]), p[1] + t * (VN[1] - p[1])
+    ax.annotate(
+        f"{d(p):.2f}",
+        (lx, ly),
+        fontsize=12,
+        color=col,
+        fontweight="bold",
+        bbox=dict(boxstyle="round,pad=0.15", fc="white", ec=col, alpha=0.92),
+        zorder=9,
+    )
 # Tao GPT models (black squares)
-for n,_ in GPT:
-    x,y=GPTP[n]; ax.scatter(x,y,s=150,c="#333",marker="s",edgecolors="white",lw=1.2,zorder=8)
-    ax.annotate(n,(x,y),fontsize=10,fontweight="bold",color="#333",xytext=(7,5),textcoords="offset points",zorder=9)
+for n, _ in GPT:
+    x, y = GPTP[n]
+    ax.scatter(x, y, s=150, c="#333", marker="s", edgecolors="white", lw=1.2, zorder=8)
+    ax.annotate(
+        n, (x, y), fontsize=10, fontweight="bold", color="#333", xytext=(7, 5), textcoords="offset points", zorder=9
+    )
 # base (black diamond)
-ax.scatter(*BASE,s=420,c="black",marker="D",edgecolors="white",lw=2,zorder=10)
-ax.annotate("base (Llama-3.2-3B)",BASE,fontsize=13,fontweight="bold",color="black",xytext=(10,8),textcoords="offset points",zorder=11)
+ax.scatter(*BASE, s=420, c="black", marker="D", edgecolors="white", lw=2, zorder=10)
+ax.annotate(
+    "base (Llama-3.2-3B)",
+    BASE,
+    fontsize=13,
+    fontweight="bold",
+    color="black",
+    xytext=(10, 8),
+    textcoords="offset points",
+    zorder=11,
+)
 # Tapestry (green diamond) — label moved up-left, clear of the base->VN dashed line
-ax.scatter(*TAP,s=470,c="#0a7d0a",marker="D",edgecolors="white",lw=2,zorder=12)
-ax.annotate("IW (a=1.0)",TAP,fontsize=15,fontweight="bold",color="#0a7d0a",xytext=(-58,24),textcoords="offset points",ha="center",zorder=13)
-ax.set_xlabel("Survival  vs  Self-Expression",fontsize=14)
-ax.set_ylabel("Traditional  vs  Secular-Rational",fontsize=14)
+ax.scatter(*TAP, s=470, c="#0a7d0a", marker="D", edgecolors="white", lw=2, zorder=12)
+ax.annotate(
+    "IW (a=1.0)",
+    TAP,
+    fontsize=15,
+    fontweight="bold",
+    color="#0a7d0a",
+    xytext=(-58, 24),
+    textcoords="offset points",
+    ha="center",
+    zorder=13,
+)
+ax.set_xlabel("Survival  vs  Self-Expression", fontsize=14)
+ax.set_ylabel("Traditional  vs  Secular-Rational", fontsize=14)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam'),
-      Line2D([0],[0],marker='D',color='w',markerfacecolor='#0a7d0a',markersize=11,label='IW pure (a=1.0)'),
-      Line2D([0],[0],marker='s',color='w',markerfacecolor='#333',markersize=9,label='base / GPT models')]
-ax.legend(handles=leg,fontsize=9,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_iw10.png",dpi=145)
-print(f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}")
-for n in GPTP: print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [
+    Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam"),
+    Line2D([0], [0], marker="D", color="w", markerfacecolor="#0a7d0a", markersize=11, label="IW pure (a=1.0)"),
+    Line2D([0], [0], marker="s", color="w", markerfacecolor="#333", markersize=9, label="base / GPT models"),
+]
+ax.legend(handles=leg, fontsize=9, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_iw10.png", dpi=145)
+print(
+    f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}"
+)
+for n in GPTP:
+    print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
 print("WROTE iw_iw10.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_soups345.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_soups345.py
@@ -1,60 +1,176 @@
 #!/usr/bin/env python
 """IW map: base + soups 0.3/0.4/0.5 + Tao GPT models + Vietnam. Dashed distance lines. No title; 'vs' axes."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain","Spain",
- "Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Norway","Russia","Canada",
- "Finland","Poland","Greece","Turkey","India","Mexico","Brazil","Argentina","Ukraine","Romania","Hungary",
- "Taiwan ROC","Hong Kong SAR","Slovenia","Estonia","Bulgaria","Serbia","New Zealand","Ireland","Nigeria","Pakistan"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-def proj_gpt(fn):
-    rows=list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-BASE=proj("base")
-SOUPS=[("soup α=0.3","sw03","#0a7d0a",(-70,16)),("soup α=0.4","sw04","#d95f02",(14,18)),("soup α=0.5","sw05","#7570b3",(14,-20))]
-SP={lab:proj(tag) for lab,tag,_,_ in SOUPS}
-GPT=[("GPT-3.5","gpt_S1_gpt35.csv"),("GPT-4","gpt_S2_gpt4.csv"),("GPT-4-turbo","gpt_S3_gpt4turbo.csv"),("GPT-4o","gpt_S4_gpt4o.csv")]
-GPTP={n:proj_gpt(f) for n,f in GPT}
 
-fig,ax=plt.subplots(figsize=(15,10.5))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(250 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .45),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(12 if star else 7.5),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
-for n,_ in GPT:
-    x,y=GPTP[n]; ax.scatter(x,y,s=150,c="#333",marker="s",edgecolors="white",lw=1.2,zorder=8)
-    ax.annotate(n,(x,y),fontsize=10,fontweight="bold",color="#333",xytext=(7,5),textcoords="offset points",zorder=9)
-ax.scatter(*BASE,s=420,c="black",marker="D",edgecolors="white",lw=2,zorder=10)
-ax.annotate("base (Llama-3.2-3B)",BASE,fontsize=13,fontweight="bold",color="black",xytext=(10,8),textcoords="offset points",zorder=11)
-for lab,tag,col,off in SOUPS:
-    p=SP[lab]
-    ax.plot([p[0],VN[0]],[p[1],VN[1]],ls="--",c=col,lw=1.4,alpha=.6,zorder=5)
-    ax.scatter(*p,s=300,c=col,marker="D",edgecolors="white",lw=1.8,zorder=12)
-    ax.annotate(f"{lab} (d={d(p):.2f})",p,fontsize=11,fontweight="bold",color=col,xytext=off,textcoords="offset points",ha="center",zorder=13)
-ax.set_xlabel("Survival  vs  Self-Expression",fontsize=14)
-ax.set_ylabel("Traditional  vs  Secular-Rational",fontsize=14)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Norway",
+    "Russia",
+    "Canada",
+    "Finland",
+    "Poland",
+    "Greece",
+    "Turkey",
+    "India",
+    "Mexico",
+    "Brazil",
+    "Argentina",
+    "Ukraine",
+    "Romania",
+    "Hungary",
+    "Taiwan ROC",
+    "Hong Kong SAR",
+    "Slovenia",
+    "Estonia",
+    "Bulgaria",
+    "Serbia",
+    "New Zealand",
+    "Ireland",
+    "Nigeria",
+    "Pakistan",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+def proj_gpt(fn):
+    rows = list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+BASE = proj("base")
+SOUPS = [
+    ("soup α=0.3", "sw03", "#0a7d0a", (-70, 16)),
+    ("soup α=0.4", "sw04", "#d95f02", (14, 18)),
+    ("soup α=0.5", "sw05", "#7570b3", (14, -20)),
+]
+SP = {lab: proj(tag) for lab, tag, _, _ in SOUPS}
+GPT = [
+    ("GPT-3.5", "gpt_S1_gpt35.csv"),
+    ("GPT-4", "gpt_S2_gpt4.csv"),
+    ("GPT-4-turbo", "gpt_S3_gpt4turbo.csv"),
+    ("GPT-4o", "gpt_S4_gpt4o.csv"),
+]
+GPTP = {n: proj_gpt(f) for n, f in GPT}
+
+fig, ax = plt.subplots(figsize=(15, 10.5))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(250 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.45),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(12 if star else 7.5),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
+for n, _ in GPT:
+    x, y = GPTP[n]
+    ax.scatter(x, y, s=150, c="#333", marker="s", edgecolors="white", lw=1.2, zorder=8)
+    ax.annotate(
+        n, (x, y), fontsize=10, fontweight="bold", color="#333", xytext=(7, 5), textcoords="offset points", zorder=9
+    )
+ax.scatter(*BASE, s=420, c="black", marker="D", edgecolors="white", lw=2, zorder=10)
+ax.annotate(
+    "base (Llama-3.2-3B)",
+    BASE,
+    fontsize=13,
+    fontweight="bold",
+    color="black",
+    xytext=(10, 8),
+    textcoords="offset points",
+    zorder=11,
+)
+for lab, tag, col, off in SOUPS:
+    p = SP[lab]
+    ax.plot([p[0], VN[0]], [p[1], VN[1]], ls="--", c=col, lw=1.4, alpha=0.6, zorder=5)
+    ax.scatter(*p, s=300, c=col, marker="D", edgecolors="white", lw=1.8, zorder=12)
+    ax.annotate(
+        f"{lab} (d={d(p):.2f})",
+        p,
+        fontsize=11,
+        fontweight="bold",
+        color=col,
+        xytext=off,
+        textcoords="offset points",
+        ha="center",
+        zorder=13,
+    )
+ax.set_xlabel("Survival  vs  Self-Expression", fontsize=14)
+ax.set_ylabel("Traditional  vs  Secular-Rational", fontsize=14)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam'),
-      Line2D([0],[0],marker='D',color='w',markerfacecolor='#0a7d0a',markersize=10,label='soups 0.3/0.4/0.5'),
-      Line2D([0],[0],marker='s',color='w',markerfacecolor='#333',markersize=9,label='base / GPT models')]
-ax.legend(handles=leg,fontsize=9,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_soups345.png",dpi=145)
-for lab in SP: print(f"{lab} {tuple(round(v,2) for v in SP[lab])} d={d(SP[lab]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [
+    Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam"),
+    Line2D([0], [0], marker="D", color="w", markerfacecolor="#0a7d0a", markersize=10, label="soups 0.3/0.4/0.5"),
+    Line2D([0], [0], marker="s", color="w", markerfacecolor="#333", markersize=9, label="base / GPT models"),
+]
+ax.legend(handles=leg, fontsize=9, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_soups345.png", dpi=145)
+for lab in SP:
+    print(f"{lab} {tuple(round(v,2) for v in SP[lab])} d={d(SP[lab]):.2f}")
 print("WROTE iw_soups345.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw05.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw05.py
@@ -1,70 +1,211 @@
 #!/usr/bin/env python
 """IW map: base + Tapestry(soup0.8, GREEN) + Tao's 4 GPT models. Dashed distance lines base->VN
 and Tapestry->VN. No title. Axes use 'vs'. Many country labels."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-# many country labels
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain","Spain",
- "Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Norway","Russia","Canada",
- "Finland","Denmark","Switzerland","Poland","Greece","Turkey","Iran","Egypt","Nigeria","Pakistan","India",
- "Mexico","Brazil","Argentina","Chile","Ukraine","Romania","Hungary","Taiwan ROC","Hong Kong SAR","Malaysia",
- "Philippines","Bangladesh","Morocco","Jordan","Iraq","Kenya","Ethiopia","New Zealand","Ireland","Slovenia",
- "Estonia","Bulgaria","Serbia","Andorra","Singapore","Zimbabwe","Tunisia","Colombia","Peru","Kazakhstan"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-def proj_gpt(fn):
-    rows=list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-BASE=proj("base"); TAP=proj("sw05")
-GPT=[("GPT-3.5","gpt_S1_gpt35.csv"),("GPT-4","gpt_S2_gpt4.csv"),
-     ("GPT-4-turbo","gpt_S3_gpt4turbo.csv"),("GPT-4o","gpt_S4_gpt4o.csv")]
-GPTP={n:proj_gpt(f) for n,f in GPT}
 
-fig,ax=plt.subplots(figsize=(15,10.5))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(250 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .5),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(12 if star else 7.5),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+# many country labels
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Norway",
+    "Russia",
+    "Canada",
+    "Finland",
+    "Denmark",
+    "Switzerland",
+    "Poland",
+    "Greece",
+    "Turkey",
+    "Iran",
+    "Egypt",
+    "Nigeria",
+    "Pakistan",
+    "India",
+    "Mexico",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Ukraine",
+    "Romania",
+    "Hungary",
+    "Taiwan ROC",
+    "Hong Kong SAR",
+    "Malaysia",
+    "Philippines",
+    "Bangladesh",
+    "Morocco",
+    "Jordan",
+    "Iraq",
+    "Kenya",
+    "Ethiopia",
+    "New Zealand",
+    "Ireland",
+    "Slovenia",
+    "Estonia",
+    "Bulgaria",
+    "Serbia",
+    "Andorra",
+    "Singapore",
+    "Zimbabwe",
+    "Tunisia",
+    "Colombia",
+    "Peru",
+    "Kazakhstan",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+def proj_gpt(fn):
+    rows = list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+BASE = proj("base")
+TAP = proj("sw05")
+GPT = [
+    ("GPT-3.5", "gpt_S1_gpt35.csv"),
+    ("GPT-4", "gpt_S2_gpt4.csv"),
+    ("GPT-4-turbo", "gpt_S3_gpt4turbo.csv"),
+    ("GPT-4o", "gpt_S4_gpt4o.csv"),
+]
+GPTP = {n: proj_gpt(f) for n, f in GPT}
+
+fig, ax = plt.subplots(figsize=(15, 10.5))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(250 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.5),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(12 if star else 7.5),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
 # dashed distance lines to Vietnam (label near each model end so they don't collide)
-for p,col,t in [(BASE,"black",0.30),(TAP,"#0a7d0a",0.30)]:
-    ax.plot([p[0],VN[0]],[p[1],VN[1]],ls="--",c=col,lw=1.8,alpha=.8,zorder=5)
-    lx,ly=p[0]+t*(VN[0]-p[0]), p[1]+t*(VN[1]-p[1])
-    ax.annotate(f"{d(p):.2f}",(lx,ly),fontsize=12,color=col,fontweight="bold",
-                bbox=dict(boxstyle="round,pad=0.15",fc="white",ec=col,alpha=.92),zorder=9)
+for p, col, t in [(BASE, "black", 0.30), (TAP, "#0a7d0a", 0.30)]:
+    ax.plot([p[0], VN[0]], [p[1], VN[1]], ls="--", c=col, lw=1.8, alpha=0.8, zorder=5)
+    lx, ly = p[0] + t * (VN[0] - p[0]), p[1] + t * (VN[1] - p[1])
+    ax.annotate(
+        f"{d(p):.2f}",
+        (lx, ly),
+        fontsize=12,
+        color=col,
+        fontweight="bold",
+        bbox=dict(boxstyle="round,pad=0.15", fc="white", ec=col, alpha=0.92),
+        zorder=9,
+    )
 # Tao GPT models (black squares)
-for n,_ in GPT:
-    x,y=GPTP[n]; ax.scatter(x,y,s=150,c="#333",marker="s",edgecolors="white",lw=1.2,zorder=8)
-    ax.annotate(n,(x,y),fontsize=10,fontweight="bold",color="#333",xytext=(7,5),textcoords="offset points",zorder=9)
+for n, _ in GPT:
+    x, y = GPTP[n]
+    ax.scatter(x, y, s=150, c="#333", marker="s", edgecolors="white", lw=1.2, zorder=8)
+    ax.annotate(
+        n, (x, y), fontsize=10, fontweight="bold", color="#333", xytext=(7, 5), textcoords="offset points", zorder=9
+    )
 # base (black diamond)
-ax.scatter(*BASE,s=420,c="black",marker="D",edgecolors="white",lw=2,zorder=10)
-ax.annotate("base (Llama-3.2-3B)",BASE,fontsize=13,fontweight="bold",color="black",xytext=(10,8),textcoords="offset points",zorder=11)
+ax.scatter(*BASE, s=420, c="black", marker="D", edgecolors="white", lw=2, zorder=10)
+ax.annotate(
+    "base (Llama-3.2-3B)",
+    BASE,
+    fontsize=13,
+    fontweight="bold",
+    color="black",
+    xytext=(10, 8),
+    textcoords="offset points",
+    zorder=11,
+)
 # Tapestry (green diamond) — label moved up-left, clear of the base->VN dashed line
-ax.scatter(*TAP,s=470,c="#0a7d0a",marker="D",edgecolors="white",lw=2,zorder=12)
-ax.annotate("Tapestry-Vietnamese",TAP,fontsize=14,fontweight="bold",color="#0a7d0a",xytext=(-78,26),textcoords="offset points",ha="center",zorder=13)
-ax.set_xlabel("Survival  vs  Self-Expression Values",fontsize=14)
-ax.set_ylabel("Traditional  vs  Secular Values",fontsize=14)
+ax.scatter(*TAP, s=470, c="#0a7d0a", marker="D", edgecolors="white", lw=2, zorder=12)
+ax.annotate(
+    "Tapestry-Vietnamese",
+    TAP,
+    fontsize=14,
+    fontweight="bold",
+    color="#0a7d0a",
+    xytext=(-78, 26),
+    textcoords="offset points",
+    ha="center",
+    zorder=13,
+)
+ax.set_xlabel("Survival  vs  Self-Expression Values", fontsize=14)
+ax.set_ylabel("Traditional  vs  Secular Values", fontsize=14)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam'),
-      Line2D([0],[0],marker='D',color='w',markerfacecolor='#0a7d0a',markersize=11,label='Tapestry-Vietnamese (ours)'),
-      Line2D([0],[0],marker='s',color='w',markerfacecolor='#333',markersize=9,label='base / GPT models')]
-ax.legend(handles=leg,fontsize=9,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_tapestry_05.png",dpi=145)
-print(f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}")
-for n in GPTP: print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [
+    Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam"),
+    Line2D(
+        [0], [0], marker="D", color="w", markerfacecolor="#0a7d0a", markersize=11, label="Tapestry-Vietnamese (ours)"
+    ),
+    Line2D([0], [0], marker="s", color="w", markerfacecolor="#333", markersize=9, label="base / GPT models"),
+]
+ax.legend(handles=leg, fontsize=9, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_tapestry_05.png", dpi=145)
+print(
+    f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}"
+)
+for n in GPTP:
+    print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
 print("WROTE iw_tapestry_05.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw09.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw09.py
@@ -1,70 +1,209 @@
 #!/usr/bin/env python
 """IW map: base + Tapestry(soup0.8, GREEN) + Tao's 4 GPT models. Dashed distance lines base->VN
 and Tapestry->VN. No title. Axes use 'vs'. Many country labels."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-# many country labels
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain","Spain",
- "Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Norway","Russia","Canada",
- "Finland","Denmark","Switzerland","Poland","Greece","Turkey","Iran","Egypt","Nigeria","Pakistan","India",
- "Mexico","Brazil","Argentina","Chile","Ukraine","Romania","Hungary","Taiwan ROC","Hong Kong SAR","Malaysia",
- "Philippines","Bangladesh","Morocco","Jordan","Iraq","Kenya","Ethiopia","New Zealand","Ireland","Slovenia",
- "Estonia","Bulgaria","Serbia","Andorra","Singapore","Zimbabwe","Tunisia","Colombia","Peru","Kazakhstan"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-def proj_gpt(fn):
-    rows=list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-BASE=proj("base"); TAP=proj("sw09")
-GPT=[("GPT-3.5","gpt_S1_gpt35.csv"),("GPT-4","gpt_S2_gpt4.csv"),
-     ("GPT-4-turbo","gpt_S3_gpt4turbo.csv"),("GPT-4o","gpt_S4_gpt4o.csv")]
-GPTP={n:proj_gpt(f) for n,f in GPT}
 
-fig,ax=plt.subplots(figsize=(15,10.5))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(250 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .5),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(12 if star else 7.5),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+# many country labels
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Norway",
+    "Russia",
+    "Canada",
+    "Finland",
+    "Denmark",
+    "Switzerland",
+    "Poland",
+    "Greece",
+    "Turkey",
+    "Iran",
+    "Egypt",
+    "Nigeria",
+    "Pakistan",
+    "India",
+    "Mexico",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Ukraine",
+    "Romania",
+    "Hungary",
+    "Taiwan ROC",
+    "Hong Kong SAR",
+    "Malaysia",
+    "Philippines",
+    "Bangladesh",
+    "Morocco",
+    "Jordan",
+    "Iraq",
+    "Kenya",
+    "Ethiopia",
+    "New Zealand",
+    "Ireland",
+    "Slovenia",
+    "Estonia",
+    "Bulgaria",
+    "Serbia",
+    "Andorra",
+    "Singapore",
+    "Zimbabwe",
+    "Tunisia",
+    "Colombia",
+    "Peru",
+    "Kazakhstan",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+def proj_gpt(fn):
+    rows = list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+BASE = proj("base")
+TAP = proj("sw09")
+GPT = [
+    ("GPT-3.5", "gpt_S1_gpt35.csv"),
+    ("GPT-4", "gpt_S2_gpt4.csv"),
+    ("GPT-4-turbo", "gpt_S3_gpt4turbo.csv"),
+    ("GPT-4o", "gpt_S4_gpt4o.csv"),
+]
+GPTP = {n: proj_gpt(f) for n, f in GPT}
+
+fig, ax = plt.subplots(figsize=(15, 10.5))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(250 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.5),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(12 if star else 7.5),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
 # dashed distance lines to Vietnam (label near each model end so they don't collide)
-for p,col,t in [(BASE,"black",0.30),(TAP,"#0a7d0a",0.30)]:
-    ax.plot([p[0],VN[0]],[p[1],VN[1]],ls="--",c=col,lw=1.8,alpha=.8,zorder=5)
-    lx,ly=p[0]+t*(VN[0]-p[0]), p[1]+t*(VN[1]-p[1])
-    ax.annotate(f"{d(p):.2f}",(lx,ly),fontsize=12,color=col,fontweight="bold",
-                bbox=dict(boxstyle="round,pad=0.15",fc="white",ec=col,alpha=.92),zorder=9)
+for p, col, t in [(BASE, "black", 0.30), (TAP, "#0a7d0a", 0.30)]:
+    ax.plot([p[0], VN[0]], [p[1], VN[1]], ls="--", c=col, lw=1.8, alpha=0.8, zorder=5)
+    lx, ly = p[0] + t * (VN[0] - p[0]), p[1] + t * (VN[1] - p[1])
+    ax.annotate(
+        f"{d(p):.2f}",
+        (lx, ly),
+        fontsize=12,
+        color=col,
+        fontweight="bold",
+        bbox=dict(boxstyle="round,pad=0.15", fc="white", ec=col, alpha=0.92),
+        zorder=9,
+    )
 # Tao GPT models (black squares)
-for n,_ in GPT:
-    x,y=GPTP[n]; ax.scatter(x,y,s=150,c="#333",marker="s",edgecolors="white",lw=1.2,zorder=8)
-    ax.annotate(n,(x,y),fontsize=10,fontweight="bold",color="#333",xytext=(7,5),textcoords="offset points",zorder=9)
+for n, _ in GPT:
+    x, y = GPTP[n]
+    ax.scatter(x, y, s=150, c="#333", marker="s", edgecolors="white", lw=1.2, zorder=8)
+    ax.annotate(
+        n, (x, y), fontsize=10, fontweight="bold", color="#333", xytext=(7, 5), textcoords="offset points", zorder=9
+    )
 # base (black diamond)
-ax.scatter(*BASE,s=420,c="black",marker="D",edgecolors="white",lw=2,zorder=10)
-ax.annotate("base (Llama-3.2-3B)",BASE,fontsize=13,fontweight="bold",color="black",xytext=(10,8),textcoords="offset points",zorder=11)
+ax.scatter(*BASE, s=420, c="black", marker="D", edgecolors="white", lw=2, zorder=10)
+ax.annotate(
+    "base (Llama-3.2-3B)",
+    BASE,
+    fontsize=13,
+    fontweight="bold",
+    color="black",
+    xytext=(10, 8),
+    textcoords="offset points",
+    zorder=11,
+)
 # Tapestry (green diamond) — label moved up-left, clear of the base->VN dashed line
-ax.scatter(*TAP,s=470,c="#0a7d0a",marker="D",edgecolors="white",lw=2,zorder=12)
-ax.annotate("soup a=0.9",TAP,fontsize=15,fontweight="bold",color="#0a7d0a",xytext=(-58,24),textcoords="offset points",ha="center",zorder=13)
-ax.set_xlabel("Survival  vs  Self-Expression",fontsize=14)
-ax.set_ylabel("Traditional  vs  Secular-Rational",fontsize=14)
+ax.scatter(*TAP, s=470, c="#0a7d0a", marker="D", edgecolors="white", lw=2, zorder=12)
+ax.annotate(
+    "soup a=0.9",
+    TAP,
+    fontsize=15,
+    fontweight="bold",
+    color="#0a7d0a",
+    xytext=(-58, 24),
+    textcoords="offset points",
+    ha="center",
+    zorder=13,
+)
+ax.set_xlabel("Survival  vs  Self-Expression", fontsize=14)
+ax.set_ylabel("Traditional  vs  Secular-Rational", fontsize=14)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam'),
-      Line2D([0],[0],marker='D',color='w',markerfacecolor='#0a7d0a',markersize=11,label='soup a=0.9 (ours)'),
-      Line2D([0],[0],marker='s',color='w',markerfacecolor='#333',markersize=9,label='base / GPT models')]
-ax.legend(handles=leg,fontsize=9,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_tapestry_09.png",dpi=145)
-print(f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}")
-for n in GPTP: print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [
+    Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam"),
+    Line2D([0], [0], marker="D", color="w", markerfacecolor="#0a7d0a", markersize=11, label="soup a=0.9 (ours)"),
+    Line2D([0], [0], marker="s", color="w", markerfacecolor="#333", markersize=9, label="base / GPT models"),
+]
+ax.legend(handles=leg, fontsize=9, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_tapestry_09.png", dpi=145)
+print(
+    f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}"
+)
+for n in GPTP:
+    print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
 print("WROTE iw_tapestry_09.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry.py
@@ -1,70 +1,209 @@
 #!/usr/bin/env python
 """IW map: base + Tapestry(soup0.8, GREEN) + Tao's 4 GPT models. Dashed distance lines base->VN
 and Tapestry->VN. No title. Axes use 'vs'. Many country labels."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-# many country labels
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain","Spain",
- "Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Norway","Russia","Canada",
- "Finland","Denmark","Switzerland","Poland","Greece","Turkey","Iran","Egypt","Nigeria","Pakistan","India",
- "Mexico","Brazil","Argentina","Chile","Ukraine","Romania","Hungary","Taiwan ROC","Hong Kong SAR","Malaysia",
- "Philippines","Bangladesh","Morocco","Jordan","Iraq","Kenya","Ethiopia","New Zealand","Ireland","Slovenia",
- "Estonia","Bulgaria","Serbia","Andorra","Singapore","Zimbabwe","Tunisia","Colombia","Peru","Kazakhstan"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-def proj_gpt(fn):
-    rows=list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-BASE=proj("base"); TAP=proj("sw08")
-GPT=[("GPT-3.5","gpt_S1_gpt35.csv"),("GPT-4","gpt_S2_gpt4.csv"),
-     ("GPT-4-turbo","gpt_S3_gpt4turbo.csv"),("GPT-4o","gpt_S4_gpt4o.csv")]
-GPTP={n:proj_gpt(f) for n,f in GPT}
 
-fig,ax=plt.subplots(figsize=(15,10.5))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(250 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .5),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(12 if star else 7.5),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+# many country labels
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Norway",
+    "Russia",
+    "Canada",
+    "Finland",
+    "Denmark",
+    "Switzerland",
+    "Poland",
+    "Greece",
+    "Turkey",
+    "Iran",
+    "Egypt",
+    "Nigeria",
+    "Pakistan",
+    "India",
+    "Mexico",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Ukraine",
+    "Romania",
+    "Hungary",
+    "Taiwan ROC",
+    "Hong Kong SAR",
+    "Malaysia",
+    "Philippines",
+    "Bangladesh",
+    "Morocco",
+    "Jordan",
+    "Iraq",
+    "Kenya",
+    "Ethiopia",
+    "New Zealand",
+    "Ireland",
+    "Slovenia",
+    "Estonia",
+    "Bulgaria",
+    "Serbia",
+    "Andorra",
+    "Singapore",
+    "Zimbabwe",
+    "Tunisia",
+    "Colombia",
+    "Peru",
+    "Kazakhstan",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+def proj_gpt(fn):
+    rows = list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+BASE = proj("base")
+TAP = proj("sw08")
+GPT = [
+    ("GPT-3.5", "gpt_S1_gpt35.csv"),
+    ("GPT-4", "gpt_S2_gpt4.csv"),
+    ("GPT-4-turbo", "gpt_S3_gpt4turbo.csv"),
+    ("GPT-4o", "gpt_S4_gpt4o.csv"),
+]
+GPTP = {n: proj_gpt(f) for n, f in GPT}
+
+fig, ax = plt.subplots(figsize=(15, 10.5))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(250 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.5),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(12 if star else 7.5),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
 # dashed distance lines to Vietnam (label near each model end so they don't collide)
-for p,col,t in [(BASE,"black",0.30),(TAP,"#0a7d0a",0.30)]:
-    ax.plot([p[0],VN[0]],[p[1],VN[1]],ls="--",c=col,lw=1.8,alpha=.8,zorder=5)
-    lx,ly=p[0]+t*(VN[0]-p[0]), p[1]+t*(VN[1]-p[1])
-    ax.annotate(f"{d(p):.2f}",(lx,ly),fontsize=12,color=col,fontweight="bold",
-                bbox=dict(boxstyle="round,pad=0.15",fc="white",ec=col,alpha=.92),zorder=9)
+for p, col, t in [(BASE, "black", 0.30), (TAP, "#0a7d0a", 0.30)]:
+    ax.plot([p[0], VN[0]], [p[1], VN[1]], ls="--", c=col, lw=1.8, alpha=0.8, zorder=5)
+    lx, ly = p[0] + t * (VN[0] - p[0]), p[1] + t * (VN[1] - p[1])
+    ax.annotate(
+        f"{d(p):.2f}",
+        (lx, ly),
+        fontsize=12,
+        color=col,
+        fontweight="bold",
+        bbox=dict(boxstyle="round,pad=0.15", fc="white", ec=col, alpha=0.92),
+        zorder=9,
+    )
 # Tao GPT models (black squares)
-for n,_ in GPT:
-    x,y=GPTP[n]; ax.scatter(x,y,s=150,c="#333",marker="s",edgecolors="white",lw=1.2,zorder=8)
-    ax.annotate(n,(x,y),fontsize=10,fontweight="bold",color="#333",xytext=(7,5),textcoords="offset points",zorder=9)
+for n, _ in GPT:
+    x, y = GPTP[n]
+    ax.scatter(x, y, s=150, c="#333", marker="s", edgecolors="white", lw=1.2, zorder=8)
+    ax.annotate(
+        n, (x, y), fontsize=10, fontweight="bold", color="#333", xytext=(7, 5), textcoords="offset points", zorder=9
+    )
 # base (black diamond)
-ax.scatter(*BASE,s=420,c="black",marker="D",edgecolors="white",lw=2,zorder=10)
-ax.annotate("base (Llama-3.2-3B)",BASE,fontsize=13,fontweight="bold",color="black",xytext=(10,8),textcoords="offset points",zorder=11)
+ax.scatter(*BASE, s=420, c="black", marker="D", edgecolors="white", lw=2, zorder=10)
+ax.annotate(
+    "base (Llama-3.2-3B)",
+    BASE,
+    fontsize=13,
+    fontweight="bold",
+    color="black",
+    xytext=(10, 8),
+    textcoords="offset points",
+    zorder=11,
+)
 # Tapestry (green diamond) — label moved up-left, clear of the base->VN dashed line
-ax.scatter(*TAP,s=470,c="#0a7d0a",marker="D",edgecolors="white",lw=2,zorder=12)
-ax.annotate("Tapestry",TAP,fontsize=15,fontweight="bold",color="#0a7d0a",xytext=(-58,24),textcoords="offset points",ha="center",zorder=13)
-ax.set_xlabel("Survival  vs  Self-Expression",fontsize=14)
-ax.set_ylabel("Traditional  vs  Secular-Rational",fontsize=14)
+ax.scatter(*TAP, s=470, c="#0a7d0a", marker="D", edgecolors="white", lw=2, zorder=12)
+ax.annotate(
+    "Tapestry",
+    TAP,
+    fontsize=15,
+    fontweight="bold",
+    color="#0a7d0a",
+    xytext=(-58, 24),
+    textcoords="offset points",
+    ha="center",
+    zorder=13,
+)
+ax.set_xlabel("Survival  vs  Self-Expression", fontsize=14)
+ax.set_ylabel("Traditional  vs  Secular-Rational", fontsize=14)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam'),
-      Line2D([0],[0],marker='D',color='w',markerfacecolor='#0a7d0a',markersize=11,label='Tapestry (ours)'),
-      Line2D([0],[0],marker='s',color='w',markerfacecolor='#333',markersize=9,label='base / GPT models')]
-ax.legend(handles=leg,fontsize=9,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_tapestry.png",dpi=145)
-print(f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}")
-for n in GPTP: print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [
+    Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam"),
+    Line2D([0], [0], marker="D", color="w", markerfacecolor="#0a7d0a", markersize=11, label="Tapestry (ours)"),
+    Line2D([0], [0], marker="s", color="w", markerfacecolor="#333", markersize=9, label="base / GPT models"),
+]
+ax.legend(handles=leg, fontsize=9, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_tapestry.png", dpi=145)
+print(
+    f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}"
+)
+for n in GPTP:
+    print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
 print("WROTE iw_tapestry.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry07.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry07.py
@@ -1,70 +1,209 @@
 #!/usr/bin/env python
 """IW map: base + Tapestry(soup0.8, GREEN) + Tao's 4 GPT models. Dashed distance lines base->VN
 and Tapestry->VN. No title. Axes use 'vs'. Many country labels."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-# many country labels
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain","Spain",
- "Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Norway","Russia","Canada",
- "Finland","Denmark","Switzerland","Poland","Greece","Turkey","Iran","Egypt","Nigeria","Pakistan","India",
- "Mexico","Brazil","Argentina","Chile","Ukraine","Romania","Hungary","Taiwan ROC","Hong Kong SAR","Malaysia",
- "Philippines","Bangladesh","Morocco","Jordan","Iraq","Kenya","Ethiopia","New Zealand","Ireland","Slovenia",
- "Estonia","Bulgaria","Serbia","Andorra","Singapore","Zimbabwe","Tunisia","Colombia","Peru","Kazakhstan"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-def proj_gpt(fn):
-    rows=list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-BASE=proj("base"); TAP=proj("sw07")
-GPT=[("GPT-3.5","gpt_S1_gpt35.csv"),("GPT-4","gpt_S2_gpt4.csv"),
-     ("GPT-4-turbo","gpt_S3_gpt4turbo.csv"),("GPT-4o","gpt_S4_gpt4o.csv")]
-GPTP={n:proj_gpt(f) for n,f in GPT}
 
-fig,ax=plt.subplots(figsize=(15,10.5))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(250 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .5),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(12 if star else 7.5),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+# many country labels
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Norway",
+    "Russia",
+    "Canada",
+    "Finland",
+    "Denmark",
+    "Switzerland",
+    "Poland",
+    "Greece",
+    "Turkey",
+    "Iran",
+    "Egypt",
+    "Nigeria",
+    "Pakistan",
+    "India",
+    "Mexico",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Ukraine",
+    "Romania",
+    "Hungary",
+    "Taiwan ROC",
+    "Hong Kong SAR",
+    "Malaysia",
+    "Philippines",
+    "Bangladesh",
+    "Morocco",
+    "Jordan",
+    "Iraq",
+    "Kenya",
+    "Ethiopia",
+    "New Zealand",
+    "Ireland",
+    "Slovenia",
+    "Estonia",
+    "Bulgaria",
+    "Serbia",
+    "Andorra",
+    "Singapore",
+    "Zimbabwe",
+    "Tunisia",
+    "Colombia",
+    "Peru",
+    "Kazakhstan",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+def proj_gpt(fn):
+    rows = list(csv.DictReader(open(f"{IW}/tao_osf/{fn}")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+BASE = proj("base")
+TAP = proj("sw07")
+GPT = [
+    ("GPT-3.5", "gpt_S1_gpt35.csv"),
+    ("GPT-4", "gpt_S2_gpt4.csv"),
+    ("GPT-4-turbo", "gpt_S3_gpt4turbo.csv"),
+    ("GPT-4o", "gpt_S4_gpt4o.csv"),
+]
+GPTP = {n: proj_gpt(f) for n, f in GPT}
+
+fig, ax = plt.subplots(figsize=(15, 10.5))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(250 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.5),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(12 if star else 7.5),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
 # dashed distance lines to Vietnam (label near each model end so they don't collide)
-for p,col,t in [(BASE,"black",0.30),(TAP,"#0a7d0a",0.30)]:
-    ax.plot([p[0],VN[0]],[p[1],VN[1]],ls="--",c=col,lw=1.8,alpha=.8,zorder=5)
-    lx,ly=p[0]+t*(VN[0]-p[0]), p[1]+t*(VN[1]-p[1])
-    ax.annotate(f"{d(p):.2f}",(lx,ly),fontsize=12,color=col,fontweight="bold",
-                bbox=dict(boxstyle="round,pad=0.15",fc="white",ec=col,alpha=.92),zorder=9)
+for p, col, t in [(BASE, "black", 0.30), (TAP, "#0a7d0a", 0.30)]:
+    ax.plot([p[0], VN[0]], [p[1], VN[1]], ls="--", c=col, lw=1.8, alpha=0.8, zorder=5)
+    lx, ly = p[0] + t * (VN[0] - p[0]), p[1] + t * (VN[1] - p[1])
+    ax.annotate(
+        f"{d(p):.2f}",
+        (lx, ly),
+        fontsize=12,
+        color=col,
+        fontweight="bold",
+        bbox=dict(boxstyle="round,pad=0.15", fc="white", ec=col, alpha=0.92),
+        zorder=9,
+    )
 # Tao GPT models (black squares)
-for n,_ in GPT:
-    x,y=GPTP[n]; ax.scatter(x,y,s=150,c="#333",marker="s",edgecolors="white",lw=1.2,zorder=8)
-    ax.annotate(n,(x,y),fontsize=10,fontweight="bold",color="#333",xytext=(7,5),textcoords="offset points",zorder=9)
+for n, _ in GPT:
+    x, y = GPTP[n]
+    ax.scatter(x, y, s=150, c="#333", marker="s", edgecolors="white", lw=1.2, zorder=8)
+    ax.annotate(
+        n, (x, y), fontsize=10, fontweight="bold", color="#333", xytext=(7, 5), textcoords="offset points", zorder=9
+    )
 # base (black diamond)
-ax.scatter(*BASE,s=420,c="black",marker="D",edgecolors="white",lw=2,zorder=10)
-ax.annotate("base (Llama-3.2-3B)",BASE,fontsize=13,fontweight="bold",color="black",xytext=(10,8),textcoords="offset points",zorder=11)
+ax.scatter(*BASE, s=420, c="black", marker="D", edgecolors="white", lw=2, zorder=10)
+ax.annotate(
+    "base (Llama-3.2-3B)",
+    BASE,
+    fontsize=13,
+    fontweight="bold",
+    color="black",
+    xytext=(10, 8),
+    textcoords="offset points",
+    zorder=11,
+)
 # Tapestry (green diamond) — label moved up-left, clear of the base->VN dashed line
-ax.scatter(*TAP,s=470,c="#0a7d0a",marker="D",edgecolors="white",lw=2,zorder=12)
-ax.annotate("Tapestry",TAP,fontsize=15,fontweight="bold",color="#0a7d0a",xytext=(-58,24),textcoords="offset points",ha="center",zorder=13)
-ax.set_xlabel("Survival  vs  Self-Expression",fontsize=14)
-ax.set_ylabel("Traditional  vs  Secular-Rational",fontsize=14)
+ax.scatter(*TAP, s=470, c="#0a7d0a", marker="D", edgecolors="white", lw=2, zorder=12)
+ax.annotate(
+    "Tapestry",
+    TAP,
+    fontsize=15,
+    fontweight="bold",
+    color="#0a7d0a",
+    xytext=(-58, 24),
+    textcoords="offset points",
+    ha="center",
+    zorder=13,
+)
+ax.set_xlabel("Survival  vs  Self-Expression", fontsize=14)
+ax.set_ylabel("Traditional  vs  Secular-Rational", fontsize=14)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam'),
-      Line2D([0],[0],marker='D',color='w',markerfacecolor='#0a7d0a',markersize=11,label='Tapestry (ours)'),
-      Line2D([0],[0],marker='s',color='w',markerfacecolor='#333',markersize=9,label='base / GPT models')]
-ax.legend(handles=leg,fontsize=9,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_tapestry_07.png",dpi=145)
-print(f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}")
-for n in GPTP: print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [
+    Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam"),
+    Line2D([0], [0], marker="D", color="w", markerfacecolor="#0a7d0a", markersize=11, label="Tapestry (ours)"),
+    Line2D([0], [0], marker="s", color="w", markerfacecolor="#333", markersize=9, label="base / GPT models"),
+]
+ax.legend(handles=leg, fontsize=9, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_tapestry_07.png", dpi=145)
+print(
+    f"base={tuple(round(v,2) for v in BASE)} d={d(BASE):.2f}; Tapestry={tuple(round(v,2) for v in TAP)} d={d(TAP):.2f}"
+)
+for n in GPTP:
+    print(f"  {n}={tuple(round(v,2) for v in GPTP[n])} d={d(GPTP[n]):.2f}")
 print("WROTE iw_tapestry_07.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_v3_sweep.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_v3_sweep.py
@@ -1,57 +1,131 @@
 #!/usr/bin/env python
 """Visualize the v3 alpha sweep on the IW map, highlighting soup 0.8. All projected from
 their answer CSVs via the bit-exact iw_project. x=Survival<->Self-Expression, y=Trad<->Secular."""
-import json, csv, sys
-import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt
-IW="/workspace/eval/iw"; sys.path.insert(0, IW)
-ANS="/workspace/results/iw/answers"; FIG="/workspace/results/iw/figures"
-from iw_project import project, ITEMS
-coords=json.load(open(f"{IW}/country_coords.json"))
-zones={r["country.territory"]:r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
-ZC={"Catholic Europe":"#9467bd","Protestant Europe":"#1f77b4","English-Speaking":"#2ca02c",
-    "Latin America":"#ff7f0e","African-Islamic":"#8c564b","West & South Asia":"#e377c2",
-    "Confucian":"#d62728","Orthodox Europe":"#17becf"}
-LABEL={"Vietnam","United States","Japan","Sweden","Czechia","China","Germany","Great Britain",
-       "Spain","Netherlands","South Korea","Thailand","Indonesia","Australia","France","Italy","Slovenia"}
-VN=tuple(coords["Vietnam"]); d=lambda p:((p[0]-VN[0])**2+(p[1]-VN[1])**2)**.5
-def proj_csv(tag):
-    rows=list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
-    pts=[project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in("","None") for it in ITEMS)]
-    return (sum(p[0] for p in pts)/len(pts), sum(p[1] for p in pts)/len(pts))
-# (label, tag, alpha, color, marker, size, highlight)
-PTS=[("base", "base", 0.0, "#888", "D", 230, False),
-     ("soup α=0.3","sw03",0.3,"#1f77b4","s",230,False),
-     ("soup α=0.5","sw05",0.5,"#ff7f0e","s",230,False),
-     ("soup α=0.8","sw08",0.8,"magenta","D",430,True),
-     ("pure IW (α=1.0)","iwv3",1.0,"black","D",260,False)]
-P={lab:proj_csv(tag) for lab,tag,*_ in PTS}
 
-fig,ax=plt.subplots(figsize=(14,10))
-ax.axhline(0,color="#ddd",lw=.9,zorder=0); ax.axvline(0,color="#ddd",lw=.9,zorder=0)
-for c,(x,y) in coords.items():
-    star=(c=="Vietnam")
-    ax.scatter(x,y,s=(240 if star else 32),c=("red" if star else ZC.get(zones.get(c,""),"#ccc")),
-               marker=("*" if star else "o"),edgecolors="k" if star else "none",lw=.6,alpha=(1 if star else .42),zorder=(6 if star else 2))
-    if c in LABEL: ax.annotate(c,(x,y),fontsize=(11 if star else 8),fontweight=("bold" if star else "normal"),
-                    color=("red" if star else "#555"),xytext=(5,3),textcoords="offset points",zorder=7)
+import json, csv, sys
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IW = "/workspace/eval/iw"
+sys.path.insert(0, IW)
+ANS = "/workspace/results/iw/answers"
+FIG = "/workspace/results/iw/figures"
+from iw_project import project, ITEMS
+
+coords = json.load(open(f"{IW}/country_coords.json"))
+zones = {r["country.territory"]: r["Category"] for r in csv.DictReader(open(f"{IW}/s003.csv"))}
+ZC = {
+    "Catholic Europe": "#9467bd",
+    "Protestant Europe": "#1f77b4",
+    "English-Speaking": "#2ca02c",
+    "Latin America": "#ff7f0e",
+    "African-Islamic": "#8c564b",
+    "West & South Asia": "#e377c2",
+    "Confucian": "#d62728",
+    "Orthodox Europe": "#17becf",
+}
+LABEL = {
+    "Vietnam",
+    "United States",
+    "Japan",
+    "Sweden",
+    "Czechia",
+    "China",
+    "Germany",
+    "Great Britain",
+    "Spain",
+    "Netherlands",
+    "South Korea",
+    "Thailand",
+    "Indonesia",
+    "Australia",
+    "France",
+    "Italy",
+    "Slovenia",
+}
+VN = tuple(coords["Vietnam"])
+d = lambda p: ((p[0] - VN[0]) ** 2 + (p[1] - VN[1]) ** 2) ** 0.5
+
+
+def proj_csv(tag):
+    rows = list(csv.DictReader(open(f"{ANS}/answers_{tag}_tao.csv")))
+    pts = [project([float(r[it]) for it in ITEMS]) for r in rows if all(r[it] not in ("", "None") for it in ITEMS)]
+    return (sum(p[0] for p in pts) / len(pts), sum(p[1] for p in pts) / len(pts))
+
+
+# (label, tag, alpha, color, marker, size, highlight)
+PTS = [
+    ("base", "base", 0.0, "#888", "D", 230, False),
+    ("soup α=0.3", "sw03", 0.3, "#1f77b4", "s", 230, False),
+    ("soup α=0.5", "sw05", 0.5, "#ff7f0e", "s", 230, False),
+    ("soup α=0.8", "sw08", 0.8, "magenta", "D", 430, True),
+    ("pure IW (α=1.0)", "iwv3", 1.0, "black", "D", 260, False),
+]
+P = {lab: proj_csv(tag) for lab, tag, *_ in PTS}
+
+fig, ax = plt.subplots(figsize=(14, 10))
+ax.axhline(0, color="#ddd", lw=0.9, zorder=0)
+ax.axvline(0, color="#ddd", lw=0.9, zorder=0)
+for c, (x, y) in coords.items():
+    star = c == "Vietnam"
+    ax.scatter(
+        x,
+        y,
+        s=(240 if star else 32),
+        c=("red" if star else ZC.get(zones.get(c, ""), "#ccc")),
+        marker=("*" if star else "o"),
+        edgecolors="k" if star else "none",
+        lw=0.6,
+        alpha=(1 if star else 0.42),
+        zorder=(6 if star else 2),
+    )
+    if c in LABEL:
+        ax.annotate(
+            c,
+            (x, y),
+            fontsize=(11 if star else 8),
+            fontweight=("bold" if star else "normal"),
+            color=("red" if star else "#555"),
+            xytext=(5, 3),
+            textcoords="offset points",
+            zorder=7,
+        )
 # trajectory line across the alpha sweep (1.0 -> 0.8 -> 0.5 -> 0.3)
-traj=[P["pure IW (α=1.0)"],P["soup α=0.8"],P["soup α=0.5"],P["soup α=0.3"]]
-ax.plot([p[0] for p in traj],[p[1] for p in traj],color="gray",ls="--",lw=1.2,alpha=.6,zorder=4)
-for lab,tag,alpha,col,mk,sz,hi in PTS:
-    p=P[lab]
-    ax.scatter(*p,s=sz,c=col,marker=mk,edgecolors="white",lw=(2.2 if hi else 1.5),zorder=(10 if hi else 9))
-    ax.annotate(f"{lab}  (d={d(p):.2f})",p,fontsize=(12 if hi else 10),fontweight="bold",color=col,
-                xytext=(9,6 if not hi else -16),textcoords="offset points",zorder=11)
+traj = [P["pure IW (α=1.0)"], P["soup α=0.8"], P["soup α=0.5"], P["soup α=0.3"]]
+ax.plot([p[0] for p in traj], [p[1] for p in traj], color="gray", ls="--", lw=1.2, alpha=0.6, zorder=4)
+for lab, tag, alpha, col, mk, sz, hi in PTS:
+    p = P[lab]
+    ax.scatter(*p, s=sz, c=col, marker=mk, edgecolors="white", lw=(2.2 if hi else 1.5), zorder=(10 if hi else 9))
+    ax.annotate(
+        f"{lab}  (d={d(p):.2f})",
+        p,
+        fontsize=(12 if hi else 10),
+        fontweight="bold",
+        color=col,
+        xytext=(9, 6 if not hi else -16),
+        textcoords="offset points",
+        zorder=11,
+    )
 # distance line for 0.8
-p8=P["soup α=0.8"]; ax.plot([p8[0],VN[0]],[p8[1],VN[1]],ls=":",c="magenta",lw=1.6,alpha=.7,zorder=5)
-ax.set_xlabel("Survival  ←————→  Self-Expression       (PC1)",fontsize=13)
-ax.set_ylabel("Traditional  ←————→  Secular-Rational       (PC2)",fontsize=13)
-ax.set_title("v3 soup alpha sweep on the IW map — soup α=0.8 highlighted (closest to Vietnam, d=1.25; God held at 6)\n"
-             "dashed = alpha trajectory (pure IW → 0.8 → 0.5 → 0.3). ★=Vietnam",fontsize=10.5)
+p8 = P["soup α=0.8"]
+ax.plot([p8[0], VN[0]], [p8[1], VN[1]], ls=":", c="magenta", lw=1.6, alpha=0.7, zorder=5)
+ax.set_xlabel("Survival  ←————→  Self-Expression       (PC1)", fontsize=13)
+ax.set_ylabel("Traditional  ←————→  Secular-Rational       (PC2)", fontsize=13)
+ax.set_title(
+    "v3 soup alpha sweep on the IW map — soup α=0.8 highlighted (closest to Vietnam, d=1.25; God held at 6)\n"
+    "dashed = alpha trajectory (pure IW → 0.8 → 0.5 → 0.3). ★=Vietnam",
+    fontsize=10.5,
+)
 from matplotlib.lines import Line2D
-leg=[Line2D([0],[0],marker='o',color='w',markerfacecolor=v,markersize=8,label=k) for k,v in ZC.items()]
-leg+=[Line2D([0],[0],marker='*',color='w',markerfacecolor='red',markersize=13,label='Vietnam (target)')]
-ax.legend(handles=leg,fontsize=8.5,loc="lower left",framealpha=.92)
-ax.grid(True,alpha=.13); fig.tight_layout(); fig.savefig(f"{FIG}/iw_v3_sweep.png",dpi=145)
-for lab in P: print(f"{lab:18s} ({P[lab][0]:+.2f},{P[lab][1]:+.2f}) d={d(P[lab]):.2f}")
+
+leg = [Line2D([0], [0], marker="o", color="w", markerfacecolor=v, markersize=8, label=k) for k, v in ZC.items()]
+leg += [Line2D([0], [0], marker="*", color="w", markerfacecolor="red", markersize=13, label="Vietnam (target)")]
+ax.legend(handles=leg, fontsize=8.5, loc="lower left", framealpha=0.92)
+ax.grid(True, alpha=0.13)
+fig.tight_layout()
+fig.savefig(f"{FIG}/iw_v3_sweep.png", dpi=145)
+for lab in P:
+    print(f"{lab:18s} ({P[lab][0]:+.2f},{P[lab][1]:+.2f}) d={d(P[lab]):.2f}")
 print("WROTE iw_v3_sweep.png")

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu.py
@@ -1,48 +1,95 @@
 """Full 14042 MMLU eval for a THINK/ANSWER model, records idx+subtask, incremental+resumable.
 Usage: python zs_full_mmlu.py <model> <tag> [budget]"""
+
 import sys, re, json, os
-sys.path.insert(0, "/workspace/eval"); sys.path.insert(0, "/workspace/train")
+
+sys.path.insert(0, "/workspace/eval")
+sys.path.insert(0, "/workspace/train")
 AO, AC = "<ANSWER>", "</ANSWER>"
+
+
 def extract(text, letters="ABCD"):
-    L=f"[{letters}]"
+    L = f"[{letters}]"
     if AO in text:
-        a=text.split(AO)[-1].split(AC)[0]
-        m=re.search(rf'({L})',a)
-        if m: return m.group(1).upper(),"answer-tag"
-    m=re.findall(rf'(?:the\s+)?(?:best|correct|final)?\s*answer\s+is\s*:?\s*\(?\*{{0,2}}({L})\b',text,re.I)
-    if m: return m[-1].upper(),"answer-is"
-    return None,"no-answer-spiral"
+        a = text.split(AO)[-1].split(AC)[0]
+        m = re.search(rf"({L})", a)
+        if m:
+            return m.group(1).upper(), "answer-tag"
+    m = re.findall(rf"(?:the\s+)?(?:best|correct|final)?\s*answer\s+is\s*:?\s*\(?\*{{0,2}}({L})\b", text, re.I)
+    if m:
+        return m[-1].upper(), "answer-is"
+    return None, "no-answer-spiral"
+
+
 def main():
     from vllm import LLM, SamplingParams
     from datasets import load_dataset
     from chat_template import CHAT_TEMPLATE
+
     model, tag = sys.argv[1], sys.argv[2]
-    budget = int(sys.argv[3]) if len(sys.argv)>3 else 6000
-    d=load_dataset("meta-llama/Llama-3.2-3B-Instruct-evals",name="Llama-3.2-3B-Instruct-evals__mmlu__details",split="latest")
-    llm=LLM(model=model,dtype="bfloat16",gpu_memory_utilization=0.7,max_model_len=8192)
-    tok=llm.get_tokenizer(); tok.chat_template=CHAT_TEMPLATE
-    sp=SamplingParams(max_tokens=budget,stop=[AC],temperature=0.0,top_p=1.0,repetition_penalty=1.1)
-    prompts,meta=[],[]
+    budget = int(sys.argv[3]) if len(sys.argv) > 3 else 6000
+    d = load_dataset(
+        "meta-llama/Llama-3.2-3B-Instruct-evals", name="Llama-3.2-3B-Instruct-evals__mmlu__details", split="latest"
+    )
+    llm = LLM(model=model, dtype="bfloat16", gpu_memory_utilization=0.7, max_model_len=8192)
+    tok = llm.get_tokenizer()
+    tok.chat_template = CHAT_TEMPLATE
+    sp = SamplingParams(max_tokens=budget, stop=[AC], temperature=0.0, top_p=1.0, repetition_penalty=1.1)
+    prompts, meta = [], []
     for i in range(len(d)):
-        r=d[i]; cl=r["input_choice_list"]; opts="\n".join(f"{k}. {v}" for k,v in cl.items())
-        body=("Given the following question and four candidate answers (A, B, C and D), choose the best answer.\n"
-              f"Question: {r['input_question']}\n{opts}\n"
-              'Your response should end with "<ANSWER>The best answer is [the_answer_letter]</ANSWER>" where the [the_answer_letter] is one of A, B, C or D.')
-        prompts.append(tok.apply_chat_template([{"role":"user","content":body}],tokenize=False,add_generation_prompt=True))
-        meta.append((i,r["input_correct_responses"][0].strip().strip('"').upper(),r["subtask_name"].replace("mmlu_chat.","")))
-    outpath=f"/workspace/results/mmlu/zs_{tag}_mmlu_results.jsonl"
+        r = d[i]
+        cl = r["input_choice_list"]
+        opts = "\n".join(f"{k}. {v}" for k, v in cl.items())
+        body = (
+            "Given the following question and four candidate answers (A, B, C and D), choose the best answer.\n"
+            f"Question: {r['input_question']}\n{opts}\n"
+            'Your response should end with "<ANSWER>The best answer is [the_answer_letter]</ANSWER>" where the [the_answer_letter] is one of A, B, C or D.'
+        )
+        prompts.append(
+            tok.apply_chat_template([{"role": "user", "content": body}], tokenize=False, add_generation_prompt=True)
+        )
+        meta.append(
+            (i, r["input_correct_responses"][0].strip().strip('"').upper(), r["subtask_name"].replace("mmlu_chat.", ""))
+        )
+    outpath = f"/workspace/results/mmlu/zs_{tag}_mmlu_results.jsonl"
     os.makedirs(os.path.dirname(outpath), exist_ok=True)
-    done=sum(1 for _ in open(outpath)) if os.path.exists(outpath) else 0
-    print(f"[plan] full {len(d)}, resume {done}",flush=True)
-    f=open(outpath,"a"); CH=512
-    for s in range(done,len(prompts),CH):
-        couts=llm.generate(prompts[s:s+CH],sp)
-        for (i,g,sub),o in zip(meta[s:s+CH],couts):
-            t=o.outputs[0].text; pred,rule=extract(t)
-            f.write(json.dumps({"idx":i,"subtask":sub,"gold":g,"pred":pred,"ok":(pred==g),"rule":rule,"finish":o.outputs[0].finish_reason,"out":t},ensure_ascii=False)+"\n")
-        f.flush(); os.fsync(f.fileno()); print(f"[ZS-FULL {tag}] {s+len(couts)}/{len(prompts)}",flush=True)
+    done = sum(1 for _ in open(outpath)) if os.path.exists(outpath) else 0
+    print(f"[plan] full {len(d)}, resume {done}", flush=True)
+    f = open(outpath, "a")
+    CH = 512
+    for s in range(done, len(prompts), CH):
+        couts = llm.generate(prompts[s : s + CH], sp)
+        for (i, g, sub), o in zip(meta[s : s + CH], couts):
+            t = o.outputs[0].text
+            pred, rule = extract(t)
+            f.write(
+                json.dumps(
+                    {
+                        "idx": i,
+                        "subtask": sub,
+                        "gold": g,
+                        "pred": pred,
+                        "ok": (pred == g),
+                        "rule": rule,
+                        "finish": o.outputs[0].finish_reason,
+                        "out": t,
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+        f.flush()
+        os.fsync(f.fileno())
+        print(f"[ZS-FULL {tag}] {s+len(couts)}/{len(prompts)}", flush=True)
     f.close()
-    recs=[json.loads(l) for l in open(outpath)]; ok=sum(r["ok"] for r in recs)
-    print(f"[RESULT {tag}] {ok}/{len(recs)}={ok/len(recs)*100:.1f}%  spirals={sum(r['pred'] is None for r in recs)}",flush=True)
-    print(f"ZS_FULL_DONE_{tag}",flush=True)
-if __name__=="__main__": main()
+    recs = [json.loads(l) for l in open(outpath)]
+    ok = sum(r["ok"] for r in recs)
+    print(
+        f"[RESULT {tag}] {ok}/{len(recs)}={ok/len(recs)*100:.1f}%  spirals={sum(r['pred'] is None for r in recs)}",
+        flush=True,
+    )
+    print(f"ZS_FULL_DONE_{tag}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu_sweep.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu_sweep.py
@@ -1,48 +1,95 @@
 """Full 14042 MMLU eval for a THINK/ANSWER model, records idx+subtask, incremental+resumable.
 Usage: python zs_full_mmlu.py <model> <tag> [budget]"""
+
 import sys, re, json, os
-sys.path.insert(0, "/workspace/eval"); sys.path.insert(0, "/workspace/train")
+
+sys.path.insert(0, "/workspace/eval")
+sys.path.insert(0, "/workspace/train")
 AO, AC = "<ANSWER>", "</ANSWER>"
+
+
 def extract(text, letters="ABCD"):
-    L=f"[{letters}]"
+    L = f"[{letters}]"
     if AO in text:
-        a=text.split(AO)[-1].split(AC)[0]
-        m=re.search(rf'({L})',a)
-        if m: return m.group(1).upper(),"answer-tag"
-    m=re.findall(rf'(?:the\s+)?(?:best|correct|final)?\s*answer\s+is\s*:?\s*\(?\*{{0,2}}({L})\b',text,re.I)
-    if m: return m[-1].upper(),"answer-is"
-    return None,"no-answer-spiral"
+        a = text.split(AO)[-1].split(AC)[0]
+        m = re.search(rf"({L})", a)
+        if m:
+            return m.group(1).upper(), "answer-tag"
+    m = re.findall(rf"(?:the\s+)?(?:best|correct|final)?\s*answer\s+is\s*:?\s*\(?\*{{0,2}}({L})\b", text, re.I)
+    if m:
+        return m[-1].upper(), "answer-is"
+    return None, "no-answer-spiral"
+
+
 def main():
     from vllm import LLM, SamplingParams
     from datasets import load_dataset
     from chat_template import CHAT_TEMPLATE
+
     model, tag = sys.argv[1], sys.argv[2]
-    budget = int(sys.argv[3]) if len(sys.argv)>3 else 6000
-    d=load_dataset("meta-llama/Llama-3.2-3B-Instruct-evals",name="Llama-3.2-3B-Instruct-evals__mmlu__details",split="latest")
-    llm=LLM(model=model,dtype="bfloat16",gpu_memory_utilization=0.5,max_model_len=8192)
-    tok=llm.get_tokenizer(); tok.chat_template=CHAT_TEMPLATE
-    sp=SamplingParams(max_tokens=budget,stop=[AC],temperature=0.0,top_p=1.0,repetition_penalty=1.1)
-    prompts,meta=[],[]
+    budget = int(sys.argv[3]) if len(sys.argv) > 3 else 6000
+    d = load_dataset(
+        "meta-llama/Llama-3.2-3B-Instruct-evals", name="Llama-3.2-3B-Instruct-evals__mmlu__details", split="latest"
+    )
+    llm = LLM(model=model, dtype="bfloat16", gpu_memory_utilization=0.5, max_model_len=8192)
+    tok = llm.get_tokenizer()
+    tok.chat_template = CHAT_TEMPLATE
+    sp = SamplingParams(max_tokens=budget, stop=[AC], temperature=0.0, top_p=1.0, repetition_penalty=1.1)
+    prompts, meta = [], []
     for i in range(len(d)):
-        r=d[i]; cl=r["input_choice_list"]; opts="\n".join(f"{k}. {v}" for k,v in cl.items())
-        body=("Given the following question and four candidate answers (A, B, C and D), choose the best answer.\n"
-              f"Question: {r['input_question']}\n{opts}\n"
-              'Your response should end with "<ANSWER>The best answer is [the_answer_letter]</ANSWER>" where the [the_answer_letter] is one of A, B, C or D.')
-        prompts.append(tok.apply_chat_template([{"role":"user","content":body}],tokenize=False,add_generation_prompt=True))
-        meta.append((i,r["input_correct_responses"][0].strip().strip('"').upper(),r["subtask_name"].replace("mmlu_chat.","")))
-    outpath=f"/workspace/results/mmlu/zs_{tag}_mmlu_results.jsonl"
+        r = d[i]
+        cl = r["input_choice_list"]
+        opts = "\n".join(f"{k}. {v}" for k, v in cl.items())
+        body = (
+            "Given the following question and four candidate answers (A, B, C and D), choose the best answer.\n"
+            f"Question: {r['input_question']}\n{opts}\n"
+            'Your response should end with "<ANSWER>The best answer is [the_answer_letter]</ANSWER>" where the [the_answer_letter] is one of A, B, C or D.'
+        )
+        prompts.append(
+            tok.apply_chat_template([{"role": "user", "content": body}], tokenize=False, add_generation_prompt=True)
+        )
+        meta.append(
+            (i, r["input_correct_responses"][0].strip().strip('"').upper(), r["subtask_name"].replace("mmlu_chat.", ""))
+        )
+    outpath = f"/workspace/results/mmlu/zs_{tag}_mmlu_results.jsonl"
     os.makedirs(os.path.dirname(outpath), exist_ok=True)
-    done=sum(1 for _ in open(outpath)) if os.path.exists(outpath) else 0
-    print(f"[plan] full {len(d)}, resume {done}",flush=True)
-    f=open(outpath,"a"); CH=512
-    for s in range(done,len(prompts),CH):
-        couts=llm.generate(prompts[s:s+CH],sp)
-        for (i,g,sub),o in zip(meta[s:s+CH],couts):
-            t=o.outputs[0].text; pred,rule=extract(t)
-            f.write(json.dumps({"idx":i,"subtask":sub,"gold":g,"pred":pred,"ok":(pred==g),"rule":rule,"finish":o.outputs[0].finish_reason,"out":t},ensure_ascii=False)+"\n")
-        f.flush(); os.fsync(f.fileno()); print(f"[ZS-FULL {tag}] {s+len(couts)}/{len(prompts)}",flush=True)
+    done = sum(1 for _ in open(outpath)) if os.path.exists(outpath) else 0
+    print(f"[plan] full {len(d)}, resume {done}", flush=True)
+    f = open(outpath, "a")
+    CH = 512
+    for s in range(done, len(prompts), CH):
+        couts = llm.generate(prompts[s : s + CH], sp)
+        for (i, g, sub), o in zip(meta[s : s + CH], couts):
+            t = o.outputs[0].text
+            pred, rule = extract(t)
+            f.write(
+                json.dumps(
+                    {
+                        "idx": i,
+                        "subtask": sub,
+                        "gold": g,
+                        "pred": pred,
+                        "ok": (pred == g),
+                        "rule": rule,
+                        "finish": o.outputs[0].finish_reason,
+                        "out": t,
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+        f.flush()
+        os.fsync(f.fileno())
+        print(f"[ZS-FULL {tag}] {s+len(couts)}/{len(prompts)}", flush=True)
     f.close()
-    recs=[json.loads(l) for l in open(outpath)]; ok=sum(r["ok"] for r in recs)
-    print(f"[RESULT {tag}] {ok}/{len(recs)}={ok/len(recs)*100:.1f}%  spirals={sum(r['pred'] is None for r in recs)}",flush=True)
-    print(f"ZS_FULL_DONE_{tag}",flush=True)
-if __name__=="__main__": main()
+    recs = [json.loads(l) for l in open(outpath)]
+    ok = sum(r["ok"] for r in recs)
+    print(
+        f"[RESULT {tag}] {ok}/{len(recs)}={ok/len(recs)*100:.1f}%  spirals={sum(r['pred'] is None for r in recs)}",
+        flush=True,
+    )
+    print(f"ZS_FULL_DONE_{tag}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/nguyennm1024-sociocultural-alignment/tests/test_consortium.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/tests/test_consortium.py
@@ -1,4 +1,5 @@
 """Smoke tests for the consortium-learning interface (no GPU/models needed)."""
+
 import os
 import sys
 

--- a/contrib/nguyennm1024-sociocultural-alignment/tests/test_iw_projection.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/tests/test_iw_projection.py
@@ -1,4 +1,5 @@
 """Smoke tests for the self-contained Inglehart-Welzel projector (no GPU/models/survey data)."""
+
 import math
 import os
 import sys

--- a/contrib/nguyennm1024-sociocultural-alignment/training/merge_ckpt.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/training/merge_ckpt.py
@@ -1,6 +1,7 @@
 import sys, os, torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import PeftModel
+
 adapter, out = sys.argv[1], sys.argv[2]
 base = "meta-llama/Llama-3.2-3B-Instruct"
 tok = AutoTokenizer.from_pretrained("/workspace/train/models/vn-3b-final")
@@ -11,9 +12,12 @@ except TypeError:
 m = PeftModel.from_pretrained(m, adapter)
 m = m.merge_and_unload()
 os.makedirs(out, exist_ok=True)
-m.save_pretrained(out); tok.save_pretrained(out)
-for r,_,fs in os.walk(out):
+m.save_pretrained(out)
+tok.save_pretrained(out)
+for r, _, fs in os.walk(out):
     for f in fs:
-        try: os.chmod(os.path.join(r,f), 0o666)
-        except: pass
+        try:
+            os.chmod(os.path.join(r, f), 0o666)
+        except:
+            pass
 print(f"MERGED {adapter} -> {out}")

--- a/contrib/nguyennm1024-sociocultural-alignment/training/pack_data.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/training/pack_data.py
@@ -12,6 +12,7 @@ already-windowed `prepared/*.jsonl` (so nothing exceeds the block).
 
 Output: datasets saved with save_to_disk to prepared/packed/{train,val_*}.
 """
+
 import argparse, json, os
 from datasets import Dataset
 from transformers import AutoTokenizer
@@ -29,8 +30,12 @@ def tokenize_all(tok, rows, chunk=1000):
     convs = [r["messages"] for r in rows]
     for i in range(0, len(convs), chunk):
         enc = tok.apply_chat_template(
-            convs[i:i + chunk], tokenize=True, return_assistant_tokens_mask=True,
-            return_dict=True, add_generation_prompt=False)
+            convs[i : i + chunk],
+            tokenize=True,
+            return_assistant_tokens_mask=True,
+            return_dict=True,
+            add_generation_prompt=False,
+        )
         ids_all.extend(enc["input_ids"])
         mask_all.extend(enc["assistant_masks"])
     return ids_all, mask_all
@@ -48,8 +53,10 @@ def pack(ids_all, mask_all, block, pad_id):
             padn = block - len(ci)
             ci += [pad_id] * padn
             cl += [-100] * padn
-            cp += list(range(padn))          # pad tail = its own dummy sequence
-        blocks_i.append(ci); blocks_l.append(cl); blocks_p.append(cp)
+            cp += list(range(padn))  # pad tail = its own dummy sequence
+        blocks_i.append(ci)
+        blocks_l.append(cl)
+        blocks_p.append(cp)
         ci, cl, cp = [], [], []
 
     for ids, mask in zip(ids_all, mask_all):
@@ -58,7 +65,9 @@ def pack(ids_all, mask_all, block, pad_id):
         if len(ci) + len(ids) > block:
             flush()
         labels = [t if m else -100 for t, m in zip(ids, mask)]
-        ci += ids; cl += labels; cp += list(range(len(ids)))
+        ci += ids
+        cl += labels
+        cp += list(range(len(ids)))
     flush()
     return {"input_ids": blocks_i, "labels": blocks_l, "position_ids": blocks_p}
 
@@ -81,7 +90,8 @@ def main():
     for name in ["train", "val_cultural", "val_rehearsal"]:
         path = os.path.join(args.data, f"{name}.jsonl")
         if not os.path.exists(path):
-            print(f"[{name:14s}] (no file, skip)", flush=True); continue
+            print(f"[{name:14s}] (no file, skip)", flush=True)
+            continue
         rows = load_jsonl(path)
         ids_all, mask_all = tokenize_all(tok, rows)
         cols = pack(ids_all, mask_all, args.block, pad_id)
@@ -89,9 +99,11 @@ def main():
         ds.save_to_disk(os.path.join(args.out, name))
         tok_total = sum(len(x) for x in ids_all)
         trained = sum(sum(1 for v in l if v != -100) for l in cols["labels"])
-        print(f"[{name:14s}] rows={len(rows):6d} blocks={len(ds):5d} "
-              f"tokens={tok_total/1e6:.1f}M trained_frac={trained/(len(ds)*args.block):.2f}",
-              flush=True)
+        print(
+            f"[{name:14s}] rows={len(rows):6d} blocks={len(ds):5d} "
+            f"tokens={tok_total/1e6:.1f}M trained_frac={trained/(len(ds)*args.block):.2f}",
+            flush=True,
+        )
 
 
 if __name__ == "__main__":

--- a/contrib/nguyennm1024-sociocultural-alignment/training/prepare_data.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/training/prepare_data.py
@@ -19,6 +19,7 @@ Outputs (to --out):
   val_cultural.jsonl   cultural_val
   val_rehearsal.jsonl  rehearsal_val
 """
+
 import argparse, json, os, random
 from transformers import AutoTokenizer
 
@@ -37,8 +38,7 @@ def load_jsonl(p):
 
 
 def norm_messages(row):
-    return [dict(m) for m in row["messages"]
-            if not (m["role"] == "system" and not (m["content"] or "").strip())]
+    return [dict(m) for m in row["messages"] if not (m["role"] == "system" and not (m["content"] or "").strip())]
 
 
 def char_pretrim(content, cutoff):
@@ -106,8 +106,9 @@ def main():
     ap.add_argument("--model", default="meta-llama/Llama-3.2-3B-Instruct")
     ap.add_argument("--cutoff", type=int, default=16384)
     ap.add_argument("--seed", type=int, default=42)
-    ap.add_argument("--rehearsal_only", action="store_true",
-                    help="train on rehearsal_train only (ablation: no cultural data)")
+    ap.add_argument(
+        "--rehearsal_only", action="store_true", help="train on rehearsal_train only (ablation: no cultural data)"
+    )
     args = ap.parse_args()
 
     os.makedirs(args.out, exist_ok=True)
@@ -115,8 +116,9 @@ def main():
     tok.chat_template = CHAT_TEMPLATE
 
     spec = {
-        "train": (["rehearsal_train.jsonl"] if args.rehearsal_only
-                  else ["cultural_train.jsonl", "rehearsal_train.jsonl"]),
+        "train": (
+            ["rehearsal_train.jsonl"] if args.rehearsal_only else ["cultural_train.jsonl", "rehearsal_train.jsonl"]
+        ),
         "val_rehearsal": ["rehearsal_val.jsonl"],
     }
     if not args.rehearsal_only:
@@ -132,8 +134,10 @@ def main():
         with open(path, "w") as fh:
             for r in out:
                 fh.write(json.dumps(r, ensure_ascii=False) + "\n")
-        print(f"[{name:14s}] in={len(rows):6d} kept={len(out):6d} "
-              f"windowed={n_win:4d} dropped={n_drop:4d} -> {path}", flush=True)
+        print(
+            f"[{name:14s}] in={len(rows):6d} kept={len(out):6d} " f"windowed={n_win:4d} dropped={n_drop:4d} -> {path}",
+            flush=True,
+        )
 
 
 if __name__ == "__main__":

--- a/contrib/nguyennm1024-sociocultural-alignment/training/train_full.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/training/train_full.py
@@ -4,14 +4,17 @@ Tests whether the rehearsal corpus alone preserves benchmarks, or whether it ALS
 teaches the verbose/format problems we found endemic to it. Same generative benchmark
 eval as the epoch-2 run, so the trajectory is directly comparable to base (70/75/80/80).
 """
+
 import argparse, os, sys
 import torch
 from datasets import load_from_disk, load_dataset
-from transformers import (AutoModelForCausalLM, AutoTokenizer, Trainer,
-                          TrainingArguments, TrainerCallback)
+from transformers import AutoModelForCausalLM, AutoTokenizer, Trainer, TrainingArguments, TrainerCallback
 from peft import LoraConfig, get_peft_model
-sys.path.insert(0, "/workspace/train"); sys.path.insert(0, "/workspace/eval")
+
+sys.path.insert(0, "/workspace/train")
+sys.path.insert(0, "/workspace/eval")
 from chat_template import CHAT_TEMPLATE
+
 ANSWER_OPEN, ANSWER_CLOSE = "<ANSWER>", "</ANSWER>"
 
 
@@ -46,13 +49,19 @@ def collate(batch):
 
 def build_eval_items(n):
     from tasks import ft_messages, subsample
+
     items = []
     for task in ["gsm8k", "mmlu", "hellaswag_chat", "arc_challenge"]:
         try:
-            d = load_dataset("meta-llama/Llama-3.2-3B-Instruct-evals",
-                             name=f"Llama-3.2-3B-Instruct-evals__{task}__details", split="latest")
-            for i in subsample(d, n, 123):       # SAME 80-item validation set
-                r = d[i]; fp = r["input_final_prompts"]; fp = fp[0] if isinstance(fp, list) else fp
+            d = load_dataset(
+                "meta-llama/Llama-3.2-3B-Instruct-evals",
+                name=f"Llama-3.2-3B-Instruct-evals__{task}__details",
+                split="latest",
+            )
+            for i in subsample(d, n, 123):  # SAME 80-item validation set
+                r = d[i]
+                fp = r["input_final_prompts"]
+                fp = fp[0] if isinstance(fp, list) else fp
                 items.append((task, ft_messages(fp), r["input_correct_responses"]))
         except Exception as e:
             print(f"[geneval] could not build {task}: {e}", flush=True)
@@ -61,79 +70,143 @@ def build_eval_items(n):
 
 
 class GenEval(TrainerCallback):
-    def __init__(self, tok, items, every): self.tok, self.items, self.every = tok, items, every
+    def __init__(self, tok, items, every):
+        self.tok, self.items, self.every = tok, items, every
+
     def on_step_end(self, args, state, control, model=None, **kw):
-        if self.every <= 0 or state.global_step % self.every != 0: return
-        try: self._run(model, state.global_step)
-        except Exception as e: print(f"[geneval] step {state.global_step} SKIPPED ({type(e).__name__}: {e})", flush=True)
+        if self.every <= 0 or state.global_step % self.every != 0:
+            return
+        try:
+            self._run(model, state.global_step)
+        except Exception as e:
+            print(f"[geneval] step {state.global_step} SKIPPED ({type(e).__name__}: {e})", flush=True)
+
     @torch.no_grad()
     def _run(self, model, step):
         from collections import defaultdict
         from tasks import TASKS
-        was_train = model.training; uc = model.config.use_cache; was_ckpt = getattr(model, "is_gradient_checkpointing", False)
-        model.eval(); model.config.use_cache = True
-        try: model.gradient_checkpointing_disable()
-        except Exception: pass
-        pad_side = self.tok.padding_side; self.tok.padding_side = "left"
-        if self.tok.pad_token is None: self.tok.pad_token = self.tok.eos_token
-        cor, tot = defaultdict(int), defaultdict(int); by = defaultdict(list)
-        for t, m, g in self.items: by[t].append((m, g))
+
+        was_train = model.training
+        uc = model.config.use_cache
+        was_ckpt = getattr(model, "is_gradient_checkpointing", False)
+        model.eval()
+        model.config.use_cache = True
+        try:
+            model.gradient_checkpointing_disable()
+        except Exception:
+            pass
+        pad_side = self.tok.padding_side
+        self.tok.padding_side = "left"
+        if self.tok.pad_token is None:
+            self.tok.pad_token = self.tok.eos_token
+        cor, tot = defaultdict(int), defaultdict(int)
+        by = defaultdict(list)
+        for t, m, g in self.items:
+            by[t].append((m, g))
         for task, rows in by.items():
             for k in range(0, len(rows), 8):
-                chunk = rows[k:k+8]
-                prompts = [self.tok.apply_chat_template(m, tokenize=False, add_generation_prompt=True) for m, _ in chunk]
-                enc = self.tok(prompts, return_tensors="pt", padding=True, truncation=True, max_length=2560).to(model.device)
+                chunk = rows[k : k + 8]
+                prompts = [
+                    self.tok.apply_chat_template(m, tokenize=False, add_generation_prompt=True) for m, _ in chunk
+                ]
+                enc = self.tok(prompts, return_tensors="pt", padding=True, truncation=True, max_length=2560).to(
+                    model.device
+                )
                 out = model.generate(**enc, max_new_tokens=768, do_sample=False, pad_token_id=self.tok.eos_token_id)
                 for j, (_, g) in enumerate(chunk):
-                    txt = self.tok.decode(out[j][enc["input_ids"].shape[1]:], skip_special_tokens=True)
+                    txt = self.tok.decode(out[j][enc["input_ids"].shape[1] :], skip_special_tokens=True)
                     ans = txt.split(ANSWER_OPEN)[-1].split(ANSWER_CLOSE)[0] if ANSWER_OPEN in txt else txt
-                    try: good, _ = TASKS[task]["score"](ans, g)
-                    except Exception: good = False
-                    cor[task] += bool(good); tot[task] += 1
+                    try:
+                        good, _ = TASKS[task]["score"](ans, g)
+                    except Exception:
+                        good = False
+                    cor[task] += bool(good)
+                    tot[task] += 1
         msg = "  ".join(f"{t}={cor[t]}/{tot[t]}={cor[t]/max(1,tot[t])*100:.0f}%" for t in sorted(tot))
         print(f"[GENEVAL] step {step}:  {msg}", flush=True)
-        self.tok.padding_side = pad_side; model.config.use_cache = uc
+        self.tok.padding_side = pad_side
+        model.config.use_cache = uc
         if was_ckpt:
-            try: model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
-            except Exception: pass
-        if was_train: model.train()
+            try:
+                model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+            except Exception:
+                pass
+        if was_train:
+            model.train()
 
 
 def main():
     a = parse()
     if a.gpu_mem_frac < 1.0:
         torch.cuda.set_per_process_memory_fraction(a.gpu_mem_frac, 0)
-    tok = AutoTokenizer.from_pretrained(a.model); tok.chat_template = CHAT_TEMPLATE
+    tok = AutoTokenizer.from_pretrained(a.model)
+    tok.chat_template = CHAT_TEMPLATE
     model = AutoModelForCausalLM.from_pretrained(a.model, dtype=torch.bfloat16, attn_implementation="flash_attention_2")
     model.config.use_cache = False
-    model = get_peft_model(model, LoraConfig(
-        r=a.rank, lora_alpha=a.alpha, lora_dropout=0.05, target_modules="all-linear",
-        use_rslora=True, bias="none", task_type="CAUSAL_LM"))
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            r=a.rank,
+            lora_alpha=a.alpha,
+            lora_dropout=0.05,
+            target_modules="all-linear",
+            use_rslora=True,
+            bias="none",
+            task_type="CAUSAL_LM",
+        ),
+    )
     model.enable_input_require_grads()
-    print("[combined-full] FRESH LoRA from base: cultural + rehearsal; val=cultural_val (loss) + MMLU (geneval)", flush=True)
+    print(
+        "[combined-full] FRESH LoRA from base: cultural + rehearsal; val=cultural_val (loss) + MMLU (geneval)",
+        flush=True,
+    )
 
     train_ds = load_from_disk(os.path.join(a.data, "train"))
     val_ds = load_from_disk(os.path.join(a.data, "val_cultural"))
     args = TrainingArguments(
-        output_dir=a.out, per_device_train_batch_size=a.bs, gradient_accumulation_steps=a.ga,
-        learning_rate=a.lr, lr_scheduler_type="cosine", warmup_ratio=0.03, num_train_epochs=a.epochs,
-        bf16=True, gradient_checkpointing=(not a.no_grad_ckpt),
+        output_dir=a.out,
+        per_device_train_batch_size=a.bs,
+        gradient_accumulation_steps=a.ga,
+        learning_rate=a.lr,
+        lr_scheduler_type="cosine",
+        warmup_ratio=0.03,
+        num_train_epochs=a.epochs,
+        bf16=True,
+        gradient_checkpointing=(not a.no_grad_ckpt),
         gradient_checkpointing_kwargs=(None if a.no_grad_ckpt else {"use_reentrant": False}),
-        optim="adamw_torch_fused", logging_steps=5, save_steps=a.save_steps,
-        save_total_limit=a.save_total_limit, eval_strategy="steps", eval_steps=a.geneval_steps,
-        per_device_eval_batch_size=1, report_to="none",
-        dataloader_num_workers=2, dataloader_pin_memory=True, seed=1234)  # fresh seed
+        optim="adamw_torch_fused",
+        logging_steps=5,
+        save_steps=a.save_steps,
+        save_total_limit=a.save_total_limit,
+        eval_strategy="steps",
+        eval_steps=a.geneval_steps,
+        per_device_eval_batch_size=1,
+        report_to="none",
+        dataloader_num_workers=2,
+        dataloader_pin_memory=True,
+        seed=1234,
+    )  # fresh seed
 
     items = build_eval_items(a.geneval_n)
-    trainer = Trainer(model=model, args=args, train_dataset=train_ds, eval_dataset=val_ds, data_collator=collate,
-                      callbacks=[GenEval(tok, items, a.geneval_steps)] if items else [])
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=train_ds,
+        eval_dataset=val_ds,
+        data_collator=collate,
+        callbacks=[GenEval(tok, items, a.geneval_steps)] if items else [],
+    )
     import glob as _glob
+
     ckpt = bool(a.resume and _glob.glob(os.path.join(a.out, "checkpoint-*")))
     if items and not ckpt:
-        try: GenEval(tok, items, 1)._run(model, 0)   # step-0 baseline = fresh-LoRA-untrained ~= base
-        except Exception as e: print(f"[geneval] baseline skipped: {e}", flush=True)
+        try:
+            GenEval(tok, items, 1)._run(model, 0)  # step-0 baseline = fresh-LoRA-untrained ~= base
+        except Exception as e:
+            print(f"[geneval] baseline skipped: {e}", flush=True)
     trainer.train(resume_from_checkpoint=ckpt if ckpt else None)
-    trainer.save_model(os.path.join(a.out, "final")); tok.save_pretrained(os.path.join(a.out, "final"))
+    trainer.save_model(os.path.join(a.out, "final"))
+    tok.save_pretrained(os.path.join(a.out, "final"))
     print("COMBINED_FULL_DONE ->", os.path.join(a.out, "final"), flush=True)
 
 

--- a/contrib/nguyennm1024-sociocultural-alignment/training/train_rehearsal.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/training/train_rehearsal.py
@@ -4,14 +4,17 @@ Tests whether the rehearsal corpus alone preserves benchmarks, or whether it ALS
 teaches the verbose/format problems we found endemic to it. Same generative benchmark
 eval as the epoch-2 run, so the trajectory is directly comparable to base (70/75/80/80).
 """
+
 import argparse, os, sys
 import torch
 from datasets import load_from_disk, load_dataset
-from transformers import (AutoModelForCausalLM, AutoTokenizer, Trainer,
-                          TrainingArguments, TrainerCallback)
+from transformers import AutoModelForCausalLM, AutoTokenizer, Trainer, TrainingArguments, TrainerCallback
 from peft import LoraConfig, get_peft_model
-sys.path.insert(0, "/workspace/train"); sys.path.insert(0, "/workspace/eval")
+
+sys.path.insert(0, "/workspace/train")
+sys.path.insert(0, "/workspace/eval")
 from chat_template import CHAT_TEMPLATE
+
 ANSWER_OPEN, ANSWER_CLOSE = "<ANSWER>", "</ANSWER>"
 
 
@@ -45,13 +48,19 @@ def collate(batch):
 
 def build_eval_items(n):
     from tasks import ft_messages, subsample
+
     items = []
     for task in ["gsm8k", "mmlu", "hellaswag_chat", "arc_challenge"]:
         try:
-            d = load_dataset("meta-llama/Llama-3.2-3B-Instruct-evals",
-                             name=f"Llama-3.2-3B-Instruct-evals__{task}__details", split="latest")
-            for i in subsample(d, n, 123):       # SAME 80-item validation set
-                r = d[i]; fp = r["input_final_prompts"]; fp = fp[0] if isinstance(fp, list) else fp
+            d = load_dataset(
+                "meta-llama/Llama-3.2-3B-Instruct-evals",
+                name=f"Llama-3.2-3B-Instruct-evals__{task}__details",
+                split="latest",
+            )
+            for i in subsample(d, n, 123):  # SAME 80-item validation set
+                r = d[i]
+                fp = r["input_final_prompts"]
+                fp = fp[0] if isinstance(fp, list) else fp
                 items.append((task, ft_messages(fp), r["input_correct_responses"]))
         except Exception as e:
             print(f"[geneval] could not build {task}: {e}", flush=True)
@@ -60,75 +69,134 @@ def build_eval_items(n):
 
 
 class GenEval(TrainerCallback):
-    def __init__(self, tok, items, every): self.tok, self.items, self.every = tok, items, every
+    def __init__(self, tok, items, every):
+        self.tok, self.items, self.every = tok, items, every
+
     def on_step_end(self, args, state, control, model=None, **kw):
-        if self.every <= 0 or state.global_step % self.every != 0: return
-        try: self._run(model, state.global_step)
-        except Exception as e: print(f"[geneval] step {state.global_step} SKIPPED ({type(e).__name__}: {e})", flush=True)
+        if self.every <= 0 or state.global_step % self.every != 0:
+            return
+        try:
+            self._run(model, state.global_step)
+        except Exception as e:
+            print(f"[geneval] step {state.global_step} SKIPPED ({type(e).__name__}: {e})", flush=True)
+
     @torch.no_grad()
     def _run(self, model, step):
         from collections import defaultdict
         from tasks import TASKS
-        was_train = model.training; uc = model.config.use_cache
-        model.eval(); model.config.use_cache = True
-        try: model.gradient_checkpointing_disable()
-        except Exception: pass
-        pad_side = self.tok.padding_side; self.tok.padding_side = "left"
-        if self.tok.pad_token is None: self.tok.pad_token = self.tok.eos_token
-        cor, tot = defaultdict(int), defaultdict(int); by = defaultdict(list)
-        for t, m, g in self.items: by[t].append((m, g))
+
+        was_train = model.training
+        uc = model.config.use_cache
+        model.eval()
+        model.config.use_cache = True
+        try:
+            model.gradient_checkpointing_disable()
+        except Exception:
+            pass
+        pad_side = self.tok.padding_side
+        self.tok.padding_side = "left"
+        if self.tok.pad_token is None:
+            self.tok.pad_token = self.tok.eos_token
+        cor, tot = defaultdict(int), defaultdict(int)
+        by = defaultdict(list)
+        for t, m, g in self.items:
+            by[t].append((m, g))
         for task, rows in by.items():
             for k in range(0, len(rows), 8):
-                chunk = rows[k:k+8]
-                prompts = [self.tok.apply_chat_template(m, tokenize=False, add_generation_prompt=True) for m, _ in chunk]
-                enc = self.tok(prompts, return_tensors="pt", padding=True, truncation=True, max_length=2560).to(model.device)
+                chunk = rows[k : k + 8]
+                prompts = [
+                    self.tok.apply_chat_template(m, tokenize=False, add_generation_prompt=True) for m, _ in chunk
+                ]
+                enc = self.tok(prompts, return_tensors="pt", padding=True, truncation=True, max_length=2560).to(
+                    model.device
+                )
                 out = model.generate(**enc, max_new_tokens=768, do_sample=False, pad_token_id=self.tok.eos_token_id)
                 for j, (_, g) in enumerate(chunk):
-                    txt = self.tok.decode(out[j][enc["input_ids"].shape[1]:], skip_special_tokens=True)
+                    txt = self.tok.decode(out[j][enc["input_ids"].shape[1] :], skip_special_tokens=True)
                     ans = txt.split(ANSWER_OPEN)[-1].split(ANSWER_CLOSE)[0] if ANSWER_OPEN in txt else txt
-                    try: good, _ = TASKS[task]["score"](ans, g)
-                    except Exception: good = False
-                    cor[task] += bool(good); tot[task] += 1
+                    try:
+                        good, _ = TASKS[task]["score"](ans, g)
+                    except Exception:
+                        good = False
+                    cor[task] += bool(good)
+                    tot[task] += 1
         msg = "  ".join(f"{t}={cor[t]}/{tot[t]}={cor[t]/max(1,tot[t])*100:.0f}%" for t in sorted(tot))
         print(f"[GENEVAL] step {step}:  {msg}", flush=True)
-        self.tok.padding_side = pad_side; model.config.use_cache = uc
-        try: model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
-        except Exception: pass
-        if was_train: model.train()
+        self.tok.padding_side = pad_side
+        model.config.use_cache = uc
+        try:
+            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+        except Exception:
+            pass
+        if was_train:
+            model.train()
 
 
 def main():
     a = parse()
     if a.gpu_mem_frac < 1.0:
         torch.cuda.set_per_process_memory_fraction(a.gpu_mem_frac, 0)
-    tok = AutoTokenizer.from_pretrained(a.model); tok.chat_template = CHAT_TEMPLATE
+    tok = AutoTokenizer.from_pretrained(a.model)
+    tok.chat_template = CHAT_TEMPLATE
     model = AutoModelForCausalLM.from_pretrained(a.model, dtype=torch.bfloat16, attn_implementation="flash_attention_2")
     model.config.use_cache = False
-    model = get_peft_model(model, LoraConfig(
-        r=a.rank, lora_alpha=a.alpha, lora_dropout=0.05, target_modules="all-linear",
-        use_rslora=True, bias="none", task_type="CAUSAL_LM"))
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            r=a.rank,
+            lora_alpha=a.alpha,
+            lora_dropout=0.05,
+            target_modules="all-linear",
+            use_rslora=True,
+            bias="none",
+            task_type="CAUSAL_LM",
+        ),
+    )
     model.enable_input_require_grads()
     print("[rehearsal-only] FRESH LoRA from base, rehearsal data only", flush=True)
 
     train_ds = load_from_disk(os.path.join(a.data, "train"))
     args = TrainingArguments(
-        output_dir=a.out, per_device_train_batch_size=a.bs, gradient_accumulation_steps=a.ga,
-        learning_rate=a.lr, lr_scheduler_type="cosine", warmup_ratio=0.03, num_train_epochs=a.epochs,
-        bf16=True, gradient_checkpointing=True, gradient_checkpointing_kwargs={"use_reentrant": False},
-        optim="adamw_torch_fused", logging_steps=5, save_steps=a.save_steps,
-        save_total_limit=a.save_total_limit, eval_strategy="no", report_to="none",
-        dataloader_num_workers=2, dataloader_pin_memory=True, seed=1234)  # fresh seed
+        output_dir=a.out,
+        per_device_train_batch_size=a.bs,
+        gradient_accumulation_steps=a.ga,
+        learning_rate=a.lr,
+        lr_scheduler_type="cosine",
+        warmup_ratio=0.03,
+        num_train_epochs=a.epochs,
+        bf16=True,
+        gradient_checkpointing=True,
+        gradient_checkpointing_kwargs={"use_reentrant": False},
+        optim="adamw_torch_fused",
+        logging_steps=5,
+        save_steps=a.save_steps,
+        save_total_limit=a.save_total_limit,
+        eval_strategy="no",
+        report_to="none",
+        dataloader_num_workers=2,
+        dataloader_pin_memory=True,
+        seed=1234,
+    )  # fresh seed
 
     items = build_eval_items(a.geneval_n)
-    trainer = Trainer(model=model, args=args, train_dataset=train_ds, data_collator=collate,
-                      callbacks=[GenEval(tok, items, a.geneval_steps)] if items else [])
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=train_ds,
+        data_collator=collate,
+        callbacks=[GenEval(tok, items, a.geneval_steps)] if items else [],
+    )
     import glob as _glob
+
     ckpt = bool(a.resume and _glob.glob(os.path.join(a.out, "checkpoint-*")))
     if items and not ckpt:
-        try: GenEval(tok, items, 1)._run(model, 0)   # step-0 baseline = fresh-LoRA-untrained ~= base
-        except Exception as e: print(f"[geneval] baseline skipped: {e}", flush=True)
+        try:
+            GenEval(tok, items, 1)._run(model, 0)  # step-0 baseline = fresh-LoRA-untrained ~= base
+        except Exception as e:
+            print(f"[geneval] baseline skipped: {e}", flush=True)
     trainer.train(resume_from_checkpoint=ckpt if ckpt else None)
-    trainer.save_model(os.path.join(a.out, "final")); tok.save_pretrained(os.path.join(a.out, "final"))
+    trainer.save_model(os.path.join(a.out, "final"))
+    tok.save_pretrained(os.path.join(a.out, "final"))
     print("REHEARSAL_DONE ->", os.path.join(a.out, "final"), flush=True)
 
 


### PR DESCRIPTION
This PR re-enables the `make format` task for this contribution and checks in the reformatted code. The tests still pass. 

Without this change, the `format` target has to be disabled for this contribution, because otherwise whenever anyone else submits a PR, the CI process will fail when `black` detects that it should reformat some of the files here.

## Changes:

All the changes are under `contrib/nguyennm1024-sociocultural-alignment/`:

* `.custom.mk`: Removes the override definition of `format-default`, so `make format` runs again.
* `consortium_experiment/**`: Reformatted files.