### PR TITLE
[Update] Fix top-level Makefile so contrib .targets.mk targets are reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
             exit 1
           fi
 
+      # Every contrib/*/.targets.mk must be read by the top-level Makefile,
+      # otherwise the contributions' custom targets are silently unreachable.
+      - name: Check contrib custom targets are included
+        run: |
+          expected=$(ls contrib/*/.targets.mk 2>/dev/null | wc -l)
+          actual=$(make --debug=v -n help | grep -c "Reading makefile 'contrib/.*/\.targets\.mk'" || true)
+          echo "contrib .targets.mk files: $expected present, $actual included"
+          test "$expected" -eq "$actual"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,12 @@ consortium-demo::
 	@echo "${INFO_LABEL}Running the consortium-training demo: ${CODE}examples/consortium_training_demo.py${_END}"
 	uv run python examples/consortium_training_demo.py
 
-# This construct uses the list of .targets.mk files in $(CONTRIB_TARGETS_MKS) and
-# includes each one individually to define custom targets for the contributions.
-#$(foreach prog_mk,$(CONTRIB_TARGETS_MKS),$(eval -include $(prog_mk)))
-include ${CONTRIB_TARGETS_MKS}
-
-# Finally, include all the common targets, including those not overridden above
+# Include all the common targets, including those not overridden above.
 include .common.mk
 include .formal-spec.mk
+
+# Include the contributions' custom targets, if any. This must come after
+# .common.mk, which defines $(CONTRIB_TARGETS_MKS), the list of every
+# contrib/*/.targets.mk file. (Before .common.mk is read the variable is
+# empty and the include silently does nothing.)
+include ${CONTRIB_TARGETS_MKS}


### PR DESCRIPTION
## Description of the PR

**Why.** The custom `make` targets that contributions define in `contrib/*/.targets.mk` are unreachable from the top-level `make`. `make consortium-experiment`, which `contrib/README.md` and the contribution's own README tell people to run, fails with `No rule to make target`. The same is true for every other contribution target, including the six `cultural-cpt-*` targets.

**What.** A one-block move in the top-level `Makefile` makes the contribution targets work again, and a small CI step makes sure they cannot silently disappear a second time. No other `make` behaviour changes.

**How.** The `Makefile` includes `${CONTRIB_TARGETS_MKS}`, the list of every `contrib/*/.targets.mk`, but that variable is defined in `.common.mk`, which the `Makefile` includes *afterwards*. When the include line runs the variable is still empty, so `include` reads nothing and there is no error to notice. This has been the case since bc3c6b6 (2026-08-18) moved the `.common.mk` include to the end of the `Makefile` for the `*-command` override mechanism; the contrib include was left above it.

The fix moves the contrib include below `.common.mk` and `.formal-spec.mk`, with a comment explaining the ordering. The `Makefile`'s own definitions stay above `.common.mk`, so the override mechanism from bc3c6b6 is untouched.

The new CI step counts the `contrib/*/.targets.mk` files on disk and the ones `make --debug=v` reports reading, and fails if they differ. It is contribution-agnostic, so it keeps working as contributions come and go.

## Related Issues

#106 defined the `.targets.mk` mechanism (landed in #132). #252 asks for make targets and run instructions for another contribution, which only helps once these targets are reachable.

## If Code Changes Are Included

### Description of Code Changes

- `Makefile`: move `include ${CONTRIB_TARGETS_MKS}` after `include .common.mk` and `include .formal-spec.mk`; update the comments.
- `.github/workflows/ci.yml`: add "Check contrib custom targets are included" right after the existing "Check contrib target failures" step.

### Testing Performed

On `develop` before the change, `make -n consortium-experiment` fails and `make --debug=v` reads 0 of the 2 `.targets.mk` files. After the change:

- `make -n consortium-experiment`, `make -n consortium-tests`, and `make -n cultural-cpt-validation` all resolve, and `make --debug=v` reads 2 of 2 `.targets.mk` files.
- `make consortium-experiment` and `make consortium-tests` run to completion (16 tests pass).
- Nothing else moved. The output of plain `make` (default goal), `make help-targets`, `make -n help`, `make -n before-pr`, `make -n formal-spec-verify`, and a `.custom.mk` override (`make SRC_DIR=contrib/jneums-consortium-experiment --include-dir=… -n pylint`) is byte-for-byte identical to `develop`. No make warnings. `make contrib-ls` still fails, as the existing CI step requires.
- The new CI step was run locally exactly as written: it passes on this branch and fails on `develop` with `2 present, 0 included`.
- `make GITHUB_CI=true before-pr` passes.

### Example Usage

```shell
make consortium-experiment
make help-targets      # the listed contribution targets now actually run
```

## Checklist

- [x] I have read and understood the [CONTRIBUTING](https://github.com/The-AI-Alliance/community/blob/main/CONTRIBUTING.md) guide.
- [x] I have tested the code changes in my local development environment.
- [x] I have added or modified tests for all code changes (the CI guard step).
- [x] I have followed the existing code styles and conventions.
- [x] I have removed all API keys and other sensitive information.
- [x] I have updated any related documentation (none needed; the existing docs describe the intended behaviour).
- [x] I have confirmed that the command `make before-pr` completes successfully.
