### PR TITLE
Generalize evaluation gate schema

### DIFF
--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -179,7 +179,7 @@ src/tapestry/
 The implemented slices today are:
 
 - **`training/consortium/`** — governed shared-base integration, sovereign training nodes (`SovereignTrainingNode`), contribution weighting (`ContributionPolicy`), and the `TinyCausalModel` demo model. See the [PoC README](../../src/tapestry/training/consortium/README.md) for the full module map.
-- **`evaluation/`** — the tool-neutral M0 evaluation gate (`EvaluationGate`, `BenchmarkSpec`, `EvaluationResult`, `EvaluationBundle`). Benchmark runners produce `EvaluationResult` records; the gate produces a deterministic go/no-go `GateDecision`. See the [M0 gate schema](../work-groups/evaluation-certification/m0-gate-schema.md) for the design and usage example.
+- **`evaluation/`** — the tool-neutral evaluation gate (`EvaluationGate`, `BenchmarkSpec`, `EvaluationResult`, `EvaluationBundle`). Benchmark runners produce `EvaluationResult` records; the gate produces a deterministic go/no-go `GateDecision`. See the [evaluation gate schema](../work-groups/evaluation-certification/evaluation-gate-schema.md) for the design and usage example.
 
 New code should stay aligned with the data / training / evaluation / infrastructure split.
 

--- a/docs/work-groups/evaluation-certification/README.md
+++ b/docs/work-groups/evaluation-certification/README.md
@@ -33,7 +33,7 @@ Out of scope: implementing training or serving stacks, deciding governance repre
 - Audit evidence requirements for Data Governance, Security & Privacy, and Governance & Participation.
 - A [policy and evaluation tooling options](tooling-options.md) catalog for
   selecting benchmark runners, evidence records, and release-gate policy checks.
-- An [M0 evaluation gate schema](m0-gate-schema.md) for machine-readable
+- An [evaluation gate schema](evaluation-gate-schema.md) for machine-readable
   benchmark requirements, runner results, and go/no-go decisions.
 
 ## Interfaces

--- a/docs/work-groups/evaluation-certification/evaluation-gate-schema.md
+++ b/docs/work-groups/evaluation-certification/evaluation-gate-schema.md
@@ -1,9 +1,10 @@
-# M0 Evaluation Gate Schema
+# Evaluation Gate Schema
 
