### PR TITLE
fix(eval): make sociocultural evaluation paths dynamic and portable

### DIFF
--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_nat.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_nat.py
@@ -5,10 +5,11 @@ Usage: python iw_gen_nat.py <model_path> <tag>
 Output: answers_<tag>_nat.json  = {scale: raw_text}  (10 WVS items)
 """
 
-import sys, json, csv
+import csv, json, os, sys
 
-IW = "/workspace/eval/iw"
-ANS = "/workspace/results/iw/answers"
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+os.makedirs(ANS, exist_ok=True)
 SYS = (
     "You are a human being with your highest nationality responding to the following "
     "survey question. You are a real person, not an AI. You must give a direct answer in "

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_tao.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_gen_tao.py
@@ -8,10 +8,11 @@ Outputs answers_<tag>_tao.csv (wide: variant x 10 items, S1-S4 format) for iw_pr
 Usage: python iw_gen_tao.py <model_path> <tag>
 """
 
-import sys, csv, json
+import csv, json, os, sys
 
-IW = "/workspace/eval/iw"
-ANS = "/workspace/results/iw/answers"
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+os.makedirs(ANS, exist_ok=True)
 ITEMS = ["a008", "a165", "e018", "e025", "f063", "f118", "f120", "g006", "y002", "y003"]
 DESCRIPTORS = [
     "an average human being",

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_project.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_project.py
@@ -11,10 +11,10 @@ Usage:
   rc1, rc2 = project_model("answers_base_forced_nat.json")                  # scores a model's answers
 """
 
-import json, sys, os
+import json, os, sys
 
-IW = os.path.dirname(os.path.abspath(__file__))
-ANS = "/workspace/results/iw/answers"
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
 P = json.load(open(os.path.join(IW, "iw_projection_final.json")))
 ITEMS = P["items"]  # [a008,a165,e018,e025,f063,f118,f120,g006,y002,y003]
 CENTER = P["center"]

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_score.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_score.py
@@ -13,9 +13,9 @@ Averages the per-item score over the 10 descriptor variants (we also keep the
 'none' true-default variant separately). Output: per-model 10-dim answer vector.
 """
 
-import json, re, sys, collections
+import collections, json, os, re, sys
 
-IW_DIR = "/workspace/eval/iw"
+IW_DIR = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 SCALES = ["f063", "y003", "f120", "g006", "e018", "y002", "a008", "f118", "e025", "a165"]
 NUMERIC = {"f063", "f120", "g006", "e018", "a008", "f118"}
 

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_iw10.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_iw10.py
@@ -8,10 +8,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_soups345.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_soups345.py
@@ -7,10 +7,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw05.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw05.py
@@ -8,10 +8,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw09.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_sw09.py
@@ -8,10 +8,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry.py
@@ -8,10 +8,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry07.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_tapestry07.py
@@ -8,10 +8,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_v3_sweep.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/plot_v3_sweep.py
@@ -8,10 +8,13 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-IW = "/workspace/eval/iw"
+import os
+
+IW = os.environ.get("TAPESTRY_IW_DIR", os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, IW)
-ANS = "/workspace/results/iw/answers"
-FIG = "/workspace/results/iw/figures"
+ANS = os.environ.get("TAPESTRY_ANS_DIR", os.path.join(IW, "../../results/iw/answers"))
+FIG = os.environ.get("TAPESTRY_FIG_DIR", os.path.join(IW, "../../results/iw/figures"))
+os.makedirs(FIG, exist_ok=True)
 from iw_project import project, ITEMS
 
 coords = json.load(open(f"{IW}/country_coords.json"))

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu.py
@@ -1,10 +1,12 @@
 """Full 14042 MMLU eval for a THINK/ANSWER model, records idx+subtask, incremental+resumable.
 Usage: python zs_full_mmlu.py <model> <tag> [budget]"""
 
-import sys, re, json, os
+import json, os, re, sys
 
-sys.path.insert(0, "/workspace/eval")
-sys.path.insert(0, "/workspace/train")
+EVAL_DIR = os.environ.get("TAPESTRY_EVAL_DIR", os.path.dirname(os.path.abspath(__file__)))
+TRAIN_DIR = os.environ.get("TAPESTRY_TRAIN_DIR", os.path.join(EVAL_DIR, "../training"))
+sys.path.insert(0, EVAL_DIR)
+sys.path.insert(0, TRAIN_DIR)
 AO, AC = "<ANSWER>", "</ANSWER>"
 
 
@@ -51,7 +53,8 @@ def main():
         meta.append(
             (i, r["input_correct_responses"][0].strip().strip('"').upper(), r["subtask_name"].replace("mmlu_chat.", ""))
         )
-    outpath = f"/workspace/results/mmlu/zs_{tag}_mmlu_results.jsonl"
+    results_dir = os.environ.get("TAPESTRY_MMLU_DIR", os.path.join(EVAL_DIR, "../results/mmlu"))
+    outpath = f"{results_dir}/zs_{tag}_mmlu_results.jsonl"
     os.makedirs(os.path.dirname(outpath), exist_ok=True)
     done = sum(1 for _ in open(outpath)) if os.path.exists(outpath) else 0
     print(f"[plan] full {len(d)}, resume {done}", flush=True)

--- a/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu_sweep.py
+++ b/contrib/nguyennm1024-sociocultural-alignment/evaluation/zs_full_mmlu_sweep.py
@@ -1,10 +1,12 @@
 """Full 14042 MMLU eval for a THINK/ANSWER model, records idx+subtask, incremental+resumable.
 Usage: python zs_full_mmlu.py <model> <tag> [budget]"""
 
-import sys, re, json, os
+import json, os, re, sys
 
-sys.path.insert(0, "/workspace/eval")
-sys.path.insert(0, "/workspace/train")
+EVAL_DIR = os.environ.get("TAPESTRY_EVAL_DIR", os.path.dirname(os.path.abspath(__file__)))
+TRAIN_DIR = os.environ.get("TAPESTRY_TRAIN_DIR", os.path.join(EVAL_DIR, "../training"))
+sys.path.insert(0, EVAL_DIR)
+sys.path.insert(0, TRAIN_DIR)
 AO, AC = "<ANSWER>", "</ANSWER>"
 
 
@@ -51,7 +53,8 @@ def main():
         meta.append(
             (i, r["input_correct_responses"][0].strip().strip('"').upper(), r["subtask_name"].replace("mmlu_chat.", ""))
         )
-    outpath = f"/workspace/results/mmlu/zs_{tag}_mmlu_results.jsonl"
+    results_dir = os.environ.get("TAPESTRY_MMLU_DIR", os.path.join(EVAL_DIR, "../results/mmlu"))
+    outpath = f"{results_dir}/zs_{tag}_mmlu_results.jsonl"
     os.makedirs(os.path.dirname(outpath), exist_ok=True)
     done = sum(1 for _ in open(outpath)) if os.path.exists(outpath) else 0
     print(f"[plan] full {len(d)}, resume {done}", flush=True)


### PR DESCRIPTION
## Description of the PR

* **Why:** The evaluation scripts in `contrib/nguyennm1024-sociocultural-alignment/` hardcoded absolute Docker paths (`/workspace/...`). This prevented contributors and partners from running the Inglehart–Welzel cultural projection, WVS elicitation, scoring, and visualization scripts outside of the original container (such as on bare-metal GPU VMs, local workstations, or cloud compute instances). The contribution's README explicitly noted this as a known follow-up.
* **What:** Replaced hardcoded `/workspace/...` paths across 13 evaluation scripts with dynamic module-relative paths (`__file__`) and environment variable overrides (`TAPESTRY_IW_DIR`, `TAPESTRY_ANS_DIR`, `TAPESTRY_FIG_DIR`, `TAPESTRY_MMLU_DIR`). Target output directories are now automatically created if missing, enabling the evaluation suite to run cleanly in any environment.

## Related Issues

Related issues or PRs (#number, ...): #22, #116, #243

## If Code Changes Are Included

### Description of Code Changes

Modified 13 scripts under `contrib/nguyennm1024-sociocultural-alignment/evaluation/`:
* `iw/iw_score.py`: `IW_DIR` now defaults dynamically to `os.path.dirname(os.path.abspath(__file__))` with a `TAPESTRY_IW_DIR` environment override.
* `iw/iw_project.py`: `ANS` defaults dynamically relative to `IW` (`../../results/iw/answers`) with a `TAPESTRY_ANS_DIR` override.
* `iw/iw_gen_tao.py` & `iw/iw_gen_nat.py`: `IW` and `ANS` paths made portable; ensures target output directories exist via `os.makedirs(..., exist_ok=True)`.
* `iw/plot_*.py` (7 plotting scripts: `plot_iw10.py`, `plot_soups345.py`, `plot_sw05.py`, `plot_sw09.py`, `plot_tapestry.py`, `plot_tapestry07.py`, `plot_v3_sweep.py`): Replaced `/workspace` paths with dynamic resolution and directory creation for figures (`FIG`).
* `zs_full_mmlu.py` & `zs_full_mmlu_sweep.py`: `sys.path` and output result paths resolved dynamically relative to `__file__` with `TAPESTRY_MMLU_DIR` override.

### Testing Performed

* Executed local verification of `iw_project.py` against R ground-truth projection values:
```text
base     python=(+1.9709,+2.1096)  R-truth=(+1.9709,+2.1096)  d=0.0000
soupiw   python=(+1.1616,+2.2365)  R-truth=(+1.1616,+2.2365)  d=0.0000
```
* Confirmed bit-exact mathematical outputs ($d=0.0000$) and dynamic creation of output directories.

### Example Usage

Run the projection script from any directory or VM without needing a `/workspace` mount:
```bash
python3 contrib/nguyennm1024-sociocultural-alignment/evaluation/iw/iw_project.py
```

## Checklist

Confirm that the following have been completed.

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.

For code changes:

- [x] I have tested the code changes in my local development environment.
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have confirmed that the command `make before-pr` completes successfully.
