### PR TITLE
Add M1 readiness planning checks

### DIFF
--- a/src/tapestry/data/__init__.py
+++ b/src/tapestry/data/__init__.py
@@ -1,0 +1,21 @@
+"""Data governance and management helpers."""
+
+from tapestry.data.management import (
+    M1_REQUIRED_DATA_CAPABILITIES,
+    DataCapabilityFinding,
+    DataParticipationMode,
+    DataPipelineCapability,
+    DataToolAssessment,
+    allowed_modes_for_shared_training,
+    ods_assessment_questions,
+)
+
+__all__ = [
+    "M1_REQUIRED_DATA_CAPABILITIES",
+    "DataCapabilityFinding",
+    "DataParticipationMode",
+    "DataPipelineCapability",
+    "DataToolAssessment",
+    "allowed_modes_for_shared_training",
+    "ods_assessment_questions",
+]

--- a/src/tapestry/data/management.py
+++ b/src/tapestry/data/management.py
@@ -1,0 +1,110 @@
+"""Data-management capability checks for M1 planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class DataParticipationMode(str, Enum):
+    """Dataset participation modes used by Tapestry governance requirements."""
+
+    OPEN = "open"
+    RESTRICTED = "restricted"
+    LOCAL_ONLY = "local-only"
+    PARTICIPANT_PRIVATE = "participant-private"
+
+
+class DataPipelineCapability(str, Enum):
+    """Capabilities required from data storage and processing pipelines."""
+
+    CATALOG = "catalog"
+    POINTER_BASED_DATASETS = "pointer-based-datasets"
+    STRUCTURED_RIGHTS_METADATA = "structured-rights-metadata"
+    ACCESS_CONTROL = "access-control"
+    EVENT_CAPTURE = "event-capture"
+    VISIBILITY_TIERS = "visibility-tiers"
+    PORTABLE_SCHEMAS = "portable-schemas"
+    STREAMING_LARGE_ARTIFACTS = "streaming-large-artifacts"
+
+
+M1_REQUIRED_DATA_CAPABILITIES: frozenset[DataPipelineCapability] = frozenset(
+    {
+        DataPipelineCapability.CATALOG,
+        DataPipelineCapability.POINTER_BASED_DATASETS,
+        DataPipelineCapability.STRUCTURED_RIGHTS_METADATA,
+        DataPipelineCapability.ACCESS_CONTROL,
+        DataPipelineCapability.EVENT_CAPTURE,
+        DataPipelineCapability.VISIBILITY_TIERS,
+        DataPipelineCapability.PORTABLE_SCHEMAS,
+    }
+)
+
+
+@dataclass(frozen=True)
+class DataCapabilityFinding:
+    """One missing capability from a data-management tool or plan."""
+
+    capability: DataPipelineCapability
+    message: str
+
+
+@dataclass(frozen=True)
+class DataToolAssessment:
+    """A tool-neutral assessment of a data platform option such as ODS."""
+
+    tool_name: str
+    supported_capabilities: frozenset[DataPipelineCapability]
+    viable_long_term: bool | None = None
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.tool_name.strip():
+            raise ValueError("tool_name must not be empty")
+        object.__setattr__(
+            self,
+            "supported_capabilities",
+            frozenset(DataPipelineCapability(capability) for capability in self.supported_capabilities),
+        )
+        object.__setattr__(self, "notes", tuple(self.notes))
+
+    @property
+    def missing_m1_capabilities(self) -> tuple[DataPipelineCapability, ...]:
+        """Capabilities still missing for M1 data-pipeline readiness."""
+        return tuple(
+            capability
+            for capability in sorted(M1_REQUIRED_DATA_CAPABILITIES, key=lambda item: item.value)
+            if capability not in self.supported_capabilities
+        )
+
+    def findings(self) -> tuple[DataCapabilityFinding, ...]:
+        """Return capability gaps as reviewer-readable findings."""
+        return tuple(
+            DataCapabilityFinding(
+                capability=capability,
+                message=f"{self.tool_name} has not shown M1 capability: {capability.value}",
+            )
+            for capability in self.missing_m1_capabilities
+        )
+
+
+def ods_assessment_questions() -> tuple[str, ...]:
+    """Questions to answer before adopting Open Data Spaces for Tapestry."""
+    return (
+        "Is the project active enough for Tapestry to depend on it?",
+        "Can it stream large training artifacts without unacceptable overhead?",
+        "Which governance controls are native and which require extensions?",
+        "Can participant-local datasets be represented by manifests, hashes, or attestations?",
+        "Can visibility-tiered evidence be exported for evaluation and certification gates?",
+    )
+
+
+def allowed_modes_for_shared_training() -> frozenset[DataParticipationMode]:
+    """Return modes that can participate in shared training with controls."""
+    return frozenset(
+        {
+            DataParticipationMode.OPEN,
+            DataParticipationMode.RESTRICTED,
+            DataParticipationMode.LOCAL_ONLY,
+        }
+    )

--- a/src/tapestry/evaluation/__init__.py
+++ b/src/tapestry/evaluation/__init__.py
@@ -21,10 +21,10 @@ from tapestry.evaluation.plan import (
 )
 
 __all__ = [
+    "DEFAULT_M1_REQUIRED_KINDS",
     "BenchmarkConfig",
     "BenchmarkKind",
     "BenchmarkSpec",
-    "DEFAULT_M1_REQUIRED_KINDS",
     "EvaluationBundle",
     "EvaluationGate",
     "EvaluationPlan",

--- a/src/tapestry/evaluation/__init__.py
+++ b/src/tapestry/evaluation/__init__.py
@@ -12,16 +12,28 @@ from tapestry.evaluation.gates import (
     GateStatus,
     benchmark_config_hash,
 )
+from tapestry.evaluation.plan import (
+    DEFAULT_M1_REQUIRED_KINDS,
+    EvaluationPlan,
+    EvaluationPlanDecision,
+    EvaluationPlanFinding,
+    required_kind_summary,
+)
 
 __all__ = [
     "BenchmarkConfig",
     "BenchmarkKind",
     "BenchmarkSpec",
+    "DEFAULT_M1_REQUIRED_KINDS",
     "EvaluationBundle",
     "EvaluationGate",
+    "EvaluationPlan",
+    "EvaluationPlanDecision",
+    "EvaluationPlanFinding",
     "EvaluationResult",
     "GateDecision",
     "GateFinding",
     "GateStatus",
     "benchmark_config_hash",
+    "required_kind_summary",
 ]

--- a/src/tapestry/evaluation/plan.py
+++ b/src/tapestry/evaluation/plan.py
@@ -1,0 +1,86 @@
+"""Evaluation-plan coverage helpers for M1 readiness.
+
+The project already has gate logic that can decide whether a result bundle
+passes. This module adds the planning layer above it: a compact way to check
+whether a proposed evaluation bundle covers the minimum axes discussed for M1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from tapestry.evaluation.gates import BenchmarkKind, BenchmarkSpec, EvaluationGate
+
+
+DEFAULT_M1_REQUIRED_KINDS: tuple[BenchmarkKind, ...] = (
+    BenchmarkKind.CAPABILITY,
+    BenchmarkKind.CULTURAL_ALIGNMENT,
+    BenchmarkKind.SAFETY,
+)
+
+
+@dataclass(frozen=True)
+class EvaluationPlanFinding:
+    """One issue found while checking an evaluation plan."""
+
+    kind: BenchmarkKind
+    message: str
+
+
+@dataclass(frozen=True)
+class EvaluationPlanDecision:
+    """Coverage decision for a proposed set of benchmark specs."""
+
+    ready: bool
+    findings: tuple[EvaluationPlanFinding, ...]
+
+
+@dataclass(frozen=True)
+class EvaluationPlan:
+    """A versioned, runner-neutral plan for M1 benchmark coverage."""
+
+    specs: tuple[BenchmarkSpec, ...]
+    required_kinds: tuple[BenchmarkKind, ...] = DEFAULT_M1_REQUIRED_KINDS
+
+    def __post_init__(self) -> None:
+        if not self.specs:
+            raise ValueError("EvaluationPlan requires at least one benchmark spec")
+        object.__setattr__(self, "specs", tuple(self.specs))
+        object.__setattr__(self, "required_kinds", tuple(BenchmarkKind(kind) for kind in self.required_kinds))
+
+    @property
+    def covered_required_kinds(self) -> frozenset[BenchmarkKind]:
+        """Required benchmark kinds covered by at least one required spec."""
+        return frozenset(spec.kind for spec in self.specs if spec.required and spec.kind in self.required_kinds)
+
+    @property
+    def missing_required_kinds(self) -> tuple[BenchmarkKind, ...]:
+        """Required benchmark kinds not represented by the plan."""
+        covered = self.covered_required_kinds
+        return tuple(kind for kind in self.required_kinds if kind not in covered)
+
+    def check_coverage(self) -> EvaluationPlanDecision:
+        """Return whether the plan covers the configured required axes."""
+        findings = tuple(
+            EvaluationPlanFinding(
+                kind=kind,
+                message=f"required M1 evaluation axis {kind.value} is missing",
+            )
+            for kind in self.missing_required_kinds
+        )
+        return EvaluationPlanDecision(ready=not findings, findings=findings)
+
+    def gate(self) -> EvaluationGate:
+        """Build a release gate from the plan specs."""
+        return EvaluationGate(list(self.specs))
+
+
+def required_kind_summary(specs: Iterable[BenchmarkSpec]) -> dict[str, int]:
+    """Count required benchmark specs by kind for PR and runbook summaries."""
+    counts: dict[str, int] = {}
+    for spec in specs:
+        if not spec.required:
+            continue
+        counts[spec.kind.value] = counts.get(spec.kind.value, 0) + 1
+    return counts