-Issue [#119](https://github.com/The-AI-Alliance/tapestry/issues/119) calls
-for a minimally sufficient M0 evaluation framework before Tapestry commits to
-a full benchmark stack. The first production artifact is the tool-neutral gate
-schema in `tapestry.evaluation`.
+Issue [#119](https://github.com/The-AI-Alliance/tapestry/issues/119) now tracks
+the post-M0/M1 evaluation framework. The initial production artifact is the
+tool-neutral gate schema in `tapestry.evaluation`, which gives benchmark
+runners a stable result contract before Tapestry commits to a full benchmark
+stack.
 
 The schema separates four concerns:
 
@@ -18,6 +19,10 @@ The schema separates four concerns:
 This lets the work group decide benchmark tools and task packaging separately
 from release-gate semantics. It also gives future CI, infrastructure, and
 certification work a stable result contract to target.
+
+The current schema version is `evaluation-gate/v1`. Bundles that still declare
+`m0-evaluation-gate/v1` remain valid as a legacy alias for the original M0
+contract.
 
 ## Example
 
@@ -87,12 +92,12 @@ assert decision.passed
 
 - Keep #119 benchmark selection discussions focused on concrete
   `BenchmarkSpec` entries.
-- Require M0 runners to emit `EvaluationResult` records, regardless of the
+- Require runners to emit `EvaluationResult` records, regardless of the
   underlying tool.
 - Include the gate's `config_hash`, model/checkpoint/artifact id, runner id, and
   runner version in each `EvaluationBundle`, so pre-registered thresholds and
   result bundles can be compared across member runs.
-- Keep evidence visibility out of this M0 gate contract until TAP-010 evidence
+- Keep evidence visibility out of this gate contract until TAP-010 evidence
   modes are typed and mapped to release-gate semantics.
 - Treat missing required results and threshold misses as blocking findings.
 - Treat unexpected runner output as reportable but non-blocking, so experiments

--- a/src/tapestry/evaluation/gates.py
+++ b/src/tapestry/evaluation/gates.py
@@ -1,7 +1,7 @@
 """Tool-neutral evaluation release gates.
 
-The M0 evaluation work needs a small, machine-readable contract before the
-project commits to a specific benchmark runner. This module records benchmark
+The evaluation work needs a small, machine-readable contract that does not
+depend on a specific benchmark runner. This module records benchmark
 requirements and evaluates runner output against those requirements.
 """
 
@@ -15,12 +15,13 @@ from enum import Enum
 from math import isfinite
 from types import MappingProxyType
 
-SCHEMA_VERSION = "m0-evaluation-gate/v1"
+SCHEMA_VERSION = "evaluation-gate/v1"
+LEGACY_SCHEMA_VERSIONS = frozenset({"m0-evaluation-gate/v1"})
 BUNDLE_FINDING_ID = "__evaluation_bundle__"
 
 
 class BenchmarkKind(str, Enum):
-    """Evaluation areas Tapestry needs to gate for M0 and later releases."""
+    """Evaluation areas Tapestry needs to gate for releases."""
 
     CAPABILITY = "capability"
     CULTURAL_ALIGNMENT = "cultural-alignment"
@@ -236,7 +237,7 @@ class EvaluationGate:
     def decide_bundle(self, bundle: EvaluationBundle) -> GateDecision:
         """Return the go/no-go decision for a versioned result bundle."""
         findings: list[GateFinding] = []
-        if bundle.schema_version != SCHEMA_VERSION:
+        if bundle.schema_version not in _SUPPORTED_SCHEMA_VERSIONS:
             findings.append(
                 GateFinding(
                     benchmark_id=BUNDLE_FINDING_ID,
@@ -277,6 +278,9 @@ def benchmark_config_hash(specs: Iterable[BenchmarkSpec]) -> str:
     ]
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+_SUPPORTED_SCHEMA_VERSIONS = frozenset({SCHEMA_VERSION, *LEGACY_SCHEMA_VERSIONS})
 
 
 def _score_message(spec: BenchmarkSpec, score: float, passed: bool) -> str:

--- a/src/tests/tapestry/evaluation/test_gates.py
+++ b/src/tests/tapestry/evaluation/test_gates.py
@@ -38,7 +38,7 @@ def _bundle(
     gate: EvaluationGate,
     results: tuple[EvaluationResult, ...],
     config_hash: str | None = None,
-    schema_version: str = "m0-evaluation-gate/v1",
+    schema_version: str = "evaluation-gate/v1",
 ) -> EvaluationBundle:
     return EvaluationBundle(
         results=results,
@@ -238,6 +238,27 @@ class EvaluationGateTest(unittest.TestCase):
         )
         gate = EvaluationGate([spec])
         bundle = _bundle(gate, (EvaluationResult("capability-core", 0.7),))
+
+        decision = gate.decide_bundle(bundle)
+
+        self.assertTrue(decision.passed)
+        self.assertEqual(decision.findings[0].status, GateStatus.PASS)
+
+    def test_gate_accepts_legacy_m0_schema_version(self) -> None:
+        spec = BenchmarkSpec(
+            benchmark_id="capability-core",
+            name="Capability Core",
+            kind=BenchmarkKind.CAPABILITY,
+            metric="accuracy",
+            config=_config(task_version="capability-core/v1"),
+            threshold=0.6,
+        )
+        gate = EvaluationGate([spec])
+        bundle = _bundle(
+            gate,
+            (EvaluationResult("capability-core", 0.7),),
+            schema_version="m0-evaluation-gate/v1",
+        )
 
         decision = gate.decide_bundle(bundle)
 


### PR DESCRIPTION
## Description of the PR

Issue #119 has moved from an M0-only effort to the post-M0/M1 evaluation framework. This PR keeps the existing tool-neutral gate contract, but makes its schema identity and documentation release-neutral so future benchmark work does not look tied to M0.

It also preserves compatibility with existing M0 result bundles by accepting `m0-evaluation-gate/v1` as a legacy schema alias while making new bundles default to `evaluation-gate/v1`.

## Related Issues

Related issues or PRs: #119

## If Code Changes Are Included

### Description of Code Changes

- Updates `tapestry.evaluation.gates` to use the release-neutral schema version `evaluation-gate/v1`.
- Keeps `m0-evaluation-gate/v1` valid as a legacy alias in `EvaluationGate.decide_bundle`.
- Adds a regression test for legacy M0 bundle compatibility.
- Renames the schema documentation from `m0-gate-schema.md` to `evaluation-gate-schema.md` and updates references.

### Testing Performed

- `git diff --check`
- `PYTHONPATH=src python3 -m unittest src/tests/tapestry/evaluation/test_gates.py`
- `python3 -m py_compile src/tapestry/evaluation/gates.py src/tests/tapestry/evaluation/test_gates.py`

I did not run `make before-pr` locally to avoid installing dependencies in this workspace.

### Example Usage

New bundles can omit `schema_version` and will default to `evaluation-gate/v1`. Previously emitted bundles using `m0-evaluation-gate/v1` continue to pass schema validation.

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For code changes:

- [x] I have tested the code changes in my local development environment.
- [x] I have added or modified tests for all code changes.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation.
- [ ] I have confirmed that the command `make before-pr` completes successfully.

For documentation changes, including `docs`:

- [x] I have followed the existing documentation styles and conventions.
- [x] I have included helpful diagrams, screenshots, tables, etc.