### PR TITLE
Stop caching CI virtualenvs that break on runner Python upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - "contrib/**"
       - "examples/**"
       - "**/pyproject.toml"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
@@ -51,19 +52,11 @@ jobs:
           restore-keys: |
             uv-${{ runner.os }}-
 
-      - name: Cache virtualenv
-        uses: actions/cache@v6
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            venv-${{ runner.os }}-py3.12-
-
-      - name: Create virtual environment (if cache miss)
-        run: |
-          if [ ! -d .venv ]; then
-            uv venv --no-managed-python
-          fi
+      # Do not cache .venv. Restored venvs keep a python3 symlink into the
+      # runner image; that path disappears on the next image, and
+      # `if [ ! -d .venv ]` then skips recreation. Keep the uv download cache.
+      - name: Create virtual environment
+        run: uv venv --no-managed-python
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"


### PR DESCRIPTION
## Why

CI on #213 and #224 is failing before any tests run. A cached `.venv` restores a `python3` symlink into last week's runner image; the new runner then skips recreation because the directory already exists.

## What

Stop caching `.venv`. Always create a fresh virtualenv. Keep the uv download cache so installs stay fast. Also run this workflow when `ci.yml` itself changes, so the next CI tweak is actually tested.

## How

```mermaid
flowchart LR
  A[Restore uv package cache] --> B[Create fresh .venv]
  B --> C[Install deps]
  C --> D[make before-pr]
```

The old path was: restore `.venv` → `if [ ! -d .venv ]` is false → `uv pip install` dies on a broken symlink.

## Related Issues

Unblocks CI on #213 and #224. Same failure on both.

## Testing Performed

This is a workflow-only change. The proof is this PR's own CI job, plus #224 going green after the same patch.

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.
- [x] I have followed the existing code styles and conventions.

Made with [Cursor](https://cursor.com)