--- a/src/tapestry/evaluation/plan.py
+++ b/src/tapestry/evaluation/plan.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 
 from tapestry.evaluation.gates import BenchmarkKind, BenchmarkSpec, EvaluationGate
 
-
 DEFAULT_M1_REQUIRED_KINDS: tuple[BenchmarkKind, ...] = (
     BenchmarkKind.CAPABILITY,
     BenchmarkKind.CULTURAL_ALIGNMENT,
@@ -47,7 +46,11 @@ class EvaluationPlan:
         if not self.specs:
             raise ValueError("EvaluationPlan requires at least one benchmark spec")
         object.__setattr__(self, "specs", tuple(self.specs))
-        object.__setattr__(self, "required_kinds", tuple(BenchmarkKind(kind) for kind in self.required_kinds))
+        object.__setattr__(
+            self,
+            "required_kinds",
+            tuple(BenchmarkKind(kind) for kind in self.required_kinds),
+        )
 
     @property
     def covered_required_kinds(self) -> frozenset[BenchmarkKind]:
@@ -82,5 +85,6 @@ def required_kind_summary(specs: Iterable[BenchmarkSpec]) -> dict[str, int]:
     for spec in specs:
         if not spec.required:
             continue
-        counts[spec.kind.value] = counts.get(spec.kind.value, 0) + 1
+        kind = BenchmarkKind(spec.kind)
+        counts[kind.value] = counts.get(kind.value, 0) + 1
     return counts

--- a/src/tapestry/infrastructure/__init__.py
+++ b/src/tapestry/infrastructure/__init__.py
@@ -1,0 +1,19 @@
+"""Infrastructure planning helpers."""
+
+from tapestry.infrastructure.communication import (
+    CommunicationFinding,
+    CommunicationPlan,
+    CommunicationSeverity,
+    CommunicationTopology,
+    TransportProtocol,
+    assess_communication_plan,
+)
+
+__all__ = [
+    "CommunicationFinding",
+    "CommunicationPlan",
+    "CommunicationSeverity",
+    "CommunicationTopology",
+    "TransportProtocol",
+    "assess_communication_plan",
+]

--- a/src/tapestry/infrastructure/communication.py
+++ b/src/tapestry/infrastructure/communication.py
@@ -61,8 +61,8 @@ class CommunicationPlan:
         object.__setattr__(self, "notes", tuple(self.notes))
 
     @property
-    def is_m1_ready(self) -> bool:
-        """Return whether the plan has no blocking findings."""
+    def has_no_blockers(self) -> bool:
+        """Return whether assessment found no blocking issues."""
         return not any(finding.severity is CommunicationSeverity.BLOCKER for finding in assess_communication_plan(self))
 
 

--- a/src/tapestry/infrastructure/communication.py
+++ b/src/tapestry/infrastructure/communication.py
@@ -1,0 +1,135 @@
+"""Inter-node communication checks for consortium-training planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class CommunicationTopology(str, Enum):
+    """Supported high-level topology choices."""
+
+    HUB_AND_SPOKE = "hub-and-spoke"
+    PEER_TO_PEER = "peer-to-peer"
+    HYBRID = "hybrid"
+
+
+class TransportProtocol(str, Enum):
+    """Transport protocols under consideration for node communication."""
+
+    GRPC_HTTP2 = "grpc-http2"
+    HTTPS = "https"
+    CUSTOM = "custom"
+
+
+class CommunicationSeverity(str, Enum):
+    """Severity for communication-plan findings."""
+
+    BLOCKER = "blocker"
+    WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class CommunicationFinding:
+    """One finding about a proposed communication plan."""
+
+    requirement_id: str
+    severity: CommunicationSeverity
+    message: str
+
+
+@dataclass(frozen=True)
+class CommunicationPlan:
+    """A small, implementation-neutral description of M1 node communication."""
+
+    topology: CommunicationTopology | str
+    protocol: TransportProtocol | str
+    sovereign_nodes_connect_outbound: bool
+    authenticated_transport: bool
+    coordinator_state_persistent: bool
+    node_supervisor_with_backoff: bool
+    membership_controls: bool
+    straggler_policy: str | None = None
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "topology", CommunicationTopology(self.topology))
+        object.__setattr__(self, "protocol", TransportProtocol(self.protocol))
+        if self.straggler_policy is not None and not self.straggler_policy.strip():
+            raise ValueError("straggler_policy must not be blank when provided")
+        object.__setattr__(self, "notes", tuple(self.notes))
+
+    @property
+    def is_m1_ready(self) -> bool:
+        """Return whether the plan has no blocking findings."""
+        return not any(finding.severity is CommunicationSeverity.BLOCKER for finding in assess_communication_plan(self))
+
+
+def assess_communication_plan(plan: CommunicationPlan) -> tuple[CommunicationFinding, ...]:
+    """Assess a communication plan against M1 consortium-readiness concerns."""
+    findings: list[CommunicationFinding] = []
+
+    if plan.topology is CommunicationTopology.PEER_TO_PEER:
+        findings.append(
+            CommunicationFinding(
+                "COMM-TOPOLOGY",
+                CommunicationSeverity.WARNING,
+                "peer-to-peer adds coordination and firewall complexity; document why hub-and-spoke is insufficient",
+            )
+        )
+
+    if not plan.sovereign_nodes_connect_outbound:
+        findings.append(
+            CommunicationFinding(
+                "COMM-EGRESS",
+                CommunicationSeverity.BLOCKER,
+                "sovereign nodes should be able to participate with outbound-only connections",
+            )
+        )
+
+    if not plan.authenticated_transport:
+        findings.append(
+            CommunicationFinding(
+                "COMM-AUTH",
+                CommunicationSeverity.BLOCKER,
+                "transport must authenticate nodes before model updates or artifacts move",
+            )
+        )
+
+    if not plan.coordinator_state_persistent:
+        findings.append(
+            CommunicationFinding(
+                "COMM-STATE",
+                CommunicationSeverity.WARNING,
+                "coordinator state persistence should be verified before multi-day M1 runs",
+            )
+        )
+
+    if not plan.node_supervisor_with_backoff:
+        findings.append(
+            CommunicationFinding(
+                "COMM-SUPERVISION",
+                CommunicationSeverity.WARNING,
+                "node processes need supervisor/backoff behavior when the coordinator is unreachable",
+            )
+        )
+
+    if not plan.membership_controls:
+        findings.append(
+            CommunicationFinding(
+                "COMM-MEMBERSHIP",
+                CommunicationSeverity.WARNING,
+                "M1 governance needs explicit node join, leave, and eject controls",
+            )
+        )
+
+    if plan.straggler_policy is None:
+        findings.append(
+            CommunicationFinding(
+                "COMM-STRAGGLERS",
+                CommunicationSeverity.WARNING,
+                "heterogeneous nodes need a timeout or partial-aggregation policy",
+            )
+        )
+
+    return tuple(findings)

--- a/src/tapestry/infrastructure/communication.py
+++ b/src/tapestry/infrastructure/communication.py
@@ -39,6 +39,7 @@ class CommunicationFinding:
 
 
 @dataclass(frozen=True)
+# pylint: disable=too-many-instance-attributes
 class CommunicationPlan:
     """A small, implementation-neutral description of M1 node communication."""
 

--- a/src/tests/tapestry/data/test_management.py
+++ b/src/tests/tapestry/data/test_management.py
@@ -1,0 +1,70 @@
+"""Tests for data-management capability checks."""
+
+from __future__ import annotations
+
+import unittest
+
+from tapestry.data import (
+    DataParticipationMode,
+    DataPipelineCapability,
+    DataToolAssessment,
+    allowed_modes_for_shared_training,
+    ods_assessment_questions,
+)
+
+
+class DataManagementTest(unittest.TestCase):
+    """Data capability and ODS assessment helpers."""
+
+    def test_complete_data_tool_assessment_has_no_findings(self) -> None:
+        assessment = DataToolAssessment(
+            tool_name="candidate-catalog",
+            supported_capabilities=frozenset(
+                {
+                    DataPipelineCapability.CATALOG,
+                    DataPipelineCapability.POINTER_BASED_DATASETS,
+                    DataPipelineCapability.STRUCTURED_RIGHTS_METADATA,
+                    DataPipelineCapability.ACCESS_CONTROL,
+                    DataPipelineCapability.EVENT_CAPTURE,
+                    DataPipelineCapability.VISIBILITY_TIERS,
+                    DataPipelineCapability.PORTABLE_SCHEMAS,
+                }
+            ),
+        )
+
+        self.assertEqual(assessment.missing_m1_capabilities, ())
+        self.assertEqual(assessment.findings(), ())
+
+    def test_assessment_reports_missing_capabilities_for_ods_research(self) -> None:
+        assessment = DataToolAssessment(
+            tool_name="Open Data Spaces",
+            supported_capabilities=frozenset(
+                {
+                    DataPipelineCapability.CATALOG,
+                    DataPipelineCapability.PORTABLE_SCHEMAS,
+                }
+            ),
+        )
+
+        missing = assessment.missing_m1_capabilities
+
+        self.assertIn(DataPipelineCapability.ACCESS_CONTROL, missing)
+        self.assertIn(DataPipelineCapability.EVENT_CAPTURE, missing)
+        self.assertGreaterEqual(len(assessment.findings()), 5)
+
+    def test_ods_questions_cover_viability_and_large_artifact_streaming(self) -> None:
+        questions = " ".join(ods_assessment_questions())
+
+        self.assertIn("active enough", questions)
+        self.assertIn("stream large training artifacts", questions)
+        self.assertIn("participant-local datasets", questions)
+
+    def test_participant_private_mode_is_not_allowed_for_shared_training(self) -> None:
+        modes = allowed_modes_for_shared_training()
+
+        self.assertIn(DataParticipationMode.LOCAL_ONLY, modes)
+        self.assertNotIn(DataParticipationMode.PARTICIPANT_PRIVATE, modes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/tapestry/data/test_management.py
+++ b/src/tests/tapestry/data/test_management.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import unittest
 
 from tapestry.data import (
+    M1_REQUIRED_DATA_CAPABILITIES,
     DataParticipationMode,
     DataPipelineCapability,
     DataToolAssessment,
@@ -17,25 +18,17 @@ class DataManagementTest(unittest.TestCase):
     """Data capability and ODS assessment helpers."""
 
     def test_complete_data_tool_assessment_has_no_findings(self) -> None:
+        """A tool supporting all required capabilities has no findings."""
         assessment = DataToolAssessment(
             tool_name="candidate-catalog",
-            supported_capabilities=frozenset(
-                {
-                    DataPipelineCapability.CATALOG,
-                    DataPipelineCapability.POINTER_BASED_DATASETS,
-                    DataPipelineCapability.STRUCTURED_RIGHTS_METADATA,
-                    DataPipelineCapability.ACCESS_CONTROL,
-                    DataPipelineCapability.EVENT_CAPTURE,
-                    DataPipelineCapability.VISIBILITY_TIERS,
-                    DataPipelineCapability.PORTABLE_SCHEMAS,
-                }
-            ),
+            supported_capabilities=M1_REQUIRED_DATA_CAPABILITIES,
         )
 
         self.assertEqual(assessment.missing_m1_capabilities, ())
         self.assertEqual(assessment.findings(), ())
 
     def test_assessment_reports_missing_capabilities_for_ods_research(self) -> None:
+        """A partial ODS assessment reports the missing M1 capabilities."""
         assessment = DataToolAssessment(
             tool_name="Open Data Spaces",
             supported_capabilities=frozenset(
@@ -53,6 +46,7 @@ class DataManagementTest(unittest.TestCase):
         self.assertGreaterEqual(len(assessment.findings()), 5)
 
     def test_ods_questions_cover_viability_and_large_artifact_streaming(self) -> None:
+        """ODS assessment prompts cover viability, artifacts, and locality."""
         questions = " ".join(ods_assessment_questions())
 
         self.assertIn("active enough", questions)
@@ -60,6 +54,7 @@ class DataManagementTest(unittest.TestCase):
         self.assertIn("participant-local datasets", questions)
 
     def test_participant_private_mode_is_not_allowed_for_shared_training(self) -> None:
+        """Private-only data is excluded from shared-training participation."""
         modes = allowed_modes_for_shared_training()
 
         self.assertIn(DataParticipationMode.LOCAL_ONLY, modes)

--- a/src/tests/tapestry/evaluation/test_plan.py
+++ b/src/tests/tapestry/evaluation/test_plan.py
@@ -1,0 +1,74 @@
+"""Tests for M1 evaluation-plan coverage helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from tapestry.evaluation import (
+    BenchmarkConfig,
+    BenchmarkKind,
+    BenchmarkSpec,
+    EvaluationPlan,
+    required_kind_summary,
+)
+
+
+def _spec(benchmark_id: str, kind: BenchmarkKind, required: bool = True) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        benchmark_id=benchmark_id,
+        name=benchmark_id.replace("-", " ").title(),
+        kind=kind,
+        metric="score",
+        config=BenchmarkConfig(
+            task_version=f"{benchmark_id}/v1",
+            dataset_revision="2026-08-01",
+            prompt_template="zero-shot",
+        ),
+        threshold=0.7,
+        required=required,
+    )
+
+
+class EvaluationPlanTest(unittest.TestCase):
+    """Coverage behavior for M1 evaluation planning."""
+
+    def test_plan_is_ready_when_required_m1_axes_are_present(self) -> None:
+        plan = EvaluationPlan(
+            (
+                _spec("capability-core", BenchmarkKind.CAPABILITY),
+                _spec("cultural-alignment-smoke", BenchmarkKind.CULTURAL_ALIGNMENT),
+                _spec("refusal-safety", BenchmarkKind.SAFETY),
+                _spec("domain-extra", BenchmarkKind.DOMAIN, required=False),
+            )
+        )
+
+        decision = plan.check_coverage()
+
+        self.assertTrue(decision.ready)
+        self.assertEqual(decision.findings, ())
+        self.assertIn("capability-core", plan.gate().specs)
+
+    def test_plan_reports_missing_required_axes(self) -> None:
+        plan = EvaluationPlan((_spec("capability-core", BenchmarkKind.CAPABILITY),))
+
+        decision = plan.check_coverage()
+
+        self.assertFalse(decision.ready)
+        self.assertEqual(
+            [finding.kind for finding in decision.findings],
+            [BenchmarkKind.CULTURAL_ALIGNMENT, BenchmarkKind.SAFETY],
+        )
+
+    def test_required_kind_summary_ignores_optional_specs(self) -> None:
+        summary = required_kind_summary(
+            (
+                _spec("capability-core", BenchmarkKind.CAPABILITY),
+                _spec("domain-extra", BenchmarkKind.DOMAIN, required=False),
+            )
+        )
+
+        self.assertEqual(summary, {"capability": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/tapestry/evaluation/test_plan.py
+++ b/src/tests/tapestry/evaluation/test_plan.py
@@ -33,6 +33,7 @@ class EvaluationPlanTest(unittest.TestCase):
     """Coverage behavior for M1 evaluation planning."""
 
     def test_plan_is_ready_when_required_m1_axes_are_present(self) -> None:
+        """A plan is ready when capability, alignment, and safety are covered."""
         plan = EvaluationPlan(
             (
                 _spec("capability-core", BenchmarkKind.CAPABILITY),
@@ -49,6 +50,7 @@ class EvaluationPlanTest(unittest.TestCase):
         self.assertIn("capability-core", plan.gate().specs)
 
     def test_plan_reports_missing_required_axes(self) -> None:
+        """Missing required benchmark axes are reported as findings."""
         plan = EvaluationPlan((_spec("capability-core", BenchmarkKind.CAPABILITY),))
 
         decision = plan.check_coverage()
@@ -60,6 +62,7 @@ class EvaluationPlanTest(unittest.TestCase):
         )
 
     def test_required_kind_summary_ignores_optional_specs(self) -> None:
+        """Optional benchmarks are omitted from required-kind summaries."""
         summary = required_kind_summary(
             (
                 _spec("capability-core", BenchmarkKind.CAPABILITY),

--- a/src/tests/tapestry/infrastructure/test_communication.py
+++ b/src/tests/tapestry/infrastructure/test_communication.py
@@ -16,7 +16,7 @@ from tapestry.infrastructure import (
 class CommunicationPlanTest(unittest.TestCase):
     """M1 communication-readiness checks."""
 
-    def test_flower_style_hub_and_spoke_plan_is_m1_ready(self) -> None:
+    def test_flower_style_hub_and_spoke_plan_has_no_blockers(self) -> None:
         """A managed hub-and-spoke transport plan has no readiness findings."""
         plan = CommunicationPlan(
             topology=CommunicationTopology.HUB_AND_SPOKE,
@@ -30,7 +30,7 @@ class CommunicationPlanTest(unittest.TestCase):
         )
 
         self.assertEqual(assess_communication_plan(plan), ())
-        self.assertTrue(plan.is_m1_ready)
+        self.assertTrue(plan.has_no_blockers)
 
     def test_missing_auth_and_outbound_participation_are_blockers(self) -> None:
         """Missing outbound participation and authentication are blockers."""
@@ -47,7 +47,7 @@ class CommunicationPlanTest(unittest.TestCase):
 
         findings = assess_communication_plan(plan)
 
-        self.assertFalse(plan.is_m1_ready)
+        self.assertFalse(plan.has_no_blockers)
         self.assertEqual(
             [finding.requirement_id for finding in findings],
             ["COMM-EGRESS", "COMM-AUTH"],
@@ -68,7 +68,7 @@ class CommunicationPlanTest(unittest.TestCase):
 
         findings = assess_communication_plan(plan)
 
-        self.assertTrue(plan.is_m1_ready)
+        self.assertTrue(plan.has_no_blockers)
         self.assertEqual(
             [finding.requirement_id for finding in findings],
             [

--- a/src/tests/tapestry/infrastructure/test_communication.py
+++ b/src/tests/tapestry/infrastructure/test_communication.py
@@ -17,6 +17,7 @@ class CommunicationPlanTest(unittest.TestCase):
     """M1 communication-readiness checks."""
 
     def test_flower_style_hub_and_spoke_plan_is_m1_ready(self) -> None:
+        """A managed hub-and-spoke transport plan has no readiness findings."""
         plan = CommunicationPlan(
             topology=CommunicationTopology.HUB_AND_SPOKE,
             protocol=TransportProtocol.GRPC_HTTP2,
@@ -32,6 +33,7 @@ class CommunicationPlanTest(unittest.TestCase):
         self.assertTrue(plan.is_m1_ready)
 
     def test_missing_auth_and_outbound_participation_are_blockers(self) -> None:
+        """Missing outbound participation and authentication are blockers."""
         plan = CommunicationPlan(
             topology=CommunicationTopology.HUB_AND_SPOKE,
             protocol=TransportProtocol.GRPC_HTTP2,
@@ -53,6 +55,7 @@ class CommunicationPlanTest(unittest.TestCase):
         self.assertTrue(all(finding.severity is CommunicationSeverity.BLOCKER for finding in findings))
 
     def test_peer_to_peer_without_operational_controls_warns(self) -> None:
+        """Peer-to-peer plans without operational controls stay warnings-only."""
         plan = CommunicationPlan(
             topology=CommunicationTopology.PEER_TO_PEER,
             protocol=TransportProtocol.CUSTOM,

--- a/src/tests/tapestry/infrastructure/test_communication.py
+++ b/src/tests/tapestry/infrastructure/test_communication.py
@@ -1,0 +1,82 @@
+"""Tests for inter-node communication planning checks."""
+
+from __future__ import annotations
+
+import unittest
+
+from tapestry.infrastructure import (
+    CommunicationPlan,
+    CommunicationSeverity,
+    CommunicationTopology,
+    TransportProtocol,
+    assess_communication_plan,
+)
+
+
+class CommunicationPlanTest(unittest.TestCase):
+    """M1 communication-readiness checks."""
+
+    def test_flower_style_hub_and_spoke_plan_is_m1_ready(self) -> None:
+        plan = CommunicationPlan(
+            topology=CommunicationTopology.HUB_AND_SPOKE,
+            protocol=TransportProtocol.GRPC_HTTP2,
+            sovereign_nodes_connect_outbound=True,
+            authenticated_transport=True,
+            coordinator_state_persistent=True,
+            node_supervisor_with_backoff=True,
+            membership_controls=True,
+            straggler_policy="round timeout with partial aggregation review",
+        )
+
+        self.assertEqual(assess_communication_plan(plan), ())
+        self.assertTrue(plan.is_m1_ready)
+
+    def test_missing_auth_and_outbound_participation_are_blockers(self) -> None:
+        plan = CommunicationPlan(
+            topology=CommunicationTopology.HUB_AND_SPOKE,
+            protocol=TransportProtocol.GRPC_HTTP2,
+            sovereign_nodes_connect_outbound=False,
+            authenticated_transport=False,
+            coordinator_state_persistent=True,
+            node_supervisor_with_backoff=True,
+            membership_controls=True,
+            straggler_policy="timeout",
+        )
+
+        findings = assess_communication_plan(plan)
+
+        self.assertFalse(plan.is_m1_ready)
+        self.assertEqual(
+            [finding.requirement_id for finding in findings],
+            ["COMM-EGRESS", "COMM-AUTH"],
+        )
+        self.assertTrue(all(finding.severity is CommunicationSeverity.BLOCKER for finding in findings))
+
+    def test_peer_to_peer_without_operational_controls_warns(self) -> None:
+        plan = CommunicationPlan(
+            topology=CommunicationTopology.PEER_TO_PEER,
+            protocol=TransportProtocol.CUSTOM,
+            sovereign_nodes_connect_outbound=True,
+            authenticated_transport=True,
+            coordinator_state_persistent=False,
+            node_supervisor_with_backoff=False,
+            membership_controls=False,
+        )
+
+        findings = assess_communication_plan(plan)
+
+        self.assertTrue(plan.is_m1_ready)
+        self.assertEqual(
+            [finding.requirement_id for finding in findings],
+            [
+                "COMM-TOPOLOGY",
+                "COMM-STATE",
+                "COMM-SUPERVISION",
+                "COMM-MEMBERSHIP",
+                "COMM-STRAGGLERS",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Several open M1 issues need a first executable contract before the project chooses final tools:

- evaluation work needs a way to verify benchmark-axis coverage before running gates;
- inter-node communication needs a checklist for outbound-only sovereign nodes, authenticated transport, state persistence, supervision, membership, and straggler behavior; and
- data-pipeline and Open Data Spaces evaluation needs a shared capability checklist.

## What

This PR adds small, tool-neutral Python planning helpers plus tests for M1 readiness. It does not choose Flower, ODS, lm-eval-harness, or any other implementation. Instead, it gives reviewers executable checks that capture the requirements emerging in the issues.

## How

- Add `tapestry.evaluation.plan` for M1 benchmark coverage checks and conversion into the existing `EvaluationGate`.
- Add `tapestry.infrastructure.communication` for inter-node communication plan findings.
- Add `tapestry.data.management` for data pipeline capability and ODS assessment helpers.
- Export the new helpers from their package `__init__` files.
- Use the existing `unit-tests` target for discovery; no dedicated Makefile target is added.
- Rename the communication convenience property to `has_no_blockers` so warning-only plans are not described as fully M1-ready.

## Related Issues

Related to #119.
Related to #204.
Related to #126.
Related to #195.
Related to #197.

## Testing

```bash
PYTHONPATH=src python3 -m unittest \
  src.tests.tapestry.evaluation.test_gates \
  src.tests.tapestry.evaluation.test_plan \
  src.tests.tapestry.infrastructure.test_communication \
  src.tests.tapestry.data.test_management

python3 -m compileall -q \
  src/tapestry/evaluation \
  src/tapestry/infrastructure \
  src/tapestry/data \
  src/tests/tapestry/evaluation \
  src/tests/tapestry/infrastructure \
  src/tests/tapestry/data

git diff --check
```

I also attempted `make before-pr`, but this local machine does not have `uv` installed (`/bin/sh: uv: command not found`). The branch has been rebased on current `develop`; CI should now use the repository runner environment and the fixed virtualenv cache from #236.
