### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - "examples/**"
       - "**/pyproject.toml"
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Format · Lint · Type-check · Tests


### PR DESCRIPTION
Potential fix for [https://github.com/The-AI-Alliance/tapestry/security/code-scanning/1](https://github.com/The-AI-Alliance/tapestry/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so token scope is least-privileged and documented.

Best fix here: define workflow-level permissions directly under `on:` block (or after it) and before `jobs:`:

- `contents: read`

This is sufficient for checkout and read-only CI tasks shown in this workflow, and it applies to all jobs unless overridden. No imports, methods, or dependencies are needed since this is YAML configuration only.

Edit file:
- `.github/workflows/ci.yml`
- Insert `permissions:` section between the trigger section and `jobs:` (after line 16 in the shown snippet).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
